### PR TITLE
HTTPS respository url throws: wrong status line: \"\\x15\\x03\\x01\\x00\\x02\\x02\"

### DIFF
--- a/lib/java_buildpack/util/download_cache.rb
+++ b/lib/java_buildpack/util/download_cache.rb
@@ -96,7 +96,7 @@ module JavaBuildpack::Util
     def download(filenames, uri)
       rich_uri = URI(uri)
 
-      Net::HTTP.start(rich_uri.host, rich_uri.port) do |http|
+      Net::HTTP.start(rich_uri.host, rich_uri.port, :use_ssl => (rich_uri.scheme == 'https')) do |http|
         request = Net::HTTP::Get.new(uri)
         http.request request do |response|
           write_response(filenames, response)
@@ -141,7 +141,7 @@ module JavaBuildpack::Util
     def update(filenames, uri)
       rich_uri = URI(uri)
 
-      Net::HTTP.start(rich_uri.host, rich_uri.port) do |http|
+      Net::HTTP.start(rich_uri.host, rich_uri.port, :use_ssl => (rich_uri.scheme == 'https')) do |http|
         request = Net::HTTP::Get.new(uri)
         set_header request, 'If-None-Match', filenames[:etag]
         set_header request, 'If-Modified-Since', filenames[:last_modified]


### PR DESCRIPTION
If you have an HTTPS respository url (eg, `config/openjdk.yml` ->  `repository_root: "https://download.pivotal.io.s3.amazonaws.com/openjdk/lucid/x86_64"), then download_cache throws:

```
"#<RuntimeError: OpenJDK JRE error:: wrong status line: \"\\x15\\x03\\x01\\x00\\x02\\x02\">"
["/Users/mrdavidlaing/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/net/http.rb:2564:in `read_status_line'",
 "/Users/mrdavidlaing/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/net/http.rb:2551:in `read_new'",
 "/Users/mrdavidlaing/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/net/http.rb:1319:in `block in transport_request'",
 "/Users/mrdavidlaing/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/net/http.rb:1316:in `catch'",
 "/Users/mrdavidlaing/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/net/http.rb:1316:in `transport_request'",
 "/Users/mrdavidlaing/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/net/http.rb:1293:in `request'",
 "/Users/mrdavidlaing/Projects/CloudFoundry/.net-buildpack/lib/java_buildpack/util/download_cache.rb:102:in `block in download'",
 "/Users/mrdavidlaing/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/net/http.rb:745:in `start'",
 "/Users/mrdavidlaing/.rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/net/http.rb:557:in `start'",
 "/Users/mrdavidlaing/Projects/CloudFoundry/.net-buildpack/lib/java_buildpack/util/download_cache.rb:100:in `download'",
... snip ...
```
