### PR TITLE
Fix a path relativity issue in Spring Insight

### DIFF
--- a/lib/java_buildpack/framework/spring_insight.rb
+++ b/lib/java_buildpack/framework/spring_insight.rb
@@ -43,8 +43,8 @@ module JavaBuildpack::Framework
       weaver_jar =  @application.relative_path_to(Pathname.new Dir[File.join(insight_home, 'weaver', 'insight-weaver-*.jar')][0])
 
       @java_opts << "-javaagent:#{weaver_jar}"
-      @java_opts << "-Dinsight.base=#{File.join insight_home, 'insight'}"
-      @java_opts << "-Dinsight.logs=#{File.join insight_home, 'insight' , 'logs'}"
+      @java_opts << "-Dinsight.base=#{File.join INSIGHT_HOME, 'insight'}"
+      @java_opts << "-Dinsight.logs=#{File.join INSIGHT_HOME, 'insight', 'logs'}"
       @java_opts << '-Daspectj.overweaving=true'
       @java_opts << '-Dorg.aspectj.tracing.factory=default'
       @java_opts << '-Dagent.http.protocol=http'
@@ -117,12 +117,12 @@ module JavaBuildpack::Framework
       insight_analyser_directory = File.join extra_applications_directory, 'insight-agent'
       uber_agent_directory = File.join agent_dir, 'springsource-insight-uber-agent-*'
 
-      shell "rm -rf #{insight_home}"
-      shell "rm -rf #{insight_analyser_directory}"
-      FileUtils.mkdir_p(container_libs_directory)
-      FileUtils.mkdir_p(extra_applications_directory)
-      FileUtils.mkdir_p(weaver_directory)
-      FileUtils.mkdir_p(insight_directory)
+      FileUtils.rm_rf insight_home
+      FileUtils.rm_rf insight_analyser_directory
+      FileUtils.mkdir_p container_libs_directory
+      FileUtils.mkdir_p extra_applications_directory
+      FileUtils.mkdir_p weaver_directory
+      FileUtils.mkdir_p insight_directory
 
       shell "mv #{File.join uber_agent_directory, 'agents', 'common', 'insight-weaver-*.jar'} #{weaver_directory}"
       shell "mv #{File.join uber_agent_directory, 'agents', 'common', 'insight-bootstrap-generic-*.jar'} #{container_libs_directory}"

--- a/spec/java_buildpack/framework/spring_insight_spec.rb
+++ b/spec/java_buildpack/framework/spring_insight_spec.rb
@@ -84,8 +84,8 @@ module JavaBuildpack::Framework
       ).release
 
       expect(java_opts).to include('-javaagent:.insight/weaver/insight-weaver-1.2.4-CI-SNAPSHOT.jar')
-      expect(java_opts).to include('-Dinsight.base=spec/fixtures/framework_spring_insight/.insight/insight')
-      expect(java_opts).to include('-Dinsight.logs=spec/fixtures/framework_spring_insight/.insight/insight/logs')
+      expect(java_opts).to include('-Dinsight.base=.insight/insight')
+      expect(java_opts).to include('-Dinsight.logs=.insight/insight/logs')
       expect(java_opts).to include('-Daspectj.overweaving=true')
       expect(java_opts).to include('-Dorg.aspectj.tracing.factory=default')
       expect(java_opts).to include('-Dagent.name.override=test-application-name')


### PR DESCRIPTION
A previous commit [1] added support for the Spring Insight application
performance monitoring tool to the Tomcat container. This commit
contained an error where the installed location of Insight was
referenced with an absolute path instead of a relative path. This
causes applications bound to the Insight service to fail to start as
the path to Insight passed to the application at startup will be
incorrect.

[1] e0e90410aaed1b87d791ad031f1577409f90614a - Zero-touch support for
Spring Insight
