### PR TITLE
Add support for proxy credentials in http_proxy

### DIFF
--- a/lib/java_buildpack/util/cache/download_cache.rb
+++ b/lib/java_buildpack/util/cache/download_cache.rb
@@ -181,7 +181,7 @@ module JavaBuildpack::Util::Cache
 
       @logger.debug { "HTTP.start(#{start_parameters(rich_uri)})" }
 
-      Net::HTTP::Proxy(proxy.host, proxy.port).start(*start_parameters(rich_uri)) do |http|
+      Net::HTTP::Proxy(proxy.host, proxy.port, proxy.user, proxy.password).start(*start_parameters(rich_uri)) do |http|
         retry_http_request(http, request, &block)
       end
     end


### PR DESCRIPTION
$http_proxy may include a username and password if the proxy requires
authentication:

```
export http_proxy=http://user:password@host:port
```

This should have been part of #38, but wasn't relevant to our use case, so it didn't occur to me until today.
