### PR TITLE
Update Anchor Links

### DIFF
--- a/docs/container-groovy.md
+++ b/docs/container-groovy.md
@@ -31,7 +31,7 @@ The container can be configured by modifying the [`config/groovy.yml`][] file.  
 | `repository_root` | The URL of the Groovy repository index ([details][repositories]).
 | `version` | The version of Groovy to use. Candidate versions can be found in [this listing][].
 
-[Configuration and Extension]: ../README.md#Configuration-and-Extension
+[Configuration and Extension]: ../README.md#configuration-and-extension
 [`config/groovy.yml`]: ../config/groovy.yml
 [repositories]: extending-repositories.md
 [this listing]: http://download.pivotal.io.s3.amazonaws.com/groovy/index.yml

--- a/docs/container-java_main.md
+++ b/docs/container-java_main.md
@@ -31,4 +31,4 @@ The container can be configured by creating or modifying the `config/java_main.y
 | `arguments` | Optional command line arguments to be passed to the Java main class. The arguments are specified as a single YAML scalar in plain style or enclosed in single or double quotes.
 | `java_main_class` | The Java class name to run. Values containing whitespace are rejected with an error, but all others values appear without modification on the Java command line.  If not specified, the Java Manifest value of `Main-Class` is used.
 
-[Configuration and Extension]: ../README.md#Configuration-and-Extension
+[Configuration and Extension]: ../README.md#configuration-and-extension

--- a/docs/container-spring_boot_cli.md
+++ b/docs/container-spring_boot_cli.md
@@ -31,7 +31,7 @@ The container can be configured by modifying the [`config/spring_boot_cli.yml`][
 | `repository_root` | The URL of the Spring Boot CLI repository index ([details][repositories]).
 | `version` | The version of Spring Boot CLI to use. Candidate versions can be found in [this listing][].
 
-[Configuration and Extension]: ../README.md#Configuration-and-Extension
+[Configuration and Extension]: ../README.md#configuration-and-extension
 [`config/spring_boot_cli.yml`]: ../config/spring_boot_cli.yml
 [repositories]: extending-repositories.md
 [Spring profiles]:http://blog.springsource.com/2011/02/14/spring-3-1-m1-introducing-profile/

--- a/docs/container-tomcat.md
+++ b/docs/container-tomcat.md
@@ -43,7 +43,7 @@ To enable Redis-based session replication, simply bind a Redis service containin
 ## Supporting Functionality
 Additional supporting functionality can be found in the [`java-buildpack-support`][] Git repository.
 
-[Configuration and Extension]: ../README.md#Configuration-and-Extension
+[Configuration and Extension]: ../README.md#configuration-and-extension
 [`config/tomcat.yml`]: ../config/tomcat.yml
 [`java-buildpack-support`]: https://github.com/cloudfoundry/java-buildpack-support
 [repositories]: extending-repositories.md

--- a/docs/extending-caches.md
+++ b/docs/extending-caches.md
@@ -83,4 +83,4 @@ def initialize
 [`config/cache.yml`]: ../config/cache.yml
 [`DownloadCache`]: ../lib/java_buildpack/util/cache/download_cache.rb
 [`GlobalCache`]: ../lib/java_buildpack/util/cache/global_cache.rb
-[Configuration and Extension]: ../README.md#Configuration-and-Extension
+[Configuration and Extension]: ../README.md#configuration-and-extension

--- a/docs/extending-logging.md
+++ b/docs/extending-logging.md
@@ -33,5 +33,5 @@ The console logging severity filter is set to `DEBUG`, `INFO`, `WARN`, `ERROR`, 
 3. `default_log_level` value in [`config/logging.yml`][].
 4. Fallback to `INFO` if none of the above are set.
 
-[Configuration and Extension]: ../README.md#Configuration-and-Extension
+[Configuration and Extension]: ../README.md#configuration-and-extension
 [`config/logging.yml`]: ../config/logging.yml

--- a/docs/extending-repositories.md
+++ b/docs/extending-repositories.md
@@ -85,6 +85,6 @@ In addition to declaring a specific versions to use, you can also specify a boun
 
 [`config/repository.yml`]: ../config/repository.yml
 [`JavaBuildpack::Repository::ConfiguredItem`]: ../lib/java_buildpack/repository/configured_item.rb
-[Configuration and Extension]: ../README.md#Configuration-and-Extension
+[Configuration and Extension]: ../README.md#configuration-and-extension
 [example]: http://download.pivotal.io.s3.amazonaws.com/openjdk/lucid/x86_64/index.yml
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,5 +1,5 @@
 # Extending
-For general information on extending the buildpack, refer to [Configuration and Extension](../README.md#Configuration-and-Extension).
+For general information on extending the buildpack, refer to [Configuration and Extension](../README.md#configuration-and-extension).
 
 To add a component, its class name must be added added to [`config/components.yml`][].  It is recommended, but not required, that the class' file be placed in a directory that matches its type.
 

--- a/docs/framework-app_dynamics_agent.md
+++ b/docs/framework-app_dynamics_agent.md
@@ -36,7 +36,7 @@ The framework can be configured by modifying the [`config/app_dynamics_agent.yml
 
 [`config/app_dynamics_agent.yml`]: ../config/app_dynamics_agent.yml
 [AppDynamics Service]: http://www.appdynamics.com
-[Configuration and Extension]: ../README.md#Configuration-and-Extension
+[Configuration and Extension]: ../README.md#configuration-and-extension
 [repositories]: extending-repositories.md
 [this listing]: http://download.pivotal.io.s3.amazonaws.com/app-dynamics/index.yml
 [version syntax]: extending-repositories.md#version-syntax-and-ordering

--- a/docs/framework-java_opts.md
+++ b/docs/framework-java_opts.md
@@ -23,4 +23,4 @@ The framework can be configured by creating or modifying the `config/java_opts.y
 | ---- | -----------
 | `java_opts` | The Java options to use when running the application.  All values are used without modification when invoking the JVM. The options are specified as a single YAML scalar in plain style or enclosed in single or double quotes.
 
-[Configuration and Extension]: ../README.md#Configuration-and-Extension
+[Configuration and Extension]: ../README.md#configuration-and-extension

--- a/docs/framework-maria_db_jdbc.md
+++ b/docs/framework-maria_db_jdbc.md
@@ -33,7 +33,7 @@ The framework can be configured by modifying the [`config/maria_db_jdbc.yml`][] 
 | `repository_root` | The URL of the MariaDB JDBC repository index ([details][repositories]).
 | `version` | The version of MariaDB JDBC to use. Candidate versions can be found in [this listing][].
 
-[Configuration and Extension]: ../README.md#Configuration-and-Extension
+[Configuration and Extension]: ../README.md#configuration-and-extension
 [`config/maria_db_jdbc.yml`]: ../config/maria_db_jdbc.yml
 [MariaDB]: https://mariadb.com
 [MySQL Service]: http://www.mysql.org

--- a/docs/framework-new_relic_agent.md
+++ b/docs/framework-new_relic_agent.md
@@ -35,7 +35,7 @@ The framework can be configured by modifying the [`config/new_relic_agent.yml`][
 | `repository_root` | The URL of the New Relic repository index ([details][repositories]).
 | `version` | The version of New Relic to use. Candidate versions can be found in [this listing][].
 
-[Configuration and Extension]: ../README.md#Configuration-and-Extension
+[Configuration and Extension]: ../README.md#configuration-and-extension
 [`config/new_relic_agent.yml`]: ../config/new_relic_agent.yml
 [New Relic Service]: https://newrelic.com
 [repositories]: extending-repositories.md

--- a/docs/framework-play_framework_auto_reconfiguration.md
+++ b/docs/framework-play_framework_auto_reconfiguration.md
@@ -24,7 +24,7 @@ The framework can be configured by modifying the [`config/play_framework_auto_re
 | `repository_root` | The URL of the Auto Reconfiguration repository index ([details][repositories]).
 | `version` | The version of Auto Reconfiguration to use. Candidate versions can be found in [this listing][].
 
-[Configuration and Extension]: ../README.md#Configuration-and-Extension
+[Configuration and Extension]: ../README.md#configuration-and-extension
 [`config/play_framework_auto_reconfiguration.yml`]: ../config/config/play_framework_auto_reconfiguration.yml
 [repositories]: extending-repositories.md
 [this listing]: http://download.pivotal.io.s3.amazonaws.com/auto-reconfiguration/index.yml

--- a/docs/framework-play_framework_jpa_plugin.md
+++ b/docs/framework-play_framework_jpa_plugin.md
@@ -28,7 +28,7 @@ The framework can be configured by modifying the [`config/play_framework_jpa_plu
 | `repository_root` | The URL of the Play Framework JPA Plugin repository index ([details][repositories]).
 | `version` | The version of the Play Framework JPA Plugin to use. Candidate versions can be found in [this listing][].
 
-[Configuration and Extension]: ../README.md#Configuration-and-Extension
+[Configuration and Extension]: ../README.md#configuration-and-extension
 [`config/play_framework_jpa_plugin.yml`]: ../config/play_framework_jpa_plugin.yml
 [repositories]: extending-repositories.md
 [this listing]: http://download.pivotal.io.s3.amazonaws.com/play-jpa-plugin/index.yml

--- a/docs/framework-postgresql_jdbc.md
+++ b/docs/framework-postgresql_jdbc.md
@@ -31,7 +31,7 @@ The framework can be configured by modifying the [`config/postgresql_jdbc.yml`][
 | `repository_root` | The URL of the PostgreSQL JDBC repository index ([details][repositories]).
 | `version` | The version of PostgreSQL JDBC to use. Candidate versions can be found in [this listing][].
 
-[Configuration and Extension]: ../README.md#Configuration-and-Extension
+[Configuration and Extension]: ../README.md#configuration-and-extension
 [`config/postgresql_jdbc.yml`]: ../config/postgresql_jdbc.yml
 [PostgreSQL Service]: http://www.postgresql.org
 [repositories]: extending-repositories.md

--- a/docs/framework-spring_auto_reconfiguration.md
+++ b/docs/framework-spring_auto_reconfiguration.md
@@ -28,7 +28,7 @@ The framework can be configured by modifying the [`config/spring_auto_reconfigur
 | `repository_root` | The URL of the Auto Reconfiguration repository index ([details][repositories]).
 | `version` | The version of Auto Reconfiguration to use. Candidate versions can be found in [this listing][].
 
-[Configuration and Extension]: ../README.md#Configuration-and-Extension
+[Configuration and Extension]: ../README.md#configuration-and-extension
 [`config/spring_auto_reconfiguration.yml`]: ../config/spring_auto_reconfiguration.yml
 [repositories]: extending-repositories.md
 [this listing]: http://download.pivotal.io.s3.amazonaws.com/auto-reconfiguration/index.yml

--- a/docs/jre-open_jdk_jre.md
+++ b/docs/jre-open_jdk_jre.md
@@ -73,7 +73,7 @@ the range, the constrained size is excluded from the remaining memory, and no fu
 Termination is guaranteed since there is a finite number of memory types and in each iteration either none of the remaining memory sizes is constrained by the corresponding range and allocation terminates or at least one memory size is constrained by the corresponding range and is omitted from the next iteration.
 
 [`config/open_jdk_jre.yml`]: ../config/open_jdk_jre.yml
-[Configuration and Extension]: ../README.md#Configuration-and-Extension
+[Configuration and Extension]: ../README.md#configuration-and-extension
 [centos6]: http://download.pivotal.io.s3.amazonaws.com/openjdk/centos6/x86_64/index.yml
 [lucid]: http://download.pivotal.io.s3.amazonaws.com/openjdk/lucid/x86_64/index.yml
 [mountainlion]: http://download.pivotal.io.s3.amazonaws.com/openjdk/mountainlion/x86_64/index.yml

--- a/docs/jre-oracle_jre.md
+++ b/docs/jre-oracle_jre.md
@@ -83,7 +83,7 @@ Termination is guaranteed since there is a finite number of memory types and in 
 
 [`config/components.yml`]: ../config/components.yml
 [`config/oracle_jre.yml`]: ../config/oracle_jre.yml
-[Configuration and Extension]: ../README.md#Configuration-and-Extension
+[Configuration and Extension]: ../README.md#configuration-and-extension
 [OpenJDK JRE]: jre-open_jdk.md
 [Oracle]: http://www.oracle.com/technetwork/java/index.html
 [repositories]: extending-repositories.md

--- a/docs/security.md
+++ b/docs/security.md
@@ -7,4 +7,4 @@ If you fork the Java buildpack, it is important to keep the fork up to date with
 ## Security and Logs
 See [Sensitive Information in Logs][].
 
-[Sensitive Information in Logs]: extending-logging.md#Sensitive-Information-in-Logs
+[Sensitive Information in Logs]: extending-logging.md#sensitive-information-in-logs


### PR DESCRIPTION
Previously GitHub used capitalization reflecting the text for anchor links, such as:

 ../README.md#Configuration-and-Extension

This recently changed to all lower case, e.g.

 ../README.md#configuration-and-extension

While the links still went to the right page they did not go to the anchor. This change
updates the affected links so they work properly.

[#67911942]
