### PR TITLE
make spring boot applied only when bin directory exists

### DIFF
--- a/lib/java_buildpack/container/spring_boot.rb
+++ b/lib/java_buildpack/container/spring_boot.rb
@@ -47,7 +47,7 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Container::DistZipLike#supports?)
       def supports?
-        @spring_boot_utils.is? @application
+        start_script(root) && (@spring_boot_utils.is? @application)
       end
 
       private


### PR DESCRIPTION
Problem:

Spring boot will be applied(detect) when it finds the boot jar in lib/. However during compile time, it was looking for start_script(root), which will fail the push.

E.g. I have a maven built spring boot application. After packaging with war plugin, when I push the war to cf. I am running into this problem. Add one more check condition will fix this.
https://github.com/bijukunjummen/sample-pso-cf-app/

Thanks

-Shaozhen Ding
