### PR TITLE
Document the tier_name config for AppDynamics agent

### DIFF
--- a/docs/container-tomcat.md
+++ b/docs/container-tomcat.md
@@ -21,17 +21,17 @@ The container can be configured by modifying the [`config/tomcat.yml`][] file in
 
 | Name | Description
 | ---- | -----------
-| `tomcat.repository_root` | The URL of the Tomcat repository index ([details][repositories]).
-| `tomcat.version` | The version of Tomcat to use. Candidate versions can be found in [this listing](http://download.pivotal.io.s3.amazonaws.com/tomcat/index.yml).
 | `lifecycle_support.repository_root` | The URL of the Tomcat Lifecycle Support repository index ([details][repositories]).
 | `lifecycle_support.version` | The version of Tomcat Lifecycle Support to use. Candidate versions can be found in [this listing](http://download.pivotal.io.s3.amazonaws.com/tomcat-lifecycle-support/index.yml).
 | `logging_support.repository_root` | The URL of the Tomcat Logging Support repository index ([details][repositories]).
 | `logging_support.version` | The version of Tomcat Logging Support to use. Candidate versions can be found in [this listing](http://download.pivotal.io.s3.amazonaws.com/tomcat-logging-support/index.yml).
-| `redis_store.repository_root` | The URL of the Redis Store repository index ([details][repositories]).
-| `redis_store.version` | The version of Redis Store to use. Candidate versions can be found in [this listing](http://download.pivotal.io.s3.amazonaws.com/redis-store/index.yml).
-| `redis_store.database` | The Redis database to connect to.
-| `redis_store.timeout` | The Redis connection timeout (in milliseconds).
 | `redis_store.connection_pool_size` | The Redis connection pool size.  Note that this is per-instance, not per-application.
+| `redis_store.database` | The Redis database to connect to.
+| `redis_store.repository_root` | The URL of the Redis Store repository index ([details][repositories]).
+| `redis_store.timeout` | The Redis connection timeout (in milliseconds).
+| `redis_store.version` | The version of Redis Store to use. Candidate versions can be found in [this listing](http://download.pivotal.io.s3.amazonaws.com/redis-store/index.yml).
+| `tomcat.repository_root` | The URL of the Tomcat repository index ([details][repositories]).
+| `tomcat.version` | The version of Tomcat to use. Candidate versions can be found in [this listing](http://download.pivotal.io.s3.amazonaws.com/tomcat/index.yml).
 
 ### Additional Resources
 The container can also be configured by overlaying a set of resources on the default distribution.  To do this, add files to the `resources/tomcat` directory in the buildpack fork.  For example, to override the default `logging.properties` add your custom file to `resources/tomcat/conf/logging.properties`.

--- a/docs/framework-app_dynamics_agent.md
+++ b/docs/framework-app_dynamics_agent.md
@@ -31,6 +31,7 @@ The framework can be configured by modifying the [`config/app_dynamics_agent.yml
 | Name | Description
 | ---- | -----------
 | `repository_root` | The URL of the AppDynamics repository index ([details][repositories]).
+| `tier_name` | The tier_name for this application in the AppDynamics dashboard.
 | `version` | The version of AppDynamics to use. Candidate versions can be found in [this listing][].
 
 ### Additional Resources

--- a/docs/framework-play_framework_auto_reconfiguration.md
+++ b/docs/framework-play_framework_auto_reconfiguration.md
@@ -21,9 +21,9 @@ The framework can be configured by modifying the [`config/play_framework_auto_re
 
 | Name | Description
 | ---- | -----------
+| `enabled` | Whether to attempt auto-reconfiguration
 | `repository_root` | The URL of the Auto-reconfiguration repository index ([details][repositories]).
 | `version` | The version of Auto-reconfiguration to use. Candidate versions can be found in [this listing][].
-| `enabled` | Whether to attempt auto-reconfiguration
 
 [Configuration and Extension]: ../README.md#configuration-and-extension
 [`config/play_framework_auto_reconfiguration.yml`]: ../config/config/play_framework_auto_reconfiguration.yml

--- a/docs/framework-play_framework_jpa_plugin.md
+++ b/docs/framework-play_framework_jpa_plugin.md
@@ -25,9 +25,9 @@ The framework can be configured by modifying the [`config/play_framework_jpa_plu
 
 | Name | Description
 | ---- | -----------
+| `enabled` | Whether to attempt reconfiguration
 | `repository_root` | The URL of the Play Framework JPA Plugin repository index ([details][repositories]).
 | `version` | The version of the Play Framework JPA Plugin to use. Candidate versions can be found in [this listing][].
-| `enabled` | Whether to attempt reconfiguration
 
 [Configuration and Extension]: ../README.md#configuration-and-extension
 [`config/play_framework_jpa_plugin.yml`]: ../config/play_framework_jpa_plugin.yml

--- a/docs/framework-spring_auto_reconfiguration.md
+++ b/docs/framework-spring_auto_reconfiguration.md
@@ -22,9 +22,9 @@ The framework can be configured by modifying the [`config/spring_auto_reconfigur
 
 | Name | Description
 | ---- | -----------
+| `enabled` | Whether to attempt auto-reconfiguration
 | `repository_root` | The URL of the Auto-reconfiguration repository index ([details][repositories]).
 | `version` | The version of Auto-reconfiguration to use. Candidate versions can be found in [this listing][].
-| `enabled` | Whether to attempt auto-reconfiguration
 
 [Configuration and Extension]: ../README.md#configuration-and-extension
 [`config/spring_auto_reconfiguration.yml`]: ../config/spring_auto_reconfiguration.yml

--- a/docs/jre-open_jdk_jre.md
+++ b/docs/jre-open_jdk_jre.md
@@ -20,10 +20,10 @@ The JRE can be configured by modifying the [`config/open_jdk_jre.yml`][] file in
 
 | Name | Description
 | ---- | -----------
-| `repository_root` | The URL of the OpenJDK repository index ([details][repositories]).
-| `version` | The version of Java runtime to use.  Candidate versions can be found in the listings for [centos6][], [lucid][], [mountainlion][], and [precise][]. Note: version 1.8.0 and higher require the `memory_sizes` and `memory_heuristics` mappings to specify `metaspace` rather than `permgen`.
 | `memory_sizes` | Optional memory sizes, described below under "Memory Sizes".
 | `memory_heuristics` | Default memory size weightings, described below under "Memory Weightings.
+| `repository_root` | The URL of the OpenJDK repository index ([details][repositories]).
+| `version` | The version of Java runtime to use.  Candidate versions can be found in the listings for [centos6][], [lucid][], [mountainlion][], and [precise][]. Note: version 1.8.0 and higher require the `memory_sizes` and `memory_heuristics` mappings to specify `metaspace` rather than `permgen`.
 
 ### Additional Resources
 The JRE can also be configured by overlaying a set of resources on the default distribution.  To do this, add files to the `resources/open_jdk_jre` directory in the buildpack fork.  For example, to add the JCE Unlimited Strength `local_policy.jar` add your file to `resources/open_jdk_jre/lib/security/local_policy.jar`.
@@ -40,9 +40,9 @@ The following optional properties may be specified in the `memory_sizes` mapping
 | ---- | -----------
 | `heap` | The maximum heap size to use. It may be a single value such as `64m` or a range of acceptable values such as `128m..256m`. It is used to calculate the value of the Java command line options `-Xmx` and `-Xms`.
 | `metaspace` | The maximum Metaspace size to use. It is applicable to versions of OpenJDK from 1.8 onwards. It may be a single value such as `64m` or a range of acceptable values such as `128m..256m`. It is used to calculate the value of the Java command line options `-XX:MaxMetaspaceSize=` and `-XX:MetaspaceSize=`.
+| `native` | The amount of memory to reserve for native memory allocation. It should normally be omitted or specified as a range with no upper bound such as `100m..`. It does not correspond to a switch on the Java command line.
 | `permgen` | The maximum PermGen size to use. It is applicable to versions of OpenJDK earlier than 1.8. It may be a single value such as `64m` or a range of acceptable values such as `128m..256m`. It is used to calculate the value of the Java command line options `-XX:MaxPermSize=` and `-XX:PermSize=`.
 | `stack` | The stack size to use. It may be a single value such as `2m` or a range of acceptable values such as `2m..4m`. It is used to calculate the value of the Java command line option `-Xss`.
-| `native` | The amount of memory to reserve for native memory allocation. It should normally be omitted or specified as a range with no upper bound such as `100m..`. It does not correspond to a switch on the Java command line.
 
 Memory sizes together with _memory weightings_ (described in the next section) are used to calculate the amount of memory for each memory type. The calculation is described later.
 

--- a/docs/jre-oracle_jre.md
+++ b/docs/jre-oracle_jre.md
@@ -29,10 +29,10 @@ The JRE can be configured by modifying the [`config/oracle_jre.yml`][] file in t
 
 | Name | Description
 | ---- | -----------
-| `repository_root` | The URL of the Oracle repository index ([details][repositories]).
-| `version` | The version of Java runtime to use.  Candidate versions can be found in the the repository that you have created to house the JREs. Note: version 1.8.0 and higher require the `memory_sizes` and `memory_heuristics` mappings to specify `metaspace` rather than `permgen`.
 | `memory_sizes` | Optional memory sizes, described below under "Memory Sizes".
 | `memory_heuristics` | Default memory size weightings, described below under "Memory Weightings.
+| `repository_root` | The URL of the Oracle repository index ([details][repositories]).
+| `version` | The version of Java runtime to use.  Candidate versions can be found in the the repository that you have created to house the JREs. Note: version 1.8.0 and higher require the `memory_sizes` and `memory_heuristics` mappings to specify `metaspace` rather than `permgen`.
 
 ### Additional Resources
 The JRE can also be configured by overlaying a set of resources on the default distribution.  To do this, add files to the `resources/oracle_jre` directory in the buildpack fork.  For example, to add the JCE Unlimited Strength `local_policy.jar` add your file to `resources/oracle_jre/lib/security/local_policy.jar`.
@@ -49,9 +49,9 @@ The following optional properties may be specified in the `memory_sizes` mapping
 | ---- | -----------
 | `heap` | The maximum heap size to use. It may be a single value such as `64m` or a range of acceptable values such as `128m..256m`. It is used to calculate the value of the Java command line options `-Xmx` and `-Xms`.
 | `metaspace` | The maximum Metaspace size to use. It is applicable to versions of Oracle from 1.8 onwards. It may be a single value such as `64m` or a range of acceptable values such as `128m..256m`. It is used to calculate the value of the Java command line options `-XX:MaxMetaspaceSize=` and `-XX:MetaspaceSize=`.
+| `native` | The amount of memory to reserve for native memory allocation. It should normally be omitted or specified as a range with no upper bound such as `100m..`. It does not correspond to a switch on the Java command line.
 | `permgen` | The maximum PermGen size to use. It is applicable to versions of Oracle earlier than 1.8. It may be a single value such as `64m` or a range of acceptable values such as `128m..256m`. It is used to calculate the value of the Java command line options `-XX:MaxPermSize=` and `-XX:PermSize=`.
 | `stack` | The stack size to use. It may be a single value such as `2m` or a range of acceptable values such as `2m..4m`. It is used to calculate the value of the Java command line option `-Xss`.
-| `native` | The amount of memory to reserve for native memory allocation. It should normally be omitted or specified as a range with no upper bound such as `100m..`. It does not correspond to a switch on the Java command line.
 
 Memory sizes together with _memory weightings_ (described in the next section) are used to calculate the amount of memory for each memory type. The calculation is described later.
 


### PR DESCRIPTION
The tier_name of the AppDynamics service plan that should be used is not
documented. This change adds the documentaion along with a link to the
publicly avaliable service plans.

[#72500698]
