### PR TITLE
Session replication should accept host as well as hostname

### DIFF
--- a/lib/java_buildpack/component/services.rb
+++ b/lib/java_buildpack/component/services.rb
@@ -33,8 +33,8 @@ module JavaBuildpack
       # +filter+ matches exactly one service, +false+ otherwise.
       #
       # @param [Regexp, String] filter a +RegExp+ or +String+ to match against the name, label, and tags of the services
-      # @param [String] required_credentials an optional list of keys that must exist in the credentials payload of
-      #                                             the candidate service
+      # @param [String] required_credentials an optional list of keys or groups of keys, where at one key from the
+      #                                      group, must exist in the credentials payload of the candidate service
       # @return [Boolean] +true+ if the +filter+ matches exactly one service with the required credentials, +false+
       #                   otherwise.
       def one_service?(filter, *required_credentials)
@@ -68,7 +68,9 @@ module JavaBuildpack
       private
 
       def credentials?(candidate, required_keys)
-        required_keys.all? { |k| candidate.key? k }
+        required_keys.all? do |k|
+          k.kind_of?(Array) ? k.one? { |g| candidate.key?(g) } : candidate.key?(k)
+        end
       end
 
       def matcher(filter)

--- a/lib/java_buildpack/container/tomcat/tomcat_redis_store.rb
+++ b/lib/java_buildpack/container/tomcat/tomcat_redis_store.rb
@@ -44,7 +44,7 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::VersionedDependencyComponent#supports?)
       def supports?
-        @application.services.one_service? FILTER, KEY_HOST_NAME, KEY_PORT, KEY_PASSWORD
+        @application.services.one_service? FILTER, [KEY_HOST_NAME, KEY_HOST], KEY_PORT, KEY_PASSWORD
       end
 
       private
@@ -54,6 +54,8 @@ module JavaBuildpack
       FLUSH_VALVE_CLASS_NAME = 'com.gopivotal.manager.SessionFlushValve'.freeze
 
       KEY_HOST_NAME = 'hostname'.freeze
+
+      KEY_HOST = 'host'.freeze
 
       KEY_PASSWORD = 'password'.freeze
 
@@ -76,7 +78,7 @@ module JavaBuildpack
 
         manager.add_element 'Store',
                             'className'          => REDIS_STORE_CLASS_NAME,
-                            'host'               => credentials[KEY_HOST_NAME],
+                            'host'               => credentials[KEY_HOST_NAME] || credentials[KEY_HOST],
                             'port'               => credentials[KEY_PORT],
                             'database'           => @configuration['database'],
                             'password'           => credentials[KEY_PASSWORD],

--- a/spec/java_buildpack/component/services_spec.rb
+++ b/spec/java_buildpack/component/services_spec.rb
@@ -58,6 +58,11 @@ describe JavaBuildpack::Component::Services do
     expect(services.one_service?(/test-tag/, 'uri')).to be
   end
 
+  it 'should return true from one_service? if there is a matching service with required group credentials' do
+    expect(services.one_service? 'test-tag', %w(uri other)).to be
+    expect(services.one_service?(/test-tag/, %w(uri other))).to be
+  end
+
   it 'should return nil from find_service? if there is no service that matches' do
     expect(services.find_service 'bad-test').to be_nil
     expect(services.find_service(/bad-test/)).to be_nil

--- a/spec/java_buildpack/container/tomcat/tomcat_redis_store_spec.rb
+++ b/spec/java_buildpack/container/tomcat/tomcat_redis_store_spec.rb
@@ -36,7 +36,7 @@ describe JavaBuildpack::Container::TomcatRedisStore do
   context do
 
     before do
-      allow(services).to receive(:one_service?).with(/session-replication/, 'hostname', 'port', 'password')
+      allow(services).to receive(:one_service?).with(/session-replication/, %w(hostname host), 'port', 'password')
                          .and_return(true)
       allow(services).to receive(:find_service).and_return('credentials' => { 'hostname' => 'test-host',
                                                                               'port'     => 'test-port',
@@ -64,6 +64,22 @@ describe JavaBuildpack::Container::TomcatRedisStore do
 
       expect((sandbox + 'conf/context.xml').read)
       .to eq(Pathname.new('spec/fixtures/container_tomcat_redis_store_context_after.xml').read)
+    end
+
+  end
+
+  context do
+
+    before do
+      allow(services).to receive(:one_service?).with(/session-replication/, %w(hostname host), 'port', 'password')
+                         .and_return(true)
+      allow(services).to receive(:find_service).and_return('credentials' => { 'host' => 'test-host',
+                                                                              'port'     => 'test-port',
+                                                                              'password' => 'test-password' })
+    end
+
+    it 'should detect with a session-replication service' do
+      expect(component.detect).to eq("tomcat-redis-store=#{version}")
     end
 
   end


### PR DESCRIPTION
Redis provides host and not hostname as a credential for session replication.
The buildpack currently only accepts hostname. This commit adds support for
either 'host' or 'hostname' but not both to be provided in the credentials.

See: https://groups.google.com/a/cloudfoundry.org/d/msg/vcap-dev/vIHzLxZHQ2A/YyT-a6va-cYJ

[#73611494]
