### PR TITLE
Upgrade to AppDynamics 3.8.+

### DIFF
--- a/config/app_dynamics_agent.yml
+++ b/config/app_dynamics_agent.yml
@@ -15,6 +15,6 @@
 
 # Configuration for the New Relic framework
 ---
-version: 3.7.+
+version: 3.8.+
 repository_root: "{default.repository.root}/app-dynamics"
 tier_name: Cloud Foundry


### PR DESCRIPTION
A new version of AppDynamics is available and should be consumed in the Java
buildpack, this change does so.

[#74772312]
