### PR TITLE
Upgrade New Relic to 3.8.+

### DIFF
--- a/config/new_relic_agent.yml
+++ b/config/new_relic_agent.yml
@@ -15,5 +15,5 @@
 
 # Configuration for the New Relic framework
 ---
-version: 3.7.+
+version: 3.8.+
 repository_root: "{default.repository.root}/new-relic"


### PR DESCRIPTION
A new version of New Relic is available and should be consumed in the Java
buildpack, this change does so.

[#74772414]
