### PR TITLE
Change the default Access Log pattern in Tomcat

### DIFF
--- a/resources/tomcat/conf/server.xml
+++ b/resources/tomcat/conf/server.xml
@@ -26,7 +26,7 @@
         <Engine defaultHost='localhost' name='Catalina'>
             <Valve className="org.apache.catalina.valves.RemoteIpValve" protocolHeader="x-forwarded-proto"/>
             <Valve className="com.gopivotal.cloudfoundry.tomcat.logging.access.CloudFoundryAccessLoggingValve"
-                   pattern='[ACCESS] %h %l %u %t "%r" %s %b %{X-Vcap-Request-Id}i' enabled="${access.logging.enabled}"/>
+                   pattern='[ACCESS] %h %l %t %D %F %B %S vcap_request_id:%{X-Vcap-Request-Id}i' enabled="${access.logging.enabled}"/>
             <Host name='localhost'>
                 <Listener className="com.gopivotal.cloudfoundry.tomcat.lifecycle.ApplicationStartupFailureDetectingLifecycleListener"/>
             </Host>


### PR DESCRIPTION
From GitHub issue #57. The current access logging pattern isn't as useful as it
could be. The logs will often be viewed alongside with the Router logs and
should provide complementing information and not overlap with it.

[#74837854]
