### PR TITLE
Update the Spring Insight documentation

### DIFF
--- a/docs/framework-spring_insight.md
+++ b/docs/framework-spring_insight.md
@@ -1,5 +1,5 @@
 # Spring Insight Framework
-The Spring Insight Framework causes an application to be automatically configured to work with a bound [Spring Insight Service][].
+The Spring Insight Framework causes an application to be automatically configured to work with a bound [Spring Insight Service][]. This feature will only work with Spring Insight versions of 2.0.0.x or above.
 
 <table>
   <tr>


### PR DESCRIPTION
The Java Buildpack requires Spring Insight version 2.0.0 or above in order to
function properly. This is not documented and this commit adds the version
requirement to the documentation.

[#74932796]
