### PR TITLE
Support New Relic on Java8

### DIFF
--- a/java-buildpack.iml
+++ b/java-buildpack.iml
@@ -287,10 +287,10 @@
     <orderEntry type="library" scope="PROVIDED" name="rake (v10.3.2, rbenv: 1.9.3-p547) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="redcarpet (v3.1.2, rbenv: 1.9.3-p547) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rspec (v3.0.0, rbenv: 1.9.3-p547) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-core (v3.0.2, rbenv: 1.9.3-p547) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-expectations (v3.0.2, rbenv: 1.9.3-p547) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-mocks (v3.0.2, rbenv: 1.9.3-p547) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-support (v3.0.2, rbenv: 1.9.3-p547) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-core (v3.0.3, rbenv: 1.9.3-p547) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-expectations (v3.0.3, rbenv: 1.9.3-p547) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-mocks (v3.0.3, rbenv: 1.9.3-p547) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-support (v3.0.3, rbenv: 1.9.3-p547) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rubocop (v0.24.1, rbenv: 1.9.3-p547) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ruby-debug-base19x (v0.11.30.pre15, rbenv: 1.9.3-p547) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ruby-debug-ide (v0.4.22, rbenv: 1.9.3-p547) [gem]" level="application" />

--- a/lib/java_buildpack/component/immutable_java_home.rb
+++ b/lib/java_buildpack/component/immutable_java_home.rb
@@ -61,6 +61,11 @@ module JavaBuildpack
         qualify_path @delegate.root
       end
 
+      # @return [String] the version of Java being used by the droplet
+      def version
+        @delegate.version
+      end
+
     end
 
   end

--- a/lib/java_buildpack/component/mutable_java_home.rb
+++ b/lib/java_buildpack/component/mutable_java_home.rb
@@ -19,8 +19,8 @@ require 'java_buildpack/component'
 module JavaBuildpack
   module Component
 
-    # An abstraction around the +JAVA_HOME+ path used by the droplet.  This implementation is mutable and should be
-    # passed to any component that is a jre.
+    # An abstraction around the +JAVA_HOME+ path and +VERSION+ used by the droplet.  This implementation is mutable and
+    # should be passed to any component that is a jre.
     #
     # A new instance of this type should be created once for the application.
     class MutableJavaHome
@@ -28,6 +28,10 @@ module JavaBuildpack
       # @!attribute [rw] root
       # @return [String] the root of the droplet's +JAVA_HOME+
       attr_accessor :root
+
+      # @!attribute [rw] version
+      # @return [Array] the major, minor, micro and qualifier of the droplet's +VERSION+
+      attr_accessor :version
 
     end
 

--- a/lib/java_buildpack/framework/new_relic_agent.rb
+++ b/lib/java_buildpack/framework/new_relic_agent.rb
@@ -27,7 +27,6 @@ module JavaBuildpack
       # (see JavaBuildpack::Component::BaseComponent#compile)
       def compile
         FileUtils.mkdir_p logs_dir
-
         download_jar
         @droplet.copy_resources
       end
@@ -40,6 +39,7 @@ module JavaBuildpack
         .add_system_property('newrelic.config.license_key', license_key)
         .add_system_property('newrelic.config.app_name', "'#{application_name}'")
         .add_system_property('newrelic.config.log_file_path', logs_dir)
+        @droplet.java_opts.add_system_property('newrelic.enable.java.8', 'true') if @droplet.java_home.version[1] == '8'
       end
 
       protected

--- a/lib/java_buildpack/jre/open_jdk_like.rb
+++ b/lib/java_buildpack/jre/open_jdk_like.rb
@@ -40,6 +40,7 @@ module JavaBuildpack
       # (see JavaBuildpack::Component::BaseComponent#detect)
       def detect
         @version, @uri = JavaBuildpack::Repository::ConfiguredItem.find_item(@component_name, @configuration)
+        @droplet.java_home.version = @version
         super
       end
 

--- a/spec/droplet_helper.rb
+++ b/spec/droplet_helper.rb
@@ -41,8 +41,7 @@ shared_context 'droplet_helper' do
   let(:sandbox) { droplet.sandbox }
 
   let(:java_home) do
-    JavaBuildpack::Component::ImmutableJavaHome.new double('MutableJavaHome', root: app_dir + '.test-java-home'),
-                                                    app_dir
+    JavaBuildpack::Component::ImmutableJavaHome.new double('MutableJavaHome', root: app_dir + '.test-java-home', version: %w(1 7 55 u60)), app_dir
   end
 
   let(:java_opts) do

--- a/spec/java_buildpack/component/immutable_java_home_spec.rb
+++ b/spec/java_buildpack/component/immutable_java_home_spec.rb
@@ -19,7 +19,7 @@ require 'java_buildpack/component/immutable_java_home'
 
 describe JavaBuildpack::Component::ImmutableJavaHome do
 
-  let(:delegate) { double('delegate', root: Pathname.new('test-java-home')) }
+  let(:delegate) { double('delegate', root: Pathname.new('test-java-home'), version: %w(1 2 3 u04)) }
 
   let(:immutable_java_home) { described_class.new delegate, Pathname.new('.') }
 
@@ -35,6 +35,10 @@ describe JavaBuildpack::Component::ImmutableJavaHome do
 
   it 'should return the qualified delegate root' do
     expect(immutable_java_home.root).to eq('$PWD/test-java-home')
+  end
+
+  it 'should return the delegate version' do
+    expect(immutable_java_home.version).to eq(%w(1 2 3 u04))
   end
 
 end

--- a/spec/java_buildpack/component/mutable_java_home_spec.rb
+++ b/spec/java_buildpack/component/mutable_java_home_spec.rb
@@ -22,11 +22,18 @@ describe JavaBuildpack::Component::MutableJavaHome do
 
   let(:path) { Pathname.new('foo/bar') }
 
+  let(:java_version) { %w(1 2 3 u04) }
+
   let(:mutable_java_home) { described_class.new }
 
   it 'should save root' do
     mutable_java_home.root = path
     expect(mutable_java_home.root).to eq(path)
+  end
+
+  it 'should save version' do
+    mutable_java_home.version = java_version
+    expect(mutable_java_home.version).to eq(java_version)
   end
 
 end

--- a/spec/java_buildpack/framework/new_relic_agent_spec.rb
+++ b/spec/java_buildpack/framework/new_relic_agent_spec.rb
@@ -63,6 +63,15 @@ describe JavaBuildpack::Framework::NewRelicAgent do
       expect(java_opts).to include('-Dnewrelic.config.log_file_path=$PWD/.java-buildpack/new_relic_agent/logs')
     end
 
+    it 'should update JAVA_OPTS on Java 8' do
+      allow(services).to receive(:find_service).and_return('credentials' => { 'licenseKey' => 'test-license-key' })
+      allow(java_home).to receive(:version).and_return(%w(1 8 0 u10))
+
+      component.release
+
+      expect(java_opts).to include('-Dnewrelic.enable.java.8=true')
+    end
+
   end
 
 end


### PR DESCRIPTION
New Relic has experimental support for Java 8 that isn't included in the
buildpack. This change adds support for New Relic on Java 8 by adding the
appropriate flag to JAVA_OPTS when Java 8 is selected and the application is
bound to a New Relic service.

See: https://discuss.newrelic.com/t/a-note-on-java-8-support/1199/2

[#75561442]
