### PR TITLE
Set AppDynamics nodeName based on instance index

### DIFF
--- a/config/tomcat.yml
+++ b/config/tomcat.yml
@@ -27,7 +27,7 @@ logging_support:
 access_logging_support:
   version: 2.+
   repository_root: "{default.repository.root}/tomcat-access-logging-support"
-  access_logging: disabled
+  access_logging: enabled
 redis_store:
   version: 1.+
   repository_root: "{default.repository.root}/redis-store"

--- a/resources/tomcat/conf/server.xml
+++ b/resources/tomcat/conf/server.xml
@@ -26,7 +26,8 @@
         <Engine defaultHost='localhost' name='Catalina'>
             <Valve className="org.apache.catalina.valves.RemoteIpValve" protocolHeader="x-forwarded-proto"/>
             <Valve className="com.gopivotal.cloudfoundry.tomcat.logging.access.CloudFoundryAccessLoggingValve"
-                   pattern='[ACCESS] %h %l %t %D %F %B %S vcap_request_id:%{X-Vcap-Request-Id}i' enabled="${access.logging.enabled}"/>
+                   pattern='[ACCESS] %a %l %t %D %F %B %S vcap_request_id:%{X-Vcap-Request-Id}i x-forwarded-for:%h'
+                   enabled="${access.logging.enabled}"/>
             <Host name='localhost'>
                 <Listener className="com.gopivotal.cloudfoundry.tomcat.lifecycle.ApplicationStartupFailureDetectingLifecycleListener"/>
             </Host>


### PR DESCRIPTION
To provide a more consistant uniqueness to App Dynamics as application
instances come and go the nodeName should be based on the instance index rather
than the ever changing instance id.

[#75252406]
