### PR TITLE
Override App Dynamics tierName from credentials

### DIFF
--- a/config/app_dynamics_agent.yml
+++ b/config/app_dynamics_agent.yml
@@ -17,4 +17,4 @@
 ---
 version: 3.8.+
 repository_root: "{default.repository.root}/app-dynamics"
-tier_name: CloudFoundry
+default_tier_name: CloudFoundry

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -38,7 +38,7 @@ module JavaBuildpack
         java_opts
         .add_javaagent(@droplet.sandbox + 'javaagent.jar')
         .add_system_property('appdynamics.agent.applicationName', "'#{application_name}'")
-        .add_system_property('appdynamics.agent.tierName', "'#{@configuration['tier_name']}'")
+        .add_system_property('appdynamics.agent.tierName', "'#{tier_name(credentials)}'")
         .add_system_property('appdynamics.agent.nodeName',
                              "$(expr \"$VCAP_APPLICATION\" : '.*instance_id[\": ]*\"\\([a-z0-9]\\+\\)\".*')")
 
@@ -61,6 +61,10 @@ module JavaBuildpack
       FILTER = /app-dynamics/.freeze
 
       private_constant :FILTER
+
+      def tier_name(credentials)
+        credentials['tier_name'] ? credentials['tier_name'] : @configuration['default_tier_name']
+      end
 
       def application_name
         @application.details['application_name']

--- a/spec/java_buildpack/framework/app_dynamics_agent_spec.rb
+++ b/spec/java_buildpack/framework/app_dynamics_agent_spec.rb
@@ -21,7 +21,7 @@ require 'java_buildpack/framework/app_dynamics_agent'
 describe JavaBuildpack::Framework::AppDynamicsAgent do
   include_context 'component_helper'
 
-  let(:configuration) { { 'tier_name' => 'test-tier-name' } }
+  let(:configuration) { { 'default_tier_name' => 'test-tier-name' } }
 
   it 'should not detect without app-dynamics-n/a service' do
     expect(component.detect).to be_nil
@@ -65,6 +65,16 @@ describe JavaBuildpack::Framework::AppDynamicsAgent do
         expect(java_opts).to include("-Dappdynamics.agent.tierName='test-tier-name'")
         expect(java_opts).to include('-Dappdynamics.agent.nodeName=$(expr "$VCAP_APPLICATION" : ' \
                                          '\'.*instance_id[": ]*"\([a-z0-9]\+\)".*\')')
+      end
+
+      context do
+        let(:credentials) { super().merge 'tier_name' => 'another-test-tier-name' }
+
+        it 'should add tier_name from credentials to JAVA_OPTS if specified' do
+          component.release
+
+          expect(java_opts).to include("-Dappdynamics.agent.tierName='another-test-tier-name'")
+        end
       end
 
       context do


### PR DESCRIPTION
The tierName provided to App Dynamics is hard coded in the config yml file and
it is beter to support an optional override with a new property in the
credentials of the bound App Dynamics service. This commit changes the
configuration property to 'default_tire_name' and allows it to be over-ridded
with a 'tier_name' property in the App Dynamics service credentials.

See: https://github.com/cloudfoundry/java-buildpack/issues/55
See: https://github.com/cloudfoundry/java-buildpack/issues/59

[#75252498]
