### PR TITLE
Set AppDynamics nodeName based on instance index

### DIFF
--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -40,7 +40,7 @@ module JavaBuildpack
         .add_system_property('appdynamics.agent.applicationName', "'#{application_name}'")
         .add_system_property('appdynamics.agent.tierName', "'#{@configuration['tier_name']}'")
         .add_system_property('appdynamics.agent.nodeName',
-                             "$(expr \"$VCAP_APPLICATION\" : '.*instance_id[\": ]*\"\\([a-z0-9]\\+\\)\".*')")
+                             "$(expr \"$VCAP_APPLICATION\" : '.*instance_index[\": ]*\\([[:digit:]]*\\).*')")
 
         account_access_key(java_opts, credentials)
         account_name(java_opts, credentials)

--- a/spec/java_buildpack/framework/app_dynamics_agent_spec.rb
+++ b/spec/java_buildpack/framework/app_dynamics_agent_spec.rb
@@ -63,8 +63,7 @@ describe JavaBuildpack::Framework::AppDynamicsAgent do
         expect(java_opts).to include('-Dappdynamics.controller.hostName=test-host-name')
         expect(java_opts).to include("-Dappdynamics.agent.applicationName='test-application-name'")
         expect(java_opts).to include("-Dappdynamics.agent.tierName='test-tier-name'")
-        expect(java_opts).to include('-Dappdynamics.agent.nodeName=$(expr "$VCAP_APPLICATION" : ' \
-                                         '\'.*instance_id[": ]*"\([a-z0-9]\+\)".*\')')
+        expect(java_opts).to include('-Dappdynamics.agent.nodeName=$(expr "$VCAP_APPLICATION" : \'.*instance_index[": ]*\\([[:digit:]]*\\).*\')')
       end
 
       context do


### PR DESCRIPTION
To provide a more consistant uniqueness to App Dynamics as application
instances come and go the nodeName should be based on the instance index rather
than the ever changing instance id.

[#75252406]
