### PR TITLE
Change the AccessLogValve pattern

### DIFF
--- a/resources/tomcat/conf/server.xml
+++ b/resources/tomcat/conf/server.xml
@@ -26,7 +26,8 @@
         <Engine defaultHost='localhost' name='Catalina'>
             <Valve className="org.apache.catalina.valves.RemoteIpValve" protocolHeader="x-forwarded-proto"/>
             <Valve className="com.gopivotal.cloudfoundry.tomcat.logging.access.CloudFoundryAccessLoggingValve"
-                   pattern='[ACCESS] %h %l %t %D %F %B %S vcap_request_id:%{X-Vcap-Request-Id}i' enabled="${access.logging.enabled}"/>
+                   pattern='[ACCESS] %{org.apache.catalina.AccessLog.RemoteAddr}r %l %t %D %F %B %S vcap_request_id:%{X-Vcap-Request-Id}i x-forwarded-for:[%{org.apache.catalina.AccessLog.RemoteAddr}r, %a]'
+                   enabled="${access.logging.enabled}"/>
             <Host name='localhost'>
                 <Listener className="com.gopivotal.cloudfoundry.tomcat.lifecycle.ApplicationStartupFailureDetectingLifecycleListener"/>
             </Host>


### PR DESCRIPTION
The existing pattern doesn't show the IP address of the original requester.
This change adds a value of '%{org.apache.catalina.AccessLog.RemoteAddr}r' to
show the IP address of the original requester as provided by the RemoteIpValve.
'%a' will continue to show the IP address of the Router.

See: https://github.com/cloudfoundry/java-buildpack/issues/75

[#75588342]
