### PR TITLE
Update the Tomcat Access Log Pattern

### DIFF
--- a/resources/tomcat/conf/server.xml
+++ b/resources/tomcat/conf/server.xml
@@ -26,7 +26,7 @@
         <Engine defaultHost='localhost' name='Catalina'>
             <Valve className="org.apache.catalina.valves.RemoteIpValve" protocolHeader="x-forwarded-proto"/>
             <Valve className="com.gopivotal.cloudfoundry.tomcat.logging.access.CloudFoundryAccessLoggingValve"
-                   pattern='[ACCESS] %{org.apache.catalina.AccessLog.RemoteAddr}r %l %t %D %F %B %S vcap_request_id:%{X-Vcap-Request-Id}i x-forwarded-for:[%{org.apache.catalina.AccessLog.RemoteAddr}r, %a]'
+                   pattern='[ACCESS] %{org.apache.catalina.AccessLog.RemoteAddr}r %l %t %D %F %B %S vcap_request_id:%{X-Vcap-Request-Id}i'
                    enabled="${access.logging.enabled}"/>
             <Host name='localhost'>
                 <Listener className="com.gopivotal.cloudfoundry.tomcat.lifecycle.ApplicationStartupFailureDetectingLifecycleListener"/>


### PR DESCRIPTION
Due to a change in the Access Logging produced by the GoRouter the
'X-Forwarded-For' header is no longer required. The commit removes it.

See: https://github.com/cloudfoundry/java-buildpack/issues/75#issuecomment-53535349

[#77701034]
