### PR TITLE
Upgrade the default Java Version to 8

### DIFF
--- a/config/open_jdk_jre.yml
+++ b/config/open_jdk_jre.yml
@@ -14,16 +14,16 @@
 # limitations under the License.
 
 # Configuration for JRE repositories keyed by vendor
-# From Java 1.8 onwards, metaspace should be used instead of permgen.  Please see the documentation for more detail.
+# To go back to Java 7, permgen should be used instead of metaspace.  Please see the documentation for more detail.
 ---
 repository_root: "{default.repository.root}/openjdk/{platform}/{architecture}"
-version: 1.7.0_+
+version: 1.8.0_+
 memory_sizes:
-  # metaspace: 64m..
-  permgen: 64m..
+  metaspace: 64m..
+  # permgen: 64m..
 memory_heuristics:
   heap: 75
-  # metaspace: 10
-  permgen: 10
+  metaspace: 10
+  # permgen: 10
   stack: 5
   native: 10


### PR DESCRIPTION
With the release of Java 8u20 it is time to move to Java 8. This commit changes
the default Java version that will be used by the Buildpack to '1.8.0_+'.

[#70715740]
