### PR TITLE
Update the Oracle JRE to Java 8

### DIFF
--- a/config/oracle_jre.yml
+++ b/config/oracle_jre.yml
@@ -14,19 +14,19 @@
 # limitations under the License.
 
 # Configuration for JRE repositories keyed by vendor
-# From Java 1.8 onwards, metaspace should be used instead of permgen.  Please see the documentation for more detail.
+# Pre Java 1.8, permgen was used instead of metaspace.  Please see the documentation for more detail.
 ---
 # You must specify a the repository root of an Oracle JRE repository. Please see the documentation for more detail.
 # e.g.  repository_root: "http://example.com/oracle-jre/{platform}/{architecture}"
 
 repository_root: ""
-version: 1.7.0_+
+version: 1.8.0_+
 memory_sizes:
-  # metaspace: 64m..
-  permgen: 64m..
+  metaspace: 64m..
+#  permgen: 64m..
 memory_heuristics:
   heap: 75
-  # metaspace: 10
-  permgen: 10
+  metaspace: 10
+#  permgen: 10
   stack: 5
   native: 10


### PR DESCRIPTION
The Oracle JRE configuration needs to be updated to Java 8 to be consistent
with the Open JDK Java version. This commit changes that configuration.

[#70715740]
