### PR TITLE
Expand the documentation around Spring profiles

### DIFF
--- a/docs/container-dist_zip.md
+++ b/docs/container-dist_zip.md
@@ -16,8 +16,11 @@ The Dist Zip Container allows applications packaged in [`distZip`-style][] to be
 </table>
 Tags are printed to standard output by the buildpack detect script
 
+If the application uses Spring, [Spring profiles][] can be specified by setting the [`SPRING_PROFILES_ACTIVE`][] environment variable. This is automatically detected and used by Spring. The Spring Auto-reconfiguration Framework will specify the `cloud` profile in addition to any others. 
+
 ## Configuration
 The Dist Zip Container cannot be configured.
 
-
 [`distZip`-style]: http://www.gradle.org/docs/current/userguide/application_plugin.html
+[Spring profiles]:http://blog.springsource.com/2011/02/14/spring-3-1-m1-introducing-profile/
+[`SPRING_PROFILES_ACTIVE`]: http://static.springsource.org/spring/docs/3.1.x/javadoc-api/org/springframework/core/env/AbstractEnvironment.html#ACTIVE_PROFILES_PROPERTY_NAME

--- a/docs/container-java_main.md
+++ b/docs/container-java_main.md
@@ -18,6 +18,8 @@ Command line arguments may optionally be configured.
 </table>
 Tags are printed to standard output by the buildpack detect script
 
+If the application uses Spring, [Spring profiles][] can be specified by setting the [`SPRING_PROFILES_ACTIVE`][] environment variable. This is automatically detected and used by Spring. The Spring Auto-reconfiguration Framework will specify the `cloud` profile in addition to any others. 
+
 ## Spring Boot
 
 If the main class is Spring Boot's `JarLauncher`, `PropertiesLauncher` or `WarLauncher`, the Java Main Container adds a `--server.port` argument to the command so that the application uses the correct port.
@@ -32,3 +34,5 @@ The container can be configured by creating or modifying the `config/java_main.y
 | `java_main_class` | The Java class name to run. Values containing whitespace are rejected with an error, but all others values appear without modification on the Java command line.  If not specified, the Java Manifest value of `Main-Class` is used.
 
 [Configuration and Extension]: ../README.md#configuration-and-extension
+[Spring profiles]:http://blog.springsource.com/2011/02/14/spring-3-1-m1-introducing-profile/
+[`SPRING_PROFILES_ACTIVE`]: http://static.springsource.org/spring/docs/3.1.x/javadoc-api/org/springframework/core/env/AbstractEnvironment.html#ACTIVE_PROFILES_PROPERTY_NAME

--- a/docs/container-spring_boot.md
+++ b/docs/container-spring_boot.md
@@ -15,8 +15,12 @@ Tags are printed to standard output by the buildpack detect script
 
 The container expects to run the application creating by running [`gradle distZip`][d] in an application built with the Spring Boot Gradle plugin.
 
+If the application uses Spring, [Spring profiles][] can be specified by setting the [`SPRING_PROFILES_ACTIVE`][] environment variable. This is automatically detected and used by Spring. The Spring Auto-reconfiguration Framework will specify the `cloud` profile in addition to any others. 
+
 ## Configuration
 The Spring Boot Container cannot be configured.
 
 [d]: http://docs.spring.io/spring-boot/docs/1.0.1.RELEASE/reference/htmlsingle/#using-boot-gradle
 [s]: http://projects.spring.io/spring-boot/
+[Spring profiles]:http://blog.springsource.com/2011/02/14/spring-3-1-m1-introducing-profile/
+[`SPRING_PROFILES_ACTIVE`]: http://static.springsource.org/spring/docs/3.1.x/javadoc-api/org/springframework/core/env/AbstractEnvironment.html#ACTIVE_PROFILES_PROPERTY_NAME

--- a/docs/container-spring_boot_cli.md
+++ b/docs/container-spring_boot_cli.md
@@ -19,7 +19,7 @@ The Spring Boot CLI Container runs one or more Groovy (i.e. `*.groovy`) files us
 </table>
 Tags are printed to standard output by the buildpack detect script.
 
-In order to specify [Spring profiles][], set the [`SPRING_PROFILES_ACTIVE`][] environment variable.  This is automatically detected and used by Spring.
+If the application uses Spring, [Spring profiles][] can be specified by setting the [`SPRING_PROFILES_ACTIVE`][] environment variable. This is automatically detected and used by Spring. The Spring Auto-reconfiguration Framework will specify the `cloud` profile in addition to any others. 
 
 ## Configuration
 For general information on configuring the buildpack, refer to [Configuration and Extension][].

--- a/docs/container-tomcat.md
+++ b/docs/container-tomcat.md
@@ -12,7 +12,7 @@ The Tomcat Container allows servlet 2 and 3 web applications to be run.  These a
 </table>
 Tags are printed to standard output by the buildpack detect script
 
-In order to specify [Spring profiles][], set the [`SPRING_PROFILES_ACTIVE`][] environment variable.  This is automatically detected and used by Spring.
+If the application uses Spring, [Spring profiles][] can be specified by setting the [`SPRING_PROFILES_ACTIVE`][] environment variable. This is automatically detected and used by Spring. The Spring Auto-reconfiguration Framework will specify the `cloud` profile in addition to any others. 
 
 ## Configuration
 For general information on configuring the buildpack, refer to [Configuration and Extension][].

--- a/docs/framework-spring_auto_reconfiguration.md
+++ b/docs/framework-spring_auto_reconfiguration.md
@@ -13,7 +13,7 @@ The Spring Auto-reconfiguration Framework causes an application to be automatica
 </table>
 Tags are printed to standard output by the buildpack detect script
 
-If a `/WEB-INF/web.xml` file exists, the framework will modify it in addition to making the auto-reconfiguration JAR available on the classpath.  This modification consists of adding `org.cloudfoundry.reconfiguration.spring.CloudProfileApplicationContextInitializer`, `org.cloudfoundry.reconfiguration.spring.CloudPropertySourceApplicationContextInitializer`, and `org.cloudfoundry.reconfiguration.spring.CloudAutoReconfigurationApplicationContextInitializer` to the collection of `contextInitializerClasses`.
+If a `/WEB-INF/web.xml` file exists, the framework will modify it in addition to making the auto-reconfiguration JAR available on the classpath. This modification consists of adding `org.cloudfoundry.reconfiguration.spring.CloudProfileApplicationContextInitializer`, `org.cloudfoundry.reconfiguration.spring.CloudPropertySourceApplicationContextInitializer`, and `org.cloudfoundry.reconfiguration.spring.CloudAutoReconfigurationApplicationContextInitializer` to the collection of `contextInitializerClasses`. The Spring Auto-reconfiguration Framework also adds the `cloud` profile to any existing Spring profiles such as those defined in the [`SPRING_PROFILES_ACTIVE`][] environment variable.
 
 ## Configuration
 For general information on configuring the buildpack, refer to [Configuration and Extension][].
@@ -31,3 +31,4 @@ The framework can be configured by modifying the [`config/spring_auto_reconfigur
 [repositories]: extending-repositories.md
 [this listing]: http://download.pivotal.io.s3.amazonaws.com/auto-reconfiguration/index.yml
 [version syntax]: extending-repositories.md#version-syntax-and-ordering
+[`SPRING_PROFILES_ACTIVE`]: http://docs.spring.io/spring/docs/4.0.0.RELEASE/javadoc-api/org/springframework/core/env/AbstractEnvironment.html#ACTIVE_PROFILES_PROPERTY_NAME


### PR DESCRIPTION
This commit adds information about Spring profiles to the documentation for
auto-reconfiguration. It also expands the documentation about Spring profiles
for each of the relavent containers.

[#76772236]
