### PR TITLE
Packaging should handle missing platform versions

### DIFF
--- a/lib/java_buildpack/repository/repository_index.rb
+++ b/lib/java_buildpack/repository/repository_index.rb
@@ -50,9 +50,10 @@ module JavaBuildpack
       # @return [TokenizedVersion] the version of the file found
       # @return [String] the URI of the file found
       def find_item(version)
-        version = VersionResolver.resolve(version, @index.keys)
-        uri     = @index[version.to_s]
-        [version, uri]
+        found_version = VersionResolver.resolve(version, @index.keys)
+        fail "No version resolvable for '#{version}' in #{@index.keys.join(', ')}" if found_version.nil?
+        uri     = @index[found_version.to_s]
+        [found_version, uri]
       end
 
       private

--- a/lib/java_buildpack/repository/version_resolver.rb
+++ b/lib/java_buildpack/repository/version_resolver.rb
@@ -35,8 +35,7 @@ module JavaBuildpack
         # @param [TokenizedVersion] candidate_version the version, possibly containing a wildcard, to resolve.  If +nil+,
         #                                        substituted with +.
         # @param [Array<String>] versions the collection of versions to resolve against
-        # @return [TokenizedVersion] the resolved version
-        # @raise if no version can be resolved
+        # @return [TokenizedVersion] the resolved version or nil if no matching version is found
         def resolve(candidate_version, versions)
           tokenized_candidate_version = safe_candidate_version candidate_version
           tokenized_versions          = versions.map { |version| JavaBuildpack::Util::TokenizedVersion.new(version, false) }
@@ -45,7 +44,6 @@ module JavaBuildpack
           .select { |tokenized_version| matches? tokenized_candidate_version, tokenized_version }
           .max { |a, b| a <=> b }
 
-          fail "No version resolvable for '#{candidate_version}' in #{versions.join(', ')}" if version.nil?
           version
         end
 

--- a/spec/java_buildpack/repository/version_resolver_spec.rb
+++ b/spec/java_buildpack/repository/version_resolver_spec.rb
@@ -53,7 +53,7 @@ describe JavaBuildpack::Repository::VersionResolver do
   end
 
   it 'should raise an exception if no version can be resolved' do
-    expect { described_class.resolve(tokenized_version('2.1.0'), versions) }.to raise_error
+    expect(described_class.resolve(tokenized_version('2.1.0'), versions)).to be_nil
   end
 
   it 'should raise an exception when a wildcard is specified in the [] collection' do


### PR DESCRIPTION
When packaging the Java buildpack it should just report that the requested
version for a specific platform can not be found and carry on. This commit makes
that change.

[#77005312]
