### PR TITLE
Update repository.yml

### DIFF
--- a/config/repository.yml
+++ b/config/repository.yml
@@ -15,4 +15,4 @@
 
 # Repository configuration
 ---
-default_repository_root: https://download.run.pivotal.io
+default_repository_root: http://download.run.pivotal.io


### PR DESCRIPTION
SSL is currently broken for download.run.pivotal.io (port 443 responds with a non-SSL connection).
