### PR TITLE
Document alternative modes of using the buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ To learn how to configure various properties of the buildpack, follow the "Confi
 	* [Repositories](docs/extending-repositories.md) ([Configuration](docs/extending-repositories.md#configuration))
 	* [Utiltities](docs/extending-utiltities.md)
 * [Debugging the Buildpack](docs/debugging-the-buildpack.md)
+* [Buildpack Modes](docs/buildpack-modes.md)
 * Related Projects
 	* [Java Buildpack Dependency Builder](https://github.com/cloudfoundry/java-buildpack-dependency-builder)
 	* [Java Test Applications](https://github.com/cloudfoundry/java-test-applications)

--- a/docs/buildpack-modes.md
+++ b/docs/buildpack-modes.md
@@ -1,0 +1,75 @@
+#Buildpack Modes
+
+The Java Buildpack has three execution modes:
+
+* Easy Mode: Uses the repository at [http://download.run.pivotal.io][1]. This does not require any cloning or downloading unless you want to modify the Cloud Foundry provided buildpack. This is the default, and what we recommend anyone to use.
+* Expert Mode: Uses a full or partial replica of the repository at [http://download.run.pivotal.io][1] hosted at a different location, possibly a local intranet. The replica must at least include the `index.yml` files that point to the actual artifacts. This is what we recommend to anyone that does not want to access the Internet. It’s easy to keep applications secure and up-to-date, but requires the expertise to run a web-server and keep it in sync with [http://download.run.pivotal.io][1].
+* Offline Mode: Uses only the packaged internal cache. This is what we recommend if you wanted a single, self-contained artifact. The downside is having to package and keep all your dependencies up to date.
+
+##Replicating the Repository (Optional)
+
+In order to use Expert Mode you will need to make a replica of the repository at [http://download.run.pivotal.io][1], then fork the `java-buildpack` and update the [configuration][4] of `default_repository_root` to point to your copy of the repository.
+
+To make a replica of the repository at [http://download.run.pivotal.io][1], first download the artifacts and `index.yml` files as described [here][3], make them available at a suitable locations on a web server. All the artifacts and `index.yml` files may be downloaded using the [`replicate`][5] script from the [Java Buildpack Dependency Builder][3] repository.
+
+To use the script, issue the following commands from the root directory of a clone of the [Java Buildpack Dependency Builder][3] repository:
+
+```bash
+bundle install
+bundle exec bin/replicate [--base-uri <BASE-URI> | --host-name <HOST-NAME>] --output <OUTPUT>
+```
+
+| Option | Description |
+| ------ | ----------- |
+| `-b`, `--base-uri <BASE-URI>` | A URI to replace `https://download.run.pivotal.io` with, in `index.yml` files.  This value should be the network location that the repository is replicated to (e.g. `https://internal-repository:8000/dependencies`).  Either this option or `--host-name`, but not both, **must** be specified.
+| `-h`, `--host-name <HOST-NAME>` | A host name to replace `download.run.pivotal.io` with, in `index.yml` files.  This value should be the network host that the repository is replicated to (e.g. `internal-repository`).  Either this option or `--base-uri`, but not both, **must** be specified.
+| `-o`, `--output <OUTPUT>` | A filesystem location to replicate the repository to.  This option **must** be specified.
+
+##Creating an Offline Buildpack
+
+You can download a packaged build of the buildpack from either [master-Tarball][7], [master-zip][8], [release-offline][9] [release-tarball][10], [release-zip][11]. An offline buildpack can also be built from a local clone of [this][6] Git repository run `bundle exec rake clean package OFFLINE=true` to create a zipped copy of the buildpack. Then use the `cf create-buildpack` and `cf update-buildpack` commands to add or update your new buildpack to a Cloud Foundry instance.
+
+```
+NAME:
+   create-buildpack - Create a buildpack
+
+USAGE:
+   cf create-buildpack BUILDPACK PATH POSITION [--enable|--disable]
+
+TIP:
+   Path should be a zip file, a url to a zip file, or a local directory. Position is an integer, sets priority, and is sorted from lowest to highest.
+
+OPTIONS:
+   --enable	Enable the buildpack
+   --disable	Disable the buildpack
+```
+
+```
+NAME:
+   update-buildpack - Update a buildpack
+
+USAGE:
+   cf update-buildpack BUILDPACK [-p PATH] [-i POSITION] [--enable|--disable] [--lock|--unlock]
+
+OPTIONS:
+   -i 		Buildpack position among other buildpacks
+   -p 		Path to directory or zip file
+   --enable	Enable the buildpack
+   --disable	Disable the buildpack
+   --lock	Lock the buildpack
+   --unlock	Unlock the buildpack
+```
+
+To gain a better understanding of the different ways the Java Buildpack can be used you can read this blog post, ['Packaged and Offline Buildpacks'][2].
+
+[1]: http://download.run.pivotal.io/
+[2]: http://blog.cloudfoundry.org/2014/04/03/packaged-and-offline-buildpacks/
+[3]: https://github.com/cloudfoundry/java-buildpack-dependency-builder
+[4]: https://github.com/cloudfoundry/java-buildpack/blob/master/config/repository.yml
+[5]: https://github.com/cloudfoundry/java-buildpack-dependency-builder/blob/master/bin/replicate
+[6]: https://github.com/cloudfoundry/java-buildpack
+[7]: https://github.com/cloudfoundry/java-buildpack/archive/master.tar.gz
+[8]: https://github.com/cloudfoundry/java-buildpack/archive/master.zip
+[9]: https://github.com/cloudfoundry/java-buildpack/releases/download/v2.4/java-buildpack-offline-v2.4.zip
+[10]: https://github.com/cloudfoundry/java-buildpack/archive/v2.4.tar.gz
+[11]: https://github.com/cloudfoundry/java-buildpack/archive/v2.4.zip

--- a/java-buildpack.iml
+++ b/java-buildpack.iml
@@ -273,26 +273,24 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" scope="PROVIDED" name="addressable (v2.3.6, rbenv: 1.9.3-p547) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ast (v2.0.0, rbenv: 1.9.3-p547) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="bundler (v1.7.0, rbenv: 1.9.3-p547) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="bundler (v1.7.3, rbenv: 1.9.3-p547) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="codeclimate-test-reporter (v0.4.0, rbenv: 1.9.3-p547) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="crack (v0.4.2, rbenv: 1.9.3-p547) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="debase (v0.0.9, rbenv: 1.9.3-p547) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="debugger-ruby_core_source (v1.3.5, rbenv: 1.9.3-p547) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="diff-lcs (v1.2.5, rbenv: 1.9.3-p547) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="docile (v1.1.5, rbenv: 1.9.3-p547) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="json (v1.8.1, rbenv: 1.9.3-p547) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="multi_json (v1.10.1, rbenv: 1.9.3-p547) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="parser (v2.2.0.pre.3, rbenv: 1.9.3-p547) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="parser (v2.2.0.pre.4, rbenv: 1.9.3-p547) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="powerpack (v0.0.9, rbenv: 1.9.3-p547) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rainbow (v2.0.0, rbenv: 1.9.3-p547) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rake (v10.3.2, rbenv: 1.9.3-p547) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="redcarpet (v3.1.2, rbenv: 1.9.3-p547) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rspec (v3.0.0, rbenv: 1.9.3-p547) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-core (v3.0.3, rbenv: 1.9.3-p547) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-expectations (v3.0.3, rbenv: 1.9.3-p547) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-mocks (v3.0.3, rbenv: 1.9.3-p547) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-support (v3.0.3, rbenv: 1.9.3-p547) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rubocop (v0.24.1, rbenv: 1.9.3-p547) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-core (v3.0.4, rbenv: 1.9.3-p547) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-expectations (v3.0.4, rbenv: 1.9.3-p547) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-mocks (v3.0.4, rbenv: 1.9.3-p547) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-support (v3.0.4, rbenv: 1.9.3-p547) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubocop (v0.25.0, rbenv: 1.9.3-p547) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ruby-debug-base19x (v0.11.30.pre15, rbenv: 1.9.3-p547) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ruby-debug-ide (v0.4.22, rbenv: 1.9.3-p547) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ruby-progressbar (v1.5.1, rbenv: 1.9.3-p547) [gem]" level="application" />


### PR DESCRIPTION
There is no documentation about the different ways that the buildpack can be
used. This commit add documentation about expert mode and offline buildpacks.

[#76619826]
