### PR TITLE
allow hidden remote git url

### DIFF
--- a/lib/java_buildpack/buildpack_version.rb
+++ b/lib/java_buildpack/buildpack_version.rb
@@ -1,6 +1,6 @@
 # Encoding: utf-8
 # Cloud Foundry Java Buildpack
-# Copyright 2013 the original author or authors.
+# Copyright 2013-2015 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -86,10 +86,13 @@ module JavaBuildpack
       s = []
       s << @version if @version
       s << (human_readable ? '(offline)' : 'offline') if @offline
-      s << '|' if @version && human_readable
-      s << "#{@remote}##{@hash}" if @remote && @hash
-      s << 'unknown' if s.empty?
 
+      if remote_string
+        s << '|' if @version && human_readable
+        s << remote_string
+      end
+
+      s << 'unknown' if s.empty?
       s.join(human_readable ? ' ' : '-')
     end
 
@@ -98,6 +101,10 @@ module JavaBuildpack
     GIT_DIR = (Pathname.new(__FILE__).dirname.join('..', '..', '.git')).freeze
 
     private_constant :GIT_DIR
+
+    def remote_string
+      "#{@remote}##{@hash}" if @remote && !@remote.empty? && @hash && !@hash.empty?
+    end
 
     def git(command)
       `git --git-dir=#{GIT_DIR} #{command}`.chomp if git? && git_dir?

--- a/spec/java_buildpack/buildpack_version_spec.rb
+++ b/spec/java_buildpack/buildpack_version_spec.rb
@@ -1,6 +1,6 @@
 # Encoding: utf-8
 # Cloud Foundry Java Buildpack
-# Copyright 2013 the original author or authors.
+# Copyright 2013-2015 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -94,6 +94,28 @@ describe JavaBuildpack::BuildpackVersion do
     allow_any_instance_of(described_class).to receive(:system).with('which git > /dev/null').and_return(false)
 
     expect(buildpack_version.to_hash).to eq({})
+  end
+
+  it 'excludes remote string when remote and hash values from config/version.yml are empty',
+     configuration: { 'hash' => '', 'remote' => '', 'version' => 'test-version' } do
+    expect(buildpack_version.to_s).to eq('test-version')
+  end
+
+  it 'include remote string when remote and hash values from config/version.yml are missing',
+     configuration: { 'version' => 'test-version' } do
+
+    git_dir = Pathname.new('.git').expand_path
+    allow_any_instance_of(described_class).to receive(:system)
+                                              .with('which git > /dev/null')
+                                              .and_return(true)
+    allow_any_instance_of(described_class).to receive(:`)
+                                              .with("git --git-dir=#{git_dir} rev-parse --short HEAD")
+                                              .and_return('test-hash')
+    allow_any_instance_of(described_class).to receive(:`)
+                                              .with("git --git-dir=#{git_dir} config --get remote.origin.url")
+                                              .and_return('test-remote')
+
+    expect(buildpack_version.to_s).to eq('test-version | test-remote#test-hash')
   end
 
   context do


### PR DESCRIPTION
I have a usage scenario where I'd like to customize the displayed version information by the buildpack and hide the remote git url.

For comparison, here is the sample output of the default behavior where version.yml hasn't been provided
```
-----> Java Buildpack Version: 6d68606 | git@github.com:spaungam/java-buildpack.git#6d68606
```
Here is a sample of a customized `version.yml` with the intention to hide the remote git url:
```
version: '1234'
remote: ''
hash: ''
```

Resulting output of the displayed version information with the customized `version.yml`:
```
-----> Java Buildpack Version: 1234 | #
```

As you can see, there's the unwanted characters `|` and `#`.  This merge request is an adjustment on the version processing to only append these characters if there is a non-empty remote/hash string value.  When the remote/hash string is empty, the desired output is:
```
-----> Java Buildpack Version: 1234
```
