### PR TITLE
Tomcat Redis Session Replication

### DIFF
--- a/lib/java_buildpack/component/services.rb
+++ b/lib/java_buildpack/component/services.rb
@@ -33,7 +33,7 @@ module JavaBuildpack
       # +filter+ matches exactly one service, +false+ otherwise.
       #
       # @param [Regexp, String] filter a +RegExp+ or +String+ to match against the name, label, and tags of the services
-      # @param [String] required_credentials an optional list of keys or groups of keys, where at one key from the
+      # @param [String] required_credentials an optional list of keys or groups of keys, where at least one key from the
       #                                      group, must exist in the credentials payload of the candidate service
       # @return [Boolean] +true+ if the +filter+ matches exactly one service with the required credentials, +false+
       #                   otherwise.
@@ -69,7 +69,7 @@ module JavaBuildpack
 
       def credentials?(candidate, required_keys)
         required_keys.all? do |k|
-          k.is_a?(Array) ? k.one? { |g| candidate.key?(g) } : candidate.key?(k)
+          k.is_a?(Array) ? k.any? { |g| candidate.key?(g) } : candidate.key?(k)
         end
       end
 

--- a/spec/java_buildpack/component/services_spec.rb
+++ b/spec/java_buildpack/component/services_spec.rb
@@ -23,7 +23,7 @@ describe JavaBuildpack::Component::Services do
 
   let(:service) do
     { 'name'        => 'test-name', 'label' => 'test-label', 'tags' => ['test-tag'], 'plan' => 'test-plan',
-      'credentials' => { 'uri' => 'test-uri' } }
+      'credentials' => { 'uri' => 'test-uri', 'h1' => 'foo', 'h2' => 'foo' } }
   end
 
   let(:services) { described_class.new('test' => [service]) }
@@ -58,9 +58,19 @@ describe JavaBuildpack::Component::Services do
     expect(services.one_service?(/test-tag/, 'uri')).to be
   end
 
-  it 'should return true from one_service? if there is a matching service with required group credentials' do
+  it 'should return true from one_service? if there is a matching service with one required group credentials' do
     expect(services.one_service? 'test-tag', %w(uri other)).to be
     expect(services.one_service?(/test-tag/, %w(uri other))).to be
+  end
+
+  it 'should return true from one_service? if there is a matching service with two required group credentials' do
+    expect(services.one_service? 'test-tag', %w(h1 h2)).to be
+    expect(services.one_service?(/test-tag/, %w(h1 h2))).to be
+  end
+
+  it 'should return false from one_service? if there is a matching service with no required group credentials' do
+    expect(services.one_service? 'test-tag', %w(foo bar)).not_to be
+    expect(services.one_service?(/test-tag/, %w(foo bar))).not_to be
   end
 
   it 'should return nil from find_service? if there is no service that matches' do


### PR DESCRIPTION
When the Tomcat Redis sub-component detects a service with a name, label, or
tag that has `session-replication` as a substring but both 'host' and
'hostname' as credentials it will fail to use the service. This commit changes
the service detection logic to require at least one credential from a group
instead of exactly one credential from a group. It is up to the individual
containers to handle the credentials provided. In the case of the Tomcat Redis
sub-component 'hostname' will win but this is not documented and users should
not rely on that behaviour in the instances where both 'host' and 'hostname'
are provided with different values.

[#80362118]
