### PR TITLE
Document excluded JAVA_OPTS memory configurations

### DIFF
--- a/docs/framework-java_opts.md
+++ b/docs/framework-java_opts.md
@@ -23,8 +23,9 @@ The framework can be configured by creating or modifying the [`config/java_opts.
 | Name | Description
 | ---- | -----------
 | `from_environment` | Whether to append the value of the `JAVA_OPTS` environment variable to the collection of Java options
-| `java_opts` | The Java options to use when running the application.  All values are used without modification when invoking the JVM. The options are specified as a single YAML scalar in plain style or enclosed in single or double quotes.
+| `java_opts` | The Java options to use when running the application. All values are used without modification when invoking the JVM. The options are specified as a single YAML scalar in plain style or enclosed in single or double quotes. 
 
+Any `JAVA_OPTS` from either the config file or environment variables that configure memory options will cause deployment to fail as they're not allowed. Memory options are configured by the buildpack and may not be modified. 
 
 ## Example
 ```yaml


### PR DESCRIPTION
Any environment variables or config in the 'config/java_opts.yml' file that
attempts to set a memory option will cause deployment to fail. This is not
documented and this commit adds the relavent documentation.

[#79949526]
