### PR TITLE
Remove the Download cache timeout

### DIFF
--- a/lib/java_buildpack/util/cache/download_cache.rb
+++ b/lib/java_buildpack/util/cache/download_cache.rb
@@ -110,9 +110,7 @@ module JavaBuildpack
           Net::HTTPTemporaryRedirect
         ].freeze
 
-        TIMEOUT_SECONDS = 10.freeze
-
-        private_constant :CA_FILE, :FAILURE_LIMIT, :HTTP_ERRORS, :REDIRECT_TYPES, :TIMEOUT_SECONDS
+        private_constant :CA_FILE, :FAILURE_LIMIT, :HTTP_ERRORS, :REDIRECT_TYPES
 
         def attempt(http, request, cached_file)
           downloaded = false
@@ -213,9 +211,6 @@ module JavaBuildpack
         # Beware known problems with timeouts: https://www.ruby-forum.com/topic/143840
         def http_options(rich_uri)
           http_options                   = {}
-          http_options[:connect_timeout] = TIMEOUT_SECONDS
-          http_options[:open_timeout]    = TIMEOUT_SECONDS
-          http_options[:read_timeout]    = TIMEOUT_SECONDS
 
           if secure?(rich_uri)
             http_options[:use_ssl] = true

--- a/spec/java_buildpack/util/cache/download_cache_spec.rb
+++ b/spec/java_buildpack/util/cache/download_cache_spec.rb
@@ -239,8 +239,7 @@ describe JavaBuildpack::Util::Cache::DownloadCache do
     .to_return(status: 200, body: 'foo-cached', headers: { Etag: 'foo-etag', 'Last-Modified' => 'foo-last-modified' })
 
     allow(Net::HTTP).to receive(:Proxy).and_call_original
-    expect(Net::HTTP).to receive(:start).with('foo-uri', 80, connect_timeout: 10, open_timeout: 10, read_timeout: 10)
-                         .and_call_original
+    expect(Net::HTTP).to receive(:start).with('foo-uri', 80, {}).and_call_original
 
     download_cache.get(uri) {}
   end
@@ -251,8 +250,7 @@ describe JavaBuildpack::Util::Cache::DownloadCache do
 
     allow(ca_certs_directory).to receive(:exist?).and_return(true)
     allow(Net::HTTP).to receive(:Proxy).and_call_original
-    expect(Net::HTTP).to receive(:start).with('foo-uri', 80, connect_timeout: 10, open_timeout: 10, read_timeout: 10)
-                         .and_call_original
+    expect(Net::HTTP).to receive(:start).with('foo-uri', 80, {}).and_call_original
 
     download_cache.get(uri) {}
   end
@@ -262,9 +260,7 @@ describe JavaBuildpack::Util::Cache::DownloadCache do
     .to_return(status: 200, body: 'foo-cached', headers: { Etag: 'foo-etag', 'Last-Modified' => 'foo-last-modified' })
 
     allow(Net::HTTP).to receive(:Proxy).and_call_original
-    expect(Net::HTTP).to receive(:start)
-                         .with('foo-uri', 443, connect_timeout: 10, open_timeout: 10, read_timeout: 10, use_ssl: true)
-                         .and_call_original
+    expect(Net::HTTP).to receive(:start).with('foo-uri', 443, use_ssl: true).and_call_original
 
     download_cache.get(uri_secure) {}
   end
@@ -275,9 +271,7 @@ describe JavaBuildpack::Util::Cache::DownloadCache do
 
     allow(ca_certs_directory).to receive(:exist?).and_return(true)
     allow(Net::HTTP).to receive(:Proxy).and_call_original
-    expect(Net::HTTP).to receive(:start)
-                         .with('foo-uri', 443, connect_timeout: 10, open_timeout: 10, read_timeout: 10, use_ssl: true,
-                               ca_file:                         'test-path').and_call_original
+    expect(Net::HTTP).to receive(:start).with('foo-uri', 443, use_ssl: true, ca_file: 'test-path').and_call_original
 
     download_cache.get(uri_secure) {}
   end


### PR DESCRIPTION
This commit removes the timeout limit for the download cache, instead
falling back to the Ruby default of 60 seconds.

[#83473194]
