### PR TITLE
Remove passwords and usernames from all output

### DIFF
--- a/lib/java_buildpack/component/base_component.rb
+++ b/lib/java_buildpack/component/base_component.rb
@@ -20,6 +20,7 @@ require 'java_buildpack/util/cache/application_cache'
 require 'java_buildpack/util/format_duration'
 require 'java_buildpack/util/shell'
 require 'java_buildpack/util/space_case'
+require 'java_buildpack/util/sanitizer'
 
 module JavaBuildpack
   module Component
@@ -84,7 +85,7 @@ module JavaBuildpack
       # @return [Void]
       def download(version, uri, name = @component_name)
         download_start_time = Time.now
-        print "-----> Downloading #{name} #{version} from #{uri} "
+        print "-----> Downloading #{name} #{version} from #{uri.sanitize_uri} "
 
         JavaBuildpack::Util::Cache::ApplicationCache.new.get(uri) do |file, downloaded|
           puts downloaded ? "(#{(Time.now - download_start_time).duration})" : '(found in cache)'

--- a/lib/java_buildpack/util/cache/cached_file.rb
+++ b/lib/java_buildpack/util/cache/cached_file.rb
@@ -33,7 +33,7 @@ module JavaBuildpack
         # @param [String] uri a uri which uniquely identifies the file in the cache
         # @param [Boolean] mutable whether the cached file should be mutable
         def initialize(cache_root, uri, mutable)
-          key            = URI.escape(uri, ':/')
+          key            = URI.escape(uri.sanitize_uri, ':/')
           @cached        = cache_root + "#{key}.cached"
           @etag          = cache_root + "#{key}.etag"
           @last_modified = cache_root + "#{key}.last_modified"

--- a/lib/java_buildpack/util/cache/download_cache.rb
+++ b/lib/java_buildpack/util/cache/download_cache.rb
@@ -19,6 +19,7 @@ require 'java_buildpack/util/cache'
 require 'java_buildpack/util/cache/cached_file'
 require 'java_buildpack/util/cache/inferred_network_failure'
 require 'java_buildpack/util/cache/internet_availability'
+require 'java_buildpack/util/sanitizer'
 require 'monitor'
 require 'net/http'
 require 'pathname'
@@ -63,7 +64,7 @@ module JavaBuildpack
           cached_file, downloaded = from_mutable_cache uri if InternetAvailability.instance.available?
           cached_file, downloaded = from_immutable_caches(uri), false unless cached_file
 
-          fail "Unable to find cached file for #{uri}" unless cached_file
+          fail "Unable to find cached file for #{uri.sanitize_uri}" unless cached_file
           cached_file.cached(File::RDONLY | File::BINARY, downloaded, &block)
         end
 
@@ -191,7 +192,7 @@ module JavaBuildpack
           cached      = update URI(uri), cached_file
           [cached_file, cached]
         rescue => e
-          @logger.warn { "Unable to download #{uri} into cache #{@mutable_cache_root}: #{e.message}" }
+          @logger.warn { "Unable to download #{uri.sanitize_uri} into cache #{@mutable_cache_root}: #{e.message}" }
           nil
         end
 
@@ -201,7 +202,7 @@ module JavaBuildpack
 
             next unless candidate.cached?
 
-            @logger.debug { "#{uri} found in cache #{cache_root}" }
+            @logger.debug { "#{uri.sanitize_uri} found in cache #{cache_root}" }
             return candidate
           end
 

--- a/lib/java_buildpack/util/sanitizer.rb
+++ b/lib/java_buildpack/util/sanitizer.rb
@@ -1,0 +1,30 @@
+# Encoding: utf-8
+# Cloud Foundry Java Buildpack
+# Copyright (c) 2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A mixin that adds the ability to turn a +String+ into sanitized uri
+class String
+
+  # Takes a uri and strips out any credentials it may contain.
+  #
+  # @return [String] the sanitized uri
+  def sanitize_uri
+    rich_uri          = URI(self)
+    rich_uri.user     = nil
+    rich_uri.password = nil
+    rich_uri.to_s
+  end
+
+end

--- a/spec/java_buildpack/util/cache/download_cache_spec.rb
+++ b/spec/java_buildpack/util/cache/download_cache_spec.rb
@@ -35,7 +35,7 @@ describe JavaBuildpack::Util::Cache::DownloadCache do
 
   let(:uri) { 'http://foo-uri/' }
 
-  let(:uri_credentials) { 'http://test-username:test-password@foo-uri/' }
+  let(:uri_credentials) { 'https://test-username:test-password@foo-uri/' }
 
   let(:uri_secure) { 'https://foo-uri/' }
 
@@ -293,7 +293,7 @@ describe JavaBuildpack::Util::Cache::DownloadCache do
   end
 
   def credential_cache_file(root, extension)
-    root + "http%3A%2F%2Ftest-username%3Atest-password@foo-uri%2F.#{extension}"
+    root + "https%3A%2F%2Ffoo-uri%2F.#{extension}"
   end
 
   def expect_complete_cache(root)

--- a/spec/java_buildpack/util/sanitize_spec.rb
+++ b/spec/java_buildpack/util/sanitize_spec.rb
@@ -1,0 +1,32 @@
+# Encoding: utf-8
+# Cloud Foundry Java Buildpack
+# Copyright (c) 2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'application_helper'
+require 'java_buildpack/util/sanitizer'
+
+describe 'sanitize uri' do
+  include_context 'application_helper'
+
+  it 'should sanatize uri with credentials in' do
+    expect('https://myuser:mypass@myhost/path/to/file'.sanitize_uri).to eq('https://myhost/path/to/file')
+  end
+
+  it 'should not sanatize uri with no credentials in' do
+    expect('https://myhost/path/to/file'.sanitize_uri).to eq('https://myhost/path/to/file')
+  end
+
+end


### PR DESCRIPTION
Currently if dependencies are downloaded from a uri containing a
username and password then it will be recorded in the logs and
filesystem. This commit stops this sensitive information from
being output.

[#83540816]
