### PR TITLE
Fix buildpack_version to work natively in windows

### DIFF
--- a/lib/java_buildpack/buildpack_version.rb
+++ b/lib/java_buildpack/buildpack_version.rb
@@ -94,8 +94,8 @@ module JavaBuildpack
 
     private
 
-    GIT_DIR = (Pathname.new(__FILE__).dirname + '../../.git').freeze
-
+    GIT_DIR = (Pathname.new(__FILE__).dirname.join('..','..','.git')).freeze
+	
     private_constant :GIT_DIR
 
     def git(command)
@@ -103,7 +103,11 @@ module JavaBuildpack
     end
 
     def git?
-      system 'which git > /dev/null'
+	  if Gem.win_platform?
+		system 'where.exe /q git.exe'
+	  else
+        system 'which git > /dev/null'
+	  end
     end
 
     def git_dir?

--- a/lib/java_buildpack/buildpack_version.rb
+++ b/lib/java_buildpack/buildpack_version.rb
@@ -94,7 +94,7 @@ module JavaBuildpack
 
     private
 
-    GIT_DIR = (Pathname.new(__FILE__).dirname.join('..','..','.git')).freeze
+    GIT_DIR = (Pathname.new(__FILE__).dirname.join('..', '..', '.git')).freeze
 
     private_constant :GIT_DIR
 

--- a/lib/java_buildpack/buildpack_version.rb
+++ b/lib/java_buildpack/buildpack_version.rb
@@ -104,7 +104,7 @@ module JavaBuildpack
 
     def git?
 	  if Gem.win_platform?
-	    system 'where.exe /q git.exe'
+        system 'where.exe /q git.exe'
 	  else
         system 'which git > /dev/null'
 	  end

--- a/lib/java_buildpack/buildpack_version.rb
+++ b/lib/java_buildpack/buildpack_version.rb
@@ -103,11 +103,11 @@ module JavaBuildpack
     end
 
     def git?
-	  if Gem.win_platform?
+      if Gem.win_platform?
         system 'where.exe /q git.exe'
-	  else
+      else
         system 'which git > /dev/null'
-	  end
+      end
     end
 
     def git_dir?

--- a/lib/java_buildpack/buildpack_version.rb
+++ b/lib/java_buildpack/buildpack_version.rb
@@ -95,7 +95,7 @@ module JavaBuildpack
     private
 
     GIT_DIR = (Pathname.new(__FILE__).dirname.join('..','..','.git')).freeze
-	
+
     private_constant :GIT_DIR
 
     def git(command)
@@ -104,7 +104,7 @@ module JavaBuildpack
 
     def git?
 	  if Gem.win_platform?
-		system 'where.exe /q git.exe'
+	    system 'where.exe /q git.exe'
 	  else
         system 'which git > /dev/null'
 	  end


### PR DESCRIPTION
The packaged output of the java buildpack has the git hash of the most recent baseline appended to the filename. The code that does this makes some unix-centric assumptions that break things when built natively in windows. Specifically:

 * Ruby Pathname objects require the correct path separator, so appending "../../.git" results in a non-existent directory. Using the Pathname.join method resolves the issue
 * To find the git executable, the class calls the native "which" command, and that does not exist in windows. As of Windows 2003, the "where" command exists and is comparable, so use that when on Windows environments.

I've tested this on Windows 8.1 and Ubuntu 14.04 LTS to ensure it didn't break things, with no ill effects noted. Note that the tests didn't complete successfully on Windows, but I think that's more an issue of the tests on Windows rather than the code change itself. 