### PR TITLE
BugFix for the GemFire session_replication support

### DIFF
--- a/lib/java_buildpack/container/tomcat/tomcat_gemfire_store.rb
+++ b/lib/java_buildpack/container/tomcat/tomcat_gemfire_store.rb
@@ -58,6 +58,7 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::ModularComponent#command)
       def command
+        return unless supports?
         credentials = @application.services.find_service(FILTER)['credentials']
         @droplet.java_opts.add_system_property 'gemfire.security-username', credentials[KEY_USERNAME]
         @droplet.java_opts.add_system_property 'gemfire.security-password', credentials[KEY_PASSWORD]

--- a/spec/java_buildpack/container/tomcat/tomcat_gemfire_store_spec.rb
+++ b/spec/java_buildpack/container/tomcat/tomcat_gemfire_store_spec.rb
@@ -57,6 +57,10 @@ describe JavaBuildpack::Container::TomcatGemfireStore do
     expect(component.detect).to be_nil
   end
 
+  it 'does nothing without a session_replication service during release' do
+    expect(component.command).to be_nil
+  end
+
   it 'creates submodules' do
     expect(JavaBuildpack::Container::GemFire)
       .to receive(:new).with(sub_configuration_context(gemfire_configuration))


### PR DESCRIPTION
The GemFire session replication code should not fire during the
release phase unless a properly configered GemFire service is bound
to the application. If it does it causes application deployment to
fail, this commit fixes this bug.

[#86291128]