### PR TITLE
Allow native Windows build support

### DIFF
--- a/lib/java_buildpack/buildpack_version.rb
+++ b/lib/java_buildpack/buildpack_version.rb
@@ -95,7 +95,7 @@ module JavaBuildpack
 
     private
 
-    GIT_DIR = (Pathname.new(__FILE__).dirname + '../../.git').freeze
+    GIT_DIR = (Pathname.new(__FILE__).dirname.join('..', '..', '.git')).freeze
 
     private_constant :GIT_DIR
 
@@ -104,7 +104,11 @@ module JavaBuildpack
     end
 
     def git?
-      system 'which git > /dev/null'
+      if Gem.win_platform?
+        system 'where.exe /q git.exe'
+      else
+        system 'which git > /dev/null'
+      end
     end
 
     def git_dir?


### PR DESCRIPTION
Refactor buildpack_version.rb to use native windows path separators
and tools (where instead of which) when in Windows to allow git hashes
to be added to output zip. Same as pull request 117 but rebased.
Issue: 117