### PR TITLE
Update Spring Boot CLI to version 1.+

### DIFF
--- a/config/spring_boot_cli.yml
+++ b/config/spring_boot_cli.yml
@@ -17,5 +17,5 @@
 # Note that the repository is shared with the Play Auto Reconfiguration framework and should be kept in step to
 # avoid conflicts.
 ---
-version: 1.1.+
+version: 1.+
 repository_root: "{default.repository.root}/spring-boot-cli"


### PR DESCRIPTION
This commit updates the version of Spring Boot CLI to be used
from 1.1.+ to 1.+

[#87191758]