### PR TITLE
Set enableLocalCache to false to ensure consistency of state

### DIFF
--- a/lib/java_buildpack/container/tomcat/tomcat_gemfire_store.rb
+++ b/lib/java_buildpack/container/tomcat/tomcat_gemfire_store.rb
@@ -121,7 +121,7 @@ module JavaBuildpack
                             'className'                => PERSISTENT_MANAGER_CLASS,
                             'enableDebugListener'      => 'false',
                             'enableGatewayReplication' => 'false',
-                            'enableLocalCache'         => 'true',
+                            'enableLocalCache'         => 'false',
                             'enableCommitValve'        => 'true',
                             'preferDeserializedForm'   => 'true',
                             'regionAttributesId'       => 'PARTITION_REDUNDANT_PERSISTENT_OVERFLOW',

--- a/spec/fixtures/container_tomcat_gemfire_store_context_after.xml
+++ b/spec/fixtures/container_tomcat_gemfire_store_context_after.xml
@@ -15,5 +15,5 @@
   ~ limitations under the License.
   --> 
 <Context allowLinking='true'>
-    <Manager className='com.gemstone.gemfire.modules.session.catalina.Tomcat7DeltaSessionManager' enableDebugListener='false' enableGatewayReplication='false' enableLocalCache='true' enableCommitValve='true' preferDeserializedForm='true' regionAttributesId='PARTITION_REDUNDANT_PERSISTENT_OVERFLOW' regionName='sessions'/>
+    <Manager className='com.gemstone.gemfire.modules.session.catalina.Tomcat7DeltaSessionManager' enableDebugListener='false' enableGatewayReplication='false' enableLocalCache='false' enableCommitValve='true' preferDeserializedForm='true' regionAttributesId='PARTITION_REDUNDANT_PERSISTENT_OVERFLOW' regionName='sessions'/>
 </Context>


### PR DESCRIPTION
Enabling local cache could cause inconsistencies in state between multiple instances of an application

Addresses issue #152

Signed-off-by: Swapnil Bawaskar <sbawaskar@pivotal.io>