### PR TITLE
Add sensible defaults for Tomcat http connector

### DIFF
--- a/resources/tomcat/conf/server.xml
+++ b/resources/tomcat/conf/server.xml
@@ -19,7 +19,9 @@
 <Server port='-1'>
 
     <Service name='Catalina'>
-        <Connector port='${http.port}' bindOnInit="false"/>
+        <Connector port='${http.port}' bindOnInit="false"
+            connectionTimeout="5000" socket.soReuseAddress="true" socket.tcpNoDelay="true"
+            maxThreads="50" minSpareThreads="10" />
 
         <Engine defaultHost='localhost' name='Catalina'>
             <Valve className="org.apache.catalina.valves.RemoteIpValve" protocolHeader="x-forwarded-proto"/>


### PR DESCRIPTION
- change connectionTimeout to 5000 ms (Tomcat default is 60000ms)
- enable SO_REUSEADDR and TCP_NODELAY by default
- limit maxThreads to 50 (Tomcat default is 200)

