### PR TITLE
Provide a way to set environment variables for the command and set MALLOC_ARENA_MAX=2 for all JVM apps to reduce the memory overhead

### DIFF
--- a/lib/java_buildpack/buildpack.rb
+++ b/lib/java_buildpack/buildpack.rb
@@ -72,20 +72,26 @@ module JavaBuildpack
       container = component_detection('container', @containers, true).first
       fail 'No container can run this application' unless container
 
-      commands = []
-      commands << component_detection('JRE', @jres, true).first.release
-      component_detection('framework', @frameworks, false).map(&:release)
-      commands << container.release
-
       payload = {
         'addons'                => [],
         'config_vars'           => {},
-        'default_process_types' => { 'web' => commands.flatten.compact.join(' && ') }
+        'default_process_types' => { 'web' => build_command(container).flatten.compact.join(' && ') }
       }.to_yaml
 
       @logger.debug { "Release Payload:\n#{payload}" }
 
       payload
+    end
+
+    private
+
+    def build_command(container)
+      commands = []
+      commands << component_detection('JRE', @jres, true).first.release
+      component_detection('framework', @frameworks, false).map(&:release)
+      command = container.respond_to?(:main_release) ? container.main_release : container.release
+      commands << command
+      commands
     end
 
     private_class_method :new

--- a/lib/java_buildpack/component/base_component.rb
+++ b/lib/java_buildpack/component/base_component.rb
@@ -94,8 +94,14 @@ module JavaBuildpack
 
       # Resolve the environment that's passed on the command line
       def resolve_command_environment
+        return if ENV['JBP_NO_MALLOC_TUNING'] && ENV['JBP_NO_MALLOC_TUNING'] != '0'
         # set MALLOC_ARENA_MAX by default
         @default_command_environment['MALLOC_ARENA_MAX'] = 2 unless ENV.key? 'MALLOC_ARENA_MAX'
+        # disable dynamic mmap threshold, see M_MMAP_THRESHOLD in "man mallopt"
+        @default_command_environment['MALLOC_MMAP_THRESHOLD_'] = 131_072 unless ENV.key? 'MALLOC_MMAP_THRESHOLD_'
+        @default_command_environment['MALLOC_TRIM_THRESHOLD_'] = 131_072 unless ENV.key? 'MALLOC_TRIM_THRESHOLD_'
+        @default_command_environment['MALLOC_TOP_PAD_'] = 131_072 unless ENV.key? 'MALLOC_TOP_PAD_'
+        @default_command_environment['MALLOC_MMAP_MAX_'] = 65_536 unless ENV.key? 'MALLOC_MMAP_MAX_'
       end
 
       # Downloads an item with the given name and version from the given URI, then yields the resultant file to the

--- a/lib/java_buildpack/component/base_component.rb
+++ b/lib/java_buildpack/component/base_component.rb
@@ -21,6 +21,7 @@ require 'java_buildpack/util/format_duration'
 require 'java_buildpack/util/shell'
 require 'java_buildpack/util/space_case'
 require 'java_buildpack/util/sanitizer'
+require 'shellwords'
 
 module JavaBuildpack
   module Component
@@ -42,6 +43,8 @@ module JavaBuildpack
         @component_name = self.class.to_s.space_case
         @configuration  = context[:configuration]
         @droplet        = context[:droplet]
+        @default_command_environment = {}
+        resolve_command_environment
       end
 
       # If the component should be used when staging an application
@@ -76,7 +79,24 @@ module JavaBuildpack
         fail "Method 'release' must be defined"
       end
 
+      # release prepended by the command_environment
+      def main_release
+        (command_environment + ' ' + release).strip
+      end
+
       protected
+
+      # Build the environment that's passed on the command line
+      # @return [String] the environment as key=value string that can be passed to the shell command
+      def command_environment
+        @default_command_environment.collect { |key, value| "#{key}=#{value.to_s.shellescape}" }.join(' ')
+      end
+
+      # Resolve the environment that's passed on the command line
+      def resolve_command_environment
+        # set MALLOC_ARENA_MAX by default
+        @default_command_environment['MALLOC_ARENA_MAX'] = 2 unless ENV.key? 'MALLOC_ARENA_MAX'
+      end
 
       # Downloads an item with the given name and version from the given URI, then yields the resultant file to the
       # given # block.

--- a/spec/bin/release_spec.rb
+++ b/spec/bin/release_spec.rb
@@ -41,4 +41,34 @@ describe 'release script', :integration do # rubocop:disable RSpec/DescribeClass
       expect(YAML.load(stdout.string)['default_process_types']['web']).to match(/.* MALLOC_ARENA_MAX=2 .*/)
     end
   end
+
+  it 'allow disabling malloc tuning',
+     app_fixture: 'integration_valid' do
+
+    ENV['JBP_NO_MALLOC_TUNING'] = '1'
+    run("bin/release #{app_dir}") do |status|
+      expect(status).to be_success
+      expect(YAML.load(stdout.string)['default_process_types']['web']).not_to match(/.* MALLOC_ARENA_MAX.*/)
+    end
+  end
+
+  it 'do malloc tuning when JBP_NO_MALLOC_TUNING=0',
+     app_fixture: 'integration_valid' do
+
+    ENV['JBP_NO_MALLOC_TUNING'] = '0'
+    run("bin/release #{app_dir}") do |status|
+      expect(status).to be_success
+      expect(YAML.load(stdout.string)['default_process_types']['web']).to match(/.* MALLOC_ARENA_MAX=2 .*/)
+    end
+  end
+
+  it 'when env contains value, don\'t include it to the command line',
+     app_fixture: 'integration_valid' do
+
+    ENV['MALLOC_ARENA_MAX'] = '4'
+    run("bin/release #{app_dir}") do |status|
+      expect(status).to be_success
+      expect(YAML.load(stdout.string)['default_process_types']['web']).not_to match(/.* MALLOC_ARENA_MAX.*/)
+    end
+  end
 end

--- a/spec/bin/release_spec.rb
+++ b/spec/bin/release_spec.rb
@@ -33,4 +33,12 @@ describe 'release script', :integration do # rubocop:disable RSpec/DescribeClass
     end
   end
 
+  it 'add default command line environment as expected',
+     app_fixture: 'integration_valid' do
+
+    run("bin/release #{app_dir}") do |status|
+      expect(status).to be_success
+      expect(YAML.load(stdout.string)['default_process_types']['web']).to match(/.* MALLOC_ARENA_MAX=2 .*/)
+    end
+  end
 end

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -43,6 +43,7 @@ shared_context 'integration_helper' do
       puts "Buildpack Directory: #{buildpack_dir}"
     else
       FileUtils.rm_rf buildpack_dir
+      ENV.delete('JBP_NO_MALLOC_TUNING')
     end
   end
 


### PR DESCRIPTION
Provide a way to set environment variables for the command that is being built.
Also make it possible to set environment variables that apply to all container types in the Java buildpack.
- example use case is setting the MALLOC_ARENA_MAX environment variable for all container types

The code in this pull request might be totally bad in style. I was more or less learning the internals of Java buildpack and how the toolchain works while doing the PR and perhaps something is useful here. Feel free to scrap the code in this PR. :)

It would be nice if the structure in Java buildpack would support the concept of environment variables that are passed on the command line to the command. This is very useful if we want to set some environment variables for all containers types that the Java buildpack supports.

Setting MALLOC_ARENA_MAX for all JVM apps can help reduce the memory overhead in 64-bit JVM apps. 
References about MALLOC_ARENA_MAX:
Heroku guide:
https://devcenter.heroku.com/articles/tuning-glibc-memory-behavior#what-value-to-choose-for-malloc_arena_max
Hadoop issue:
https://issues.apache.org/jira/browse/HADOOP-7154

