### PR TITLE
Configurable AppDynamics application & node names

### DIFF
--- a/config/app_dynamics_agent.yml
+++ b/config/app_dynamics_agent.yml
@@ -17,4 +17,5 @@
 ---
 version: 4.0.+
 repository_root: "{default.repository.root}/app-dynamics"
+default_node_name: "$(expr \"$VCAP_APPLICATION\" : \'.*instance_index[\": ]*\\([[:digit:]]*\\).*\')"
 default_tier_name: CloudFoundry

--- a/docs/framework-app_dynamics_agent.md
+++ b/docs/framework-app_dynamics_agent.md
@@ -19,10 +19,14 @@ When binding AppDynamics using a user-provided service, it must have name or tag
 | ---- | -----------
 | `account-access-key` | (Optional) The account access key to use when authenticating with the controller
 | `account-name` | (Optional) The account name to use when authenticating with the controller
+| `application-name` | (Optional) the applicationa's name
 | `host-name` | The controller host name
+| `node-name` | (Optional) the application's node name
 | `port` | (Optional) The controller port
 | `ssl-enabled` | (Optional) Whether or not to use an SSL connection to the controller
 | `tier-name` | (Optional) the application's tier name
+
+To provide more complex values such as the `tier-name`, using the interactive mode when creating a user-provided service will manage the character escaping automatically. For example, the default `tier-name` could be set with a value of `Tier-$(expr "$VCAP_APPLICATION" : '.*instance_index[": ]*\([[:digit:]]*\).*')` to calculate a value from the Cloud Foundry instance index.
 
 ## Configuration
 For general information on configuring the buildpack, refer to [Configuration and Extension][].
@@ -31,7 +35,9 @@ The framework can be configured by modifying the [`config/app_dynamics_agent.yml
 
 | Name | Description
 | ---- | -----------
+| `default_application_name` | This is not provided by default but can be added to specify the application name in the AppDynamics dashboard.  This can be overridden with an `application-name` entry in the credentials payload.
 | `default_tier_name` | The default tier name for this application in the AppDynamics dashboard.  This can be overridden with a `tier-name` entry in the credentials payload.
+| `default_node_name` | The default node name for this application in the AppDynamics dashboard.  The default value is an expression that will be evaluated based on the `instance_index` of the application. This can be overridden with a `node-name` entry in the credentials payload.
 | `repository_root` | The URL of the AppDynamics repository index ([details][repositories]).
 | `version` | The version of AppDynamics to use. Candidate versions can be found in [this listing][].
 

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -34,14 +34,11 @@ module JavaBuildpack
       def release
         credentials = @application.services.find_service(FILTER)['credentials']
         java_opts   = @droplet.java_opts
+        java_opts.add_javaagent(@droplet.sandbox + 'javaagent.jar')
 
-        java_opts
-          .add_javaagent(@droplet.sandbox + 'javaagent.jar')
-          .add_system_property('appdynamics.agent.applicationName', "'#{application_name}'")
-          .add_system_property('appdynamics.agent.tierName', "'#{tier_name(credentials)}'")
-          .add_system_property('appdynamics.agent.nodeName',
-                               "$(expr \"$VCAP_APPLICATION\" : '.*instance_index[\": ]*\\([[:digit:]]*\\).*')")
-
+        application_name(java_opts, credentials)
+        tier_name(java_opts, credentials)
+        node_name(java_opts, credentials)
         account_access_key(java_opts, credentials)
         account_name(java_opts, credentials)
         host_name(java_opts, credentials)
@@ -62,12 +59,11 @@ module JavaBuildpack
 
       private_constant :FILTER
 
-      def tier_name(credentials)
-        credentials.key?('tier-name') ? credentials['tier-name'] : @configuration['default_tier_name']
-      end
-
-      def application_name
-        @application.details['application_name']
+      def application_name(java_opts, credentials)
+        name = credentials.key?('application-name') ? credentials['application-name'] :
+          @configuration['default_application_name']
+        name = name ? name : @application.details['application_name']
+        java_opts.add_system_property('appdynamics.agent.applicationName', "'#{name}'")
       end
 
       def account_access_key(java_opts, credentials)
@@ -86,6 +82,11 @@ module JavaBuildpack
         java_opts.add_system_property 'appdynamics.controller.hostName', host_name
       end
 
+      def node_name(java_opts, credentials)
+        name = credentials.key?('node-name') ? credentials['node-name'] : @configuration['default_node_name']
+        java_opts.add_system_property('appdynamics.agent.nodeName', "#{name}")
+      end
+
       def port(java_opts, credentials)
         port = credentials['port']
         java_opts.add_system_property 'appdynamics.controller.port', port if port
@@ -94,6 +95,11 @@ module JavaBuildpack
       def ssl_enabled(java_opts, credentials)
         ssl_enabled = credentials['ssl-enabled']
         java_opts.add_system_property 'appdynamics.controller.ssl.enabled', ssl_enabled if ssl_enabled
+      end
+
+      def tier_name(java_opts, credentials)
+        name = credentials.key?('tier-name') ? credentials['tier-name'] : @configuration['default_tier_name']
+        java_opts.add_system_property('appdynamics.agent.tierName', "'#{name}'")
       end
 
     end

--- a/spec/java_buildpack/framework/app_dynamics_agent_spec.rb
+++ b/spec/java_buildpack/framework/app_dynamics_agent_spec.rb
@@ -21,7 +21,10 @@ require 'java_buildpack/framework/app_dynamics_agent'
 describe JavaBuildpack::Framework::AppDynamicsAgent do
   include_context 'component_helper'
 
-  let(:configuration) { { 'default_tier_name' => 'test-tier-name' } }
+  let(:configuration) do
+    { 'default_tier_name' => 'test-tier-name',
+      'default_node_name' => "$(expr \"$VCAP_APPLICATION\" : '.*instance_index[\": ]*\\([[:digit:]]*\\).*')" }
+  end
 
   it 'does not detect without app-dynamics-n/a service' do
     expect(component.detect).to be_nil
@@ -74,6 +77,26 @@ describe JavaBuildpack::Framework::AppDynamicsAgent do
           component.release
 
           expect(java_opts).to include("-Dappdynamics.agent.tierName='another-test-tier-name'")
+        end
+      end
+
+      context do
+        let(:credentials) { super().merge 'application-name' => 'another-test-application-name' }
+
+        it 'adds application_name from credentials to JAVA_OPTS if specified' do
+          component.release
+
+          expect(java_opts).to include("-Dappdynamics.agent.applicationName='another-test-application-name'")
+        end
+      end
+
+      context do
+        let(:credentials) { super().merge 'node-name' => 'another-test-node-name' }
+
+        it 'adds node_name from credentials to JAVA_OPTS if specified' do
+          component.release
+
+          expect(java_opts).to include('-Dappdynamics.agent.nodeName=another-test-node-name')
         end
       end
 


### PR DESCRIPTION
This commit makes it possible to supply values for the AppDynamics
application and node names in the configuration and through service
credentials. Testing and documentation also updated.

[#89413382]