### PR TITLE
User configuration via variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ The following are _very_ simple examples for deploying the artifact types that w
 * [Spring Boot CLI](docs/example-spring_boot_cli.md)
 
 ## Configuration and Extension
-The buildpack supports configuration and extension through the use of Git repository forking.  The easiest way to accomplish this is to use [GitHub's forking functionality][] to create a copy of this repository.  Make the required configuration and extension changes in the copy of the repository.  Then specify the URL of the new repository when pushing Cloud Foundry applications.  If the modifications are generally applicable to the Cloud Foundry community, please submit a [pull request][] with the changes.
+The buildpack supports extension through the use of Git repository forking. The easiest way to accomplish this is to use [GitHub's forking functionality][] to create a copy of this repository.  Make the required extension changes in the copy of the repository. Then specify the URL of the new repository when pushing Cloud Foundry applications. If the modifications are generally applicable to the Cloud Foundry community, please submit a [pull request][] with the changes.
+
+Buildpack configuration can be overridden with an environment variable matching the configuration file you wish to override minus the `.yml` extension and with a prefix of `JBP_CONFIG`. The value of the variable should be valid inline yaml. For example, to change the default version of Java to 7 and adjust the memory heuristics apply this environment variable to the application.
+
+```cf set-env my-application JBP_CONFIG_OPEN_JDK_JRE '[version: 1.7.0_+, memory_heuristics: {heap: 85, stack: 10}]'```
+
+Environment variable can also be specified in the applications `manifest` file. See the [Environment Variables][] documentation for more information.
 
 To learn how to configure various properties of the buildpack, follow the "Configuration" links below. More information on extending the buildpack is available [here](docs/extending.md).
 
@@ -125,6 +131,7 @@ This buildpack is released under version 2.0 of the [Apache License][].
 [Cloud Foundry]: http://www.cloudfoundry.com
 [contributor guidelines]: CONTRIBUTING.md
 [disables `remote_downloads`]: docs/extending-caches.md#configuration
+[Environment Variables]: http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#env-block
 [GitHub's forking functionality]: https://help.github.com/articles/fork-a-repo
 [Grails]: http://grails.org
 [Groovy]: http://groovy.codehaus.org

--- a/config/app_dynamics_agent.yml
+++ b/config/app_dynamics_agent.yml
@@ -17,5 +17,4 @@
 ---
 version: 4.0.+
 repository_root: "{default.repository.root}/app-dynamics"
-default_node_name: "$(expr \"$VCAP_APPLICATION\" : \'.*instance_index[\": ]*\\([[:digit:]]*\\).*\')"
 default_tier_name: CloudFoundry

--- a/config/open_jdk_jre.yml
+++ b/config/open_jdk_jre.yml
@@ -14,16 +14,16 @@
 # limitations under the License.
 
 # Configuration for JRE repositories keyed by vendor
-# To go back to Java 7, permgen should be used instead of metaspace.  Please see the documentation for more detail.
+# If Java 7 is required, permgen will be used instead of metaspace. Please see the documentation for more detail.
 ---
 repository_root: "{default.repository.root}/openjdk/{platform}/{architecture}"
 version: 1.8.0_+
 memory_sizes:
   metaspace: 64m..
-  # permgen: 64m..
+  permgen: 64m..
 memory_heuristics:
   heap: 75
   metaspace: 10
-  # permgen: 10
+  permgen: 10
   stack: 5
   native: 10

--- a/docs/framework-app_dynamics_agent.md
+++ b/docs/framework-app_dynamics_agent.md
@@ -19,14 +19,10 @@ When binding AppDynamics using a user-provided service, it must have name or tag
 | ---- | -----------
 | `account-access-key` | (Optional) The account access key to use when authenticating with the controller
 | `account-name` | (Optional) The account name to use when authenticating with the controller
-| `application-name` | (Optional) the applicationa's name
 | `host-name` | The controller host name
-| `node-name` | (Optional) the application's node name
 | `port` | (Optional) The controller port
 | `ssl-enabled` | (Optional) Whether or not to use an SSL connection to the controller
 | `tier-name` | (Optional) the application's tier name
-
-To provide more complex values such as the `tier-name`, using the interactive mode when creating a user-provided service will manage the character escaping automatically. For example, the default `tier-name` could be set with a value of `Tier-$(expr "$VCAP_APPLICATION" : '.*instance_index[": ]*\([[:digit:]]*\).*')` to calculate a value from the Cloud Foundry instance index.
 
 ## Configuration
 For general information on configuring the buildpack, refer to [Configuration and Extension][].
@@ -35,9 +31,7 @@ The framework can be configured by modifying the [`config/app_dynamics_agent.yml
 
 | Name | Description
 | ---- | -----------
-| `default_application_name` | This is not provided by default but can be added to specify the application name in the AppDynamics dashboard.  This can be overridden with an `application-name` entry in the credentials payload.
 | `default_tier_name` | The default tier name for this application in the AppDynamics dashboard.  This can be overridden with a `tier-name` entry in the credentials payload.
-| `default_node_name` | The default node name for this application in the AppDynamics dashboard.  The default value is an expression that will be evaluated based on the `instance_index` of the application. This can be overridden with a `node-name` entry in the credentials payload.
 | `repository_root` | The URL of the AppDynamics repository index ([details][repositories]).
 | `version` | The version of AppDynamics to use. Candidate versions can be found in [this listing][].
 

--- a/lib/java_buildpack/util/configuration_utils.rb
+++ b/lib/java_buildpack/util/configuration_utils.rb
@@ -17,12 +17,13 @@
 require 'pathname'
 require 'java_buildpack/util'
 require 'java_buildpack/logging/logger_factory'
+require 'shellwords'
 require 'yaml'
 
 module JavaBuildpack
   module Util
 
-    # Utilities for dealing with Groovy applications
+    # Utility for loading configuration
     class ConfigurationUtils
 
       private_class_method :new
@@ -30,7 +31,8 @@ module JavaBuildpack
       class << self
 
         # Loads a configuration file from the buildpack configuration directory.  If the configuration file does not
-        # exist, returns an empty hash.
+        # exist, returns an empty hash. Overlays configuration in a matching environment variable, on top of the loaded
+        # configuration, if present. Will not add a new configuration key where an existing one does not exist.
         #
         # @param [String] identifier the identifier of the configuration
         # @param [Boolean] should_log whether the contents of the configuration file should be logged.  This value
@@ -42,6 +44,15 @@ module JavaBuildpack
           if file.exist?
             configuration = YAML.load_file(file)
             logger.debug { "Configuration from #{file}: #{configuration}" } if should_log
+
+            user_provided = ENV[environment_variable_name(identifier)]
+
+            if user_provided
+              YAML.load(user_provided).each do |new_prop|
+                configuration = do_merge(configuration, new_prop, should_log)
+              end
+              logger.debug { "Configuration from #{file} modified with: #{user_provided}" } if should_log
+            end
           else
             logger.debug { "No configuration file #{file} found" } if should_log
           end
@@ -53,7 +64,31 @@ module JavaBuildpack
 
         CONFIG_DIRECTORY = Pathname.new(File.expand_path('../../../config', File.dirname(__FILE__))).freeze
 
-        private_constant :CONFIG_DIRECTORY
+        ENVIRONMENT_VARIABLE_PATTERN = 'JBP_CONFIG_'
+
+        private_constant :CONFIG_DIRECTORY, :ENVIRONMENT_VARIABLE_PATTERN
+
+        def do_merge(hash_v1, hash_v2, should_log)
+          hash_v2.each do |key, value|
+            if hash_v1.key? key
+              hash_v1[key] = do_resolve_value(key, hash_v1[key], value, should_log)
+            else
+              logger.warn { "User config value for '#{key}' is not valid, existing property not present" } if should_log
+            end
+          end
+          hash_v1
+        end
+
+        def do_resolve_value(key, v1, v2, should_log)
+          return do_merge(v1, v2, should_log) if v1.is_a?(Hash) && v2.is_a?(Hash)
+          return v2 if (!v1.is_a?(Hash)) && (!v2.is_a?(Hash))
+          logger.warn { "User config value for '#{key}' is not valid, must be of a similar type" } if should_log
+          v1
+        end
+
+        def environment_variable_name(config_name)
+          ENVIRONMENT_VARIABLE_PATTERN + config_name.upcase
+        end
 
         def logger
           JavaBuildpack::Logging::LoggerFactory.instance.get_logger ConfigurationUtils

--- a/spec/java_buildpack/framework/app_dynamics_agent_spec.rb
+++ b/spec/java_buildpack/framework/app_dynamics_agent_spec.rb
@@ -21,10 +21,7 @@ require 'java_buildpack/framework/app_dynamics_agent'
 describe JavaBuildpack::Framework::AppDynamicsAgent do
   include_context 'component_helper'
 
-  let(:configuration) do
-    { 'default_tier_name' => 'test-tier-name',
-      'default_node_name' => "$(expr \"$VCAP_APPLICATION\" : '.*instance_index[\": ]*\\([[:digit:]]*\\).*')" }
-  end
+  let(:configuration) { { 'default_tier_name' => 'test-tier-name' } }
 
   it 'does not detect without app-dynamics-n/a service' do
     expect(component.detect).to be_nil
@@ -77,26 +74,6 @@ describe JavaBuildpack::Framework::AppDynamicsAgent do
           component.release
 
           expect(java_opts).to include("-Dappdynamics.agent.tierName='another-test-tier-name'")
-        end
-      end
-
-      context do
-        let(:credentials) { super().merge 'application-name' => 'another-test-application-name' }
-
-        it 'adds application_name from credentials to JAVA_OPTS if specified' do
-          component.release
-
-          expect(java_opts).to include("-Dappdynamics.agent.applicationName='another-test-application-name'")
-        end
-      end
-
-      context do
-        let(:credentials) { super().merge 'node-name' => 'another-test-node-name' }
-
-        it 'adds node_name from credentials to JAVA_OPTS if specified' do
-          component.release
-
-          expect(java_opts).to include('-Dappdynamics.agent.nodeName=another-test-node-name')
         end
       end
 

--- a/spec/java_buildpack/jre/open_jdk_jre_spec.rb
+++ b/spec/java_buildpack/jre/open_jdk_jre_spec.rb
@@ -23,16 +23,38 @@ require 'java_buildpack/jre/memory/weight_balancing_memory_heuristic'
 describe JavaBuildpack::Jre::OpenJdkJRE do
   include_context 'component_helper'
 
+  let(:version_8) { VERSION_8 = JavaBuildpack::Util::TokenizedVersion.new('1.8.0_+') }
+
+  let(:version_7) { VERSION_7 = JavaBuildpack::Util::TokenizedVersion.new('1.7.0_+') }
+
+  let(:configuration) do
+    { 'memory_sizes'      => { 'metaspace' => '64m..',
+                               'permgen'   => '64m..' },
+      'memory_heuristics' => { 'heap'      => '75',
+                               'metaspace' => '10',
+                               'permgen'   => '10',
+                               'stack'     => '5',
+                               'native'    => '10' } }
+  end
+
   let(:java_home) { JavaBuildpack::Component::MutableJavaHome.new }
 
-  let(:memory_heuristic) { double('MemoryHeuristic', resolve: %w(opt-1 opt-2)) }
+  let(:memory_heuristic_7) { double('MemoryHeuristic', resolve: %w(opt-7-1 opt-7-2)) }
+
+  let(:memory_heuristic_8) { double('MemoryHeuristic', resolve: %w(opt-8-1 opt-8-2)) }
 
   before do
-    allow(JavaBuildpack::Jre::WeightBalancingMemoryHeuristic).to receive(:new).and_return(memory_heuristic)
+    allow(JavaBuildpack::Repository::ConfiguredItem).to receive(:find_item).and_return([version_8, 'test-uri'])
+    allow(JavaBuildpack::Jre::WeightBalancingMemoryHeuristic).to receive(:new).with({ 'permgen' => '64m..' },
+                                                                                    anything, anything, anything)
+                                                                   .and_return(memory_heuristic_7)
+    allow(JavaBuildpack::Jre::WeightBalancingMemoryHeuristic).to receive(:new).with({ 'metaspace' => '64m..' },
+                                                                                    anything, anything, anything)
+                                                                   .and_return(memory_heuristic_8)
   end
 
   it 'detects with id of openjdk_jre-<version>' do
-    expect(component.detect).to eq("open-jdk-jre=#{version}")
+    expect(component.detect).to eq("open-jdk-jre=#{version_8}")
   end
 
   it 'extracts Java from a GZipped TAR',
@@ -48,14 +70,6 @@ describe JavaBuildpack::Jre::OpenJdkJRE do
     component
 
     expect(java_home.root).to eq(sandbox)
-  end
-
-  it 'adds memory options to java_opts' do
-    component.detect
-    component.release
-
-    expect(java_opts).to include('opt-1')
-    expect(java_opts).to include('opt-2')
   end
 
   it 'adds OnOutOfMemoryError to java_opts' do
@@ -79,6 +93,34 @@ describe JavaBuildpack::Jre::OpenJdkJRE do
     component.release
 
     expect(java_opts).to include('-Djava.io.tmpdir=$TMPDIR')
+  end
+
+  it 'removes memory options for a java 8 app',
+     cache_fixture: 'stub-java.tar.gz' do
+
+    component.detect
+    component.release
+
+    expect(java_opts).to include('opt-8-1')
+    expect(java_opts).to include('opt-8-2')
+  end
+
+  context do
+
+    before do
+      allow(JavaBuildpack::Repository::ConfiguredItem).to receive(:find_item).and_return([version_7, 'test-uri'])
+    end
+
+    it 'removes memory options for a java 7 app',
+       cache_fixture: 'stub-java.tar.gz' do
+
+      component.detect
+      component.release
+
+      expect(java_opts).to include('opt-7-1')
+      expect(java_opts).to include('opt-7-2')
+    end
+
   end
 
 end

--- a/spec/java_buildpack/util/configuration_utils_spec.rb
+++ b/spec/java_buildpack/util/configuration_utils_spec.rb
@@ -1,0 +1,61 @@
+# Encoding: utf-8
+# Cloud Foundry Java Buildpack
+# Copyright 2013-2015 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'java_buildpack/util'
+require 'java_buildpack/util/configuration_utils'
+require 'logging_helper'
+require 'pathname'
+require 'spec_helper'
+require 'yaml'
+
+describe JavaBuildpack::Util::ConfigurationUtils do
+  include_context 'logging_helper'
+
+  it 'not load absent configuration file' do
+    allow_any_instance_of(Pathname).to receive(:exist?).and_return(false)
+    expect(described_class.load('test')).to eq({})
+  end
+
+  context do
+
+    before do
+      allow_any_instance_of(Pathname).to receive(:exist?).and_return(true)
+      allow(YAML).to receive(:load_file).and_return('foo' => { 'one' => '1', 'two' => 2 },
+                                                    'bar' => { 'alpha' => { 'one' => 'cat', 'two' => 'dog' } })
+    end
+
+    it 'load configuration file' do
+      expect(described_class.load('test')).to eq('foo' => { 'one' => '1', 'two' => 2 },
+                                                 'bar' => { 'alpha' => { 'one' => 'cat', 'two' => 'dog' } })
+    end
+
+    context do
+
+      let(:environment) do
+        { 'JBP_CONFIG_TEST' => '[bar: {alpha: {one: 3, two: {one: 3}}, bravo: newValue}, foo: lion]' }
+      end
+
+      it 'overlays matching environment variables' do
+
+        expect(described_class.load('test')).to eq('foo' => { 'one' => '1', 'two' => 2 },
+                                                   'bar' => { 'alpha' => { 'one' => 3, 'two' => 'dog' } })
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
This commit adds support for overriding buildpack configuration with
environment variables. The way Java config is processed has been
modified to allow this new support to work when configuring the
required version of Java. Includes new tests and documentation, see
the main README.md for more details.

[#86997400]