### PR TITLE
OS Detection and specs work on non-centos and future CentOS versions

### DIFF
--- a/lib/java_buildpack/repository/repository_index.rb
+++ b/lib/java_buildpack/repository/repository_index.rb
@@ -85,7 +85,8 @@ module JavaBuildpack
         redhat_release = Pathname.new('/etc/redhat-release')
 
         if redhat_release.exist?
-          "centos#{redhat_release.read.match(/CentOS release (\d)/)[1]}"
+          tokens = redhat_release.read.match(/(\w+) (?:Linux )?release (\d+)/)
+          "#{tokens[1].downcase}#{tokens[2]}"
         elsif `uname -s` =~ /Darwin/
           'mountainlion'
         elsif !`which lsb_release 2> /dev/null`.empty?

--- a/spec/java_buildpack/repository/repository_index_spec.rb
+++ b/spec/java_buildpack/repository/repository_index_spec.rb
@@ -84,6 +84,10 @@ describe JavaBuildpack::Repository::RepositoryIndex do
   end
 
   it 'handles Mac OS X' do
+    allow(Pathname).to receive(:new).and_call_original
+    non_redhat = double('non-redhat', exist?: false)
+    allow(Pathname).to receive(:new).with('/etc/redhat-release').and_return(non_redhat)
+
     allow_any_instance_of(described_class).to receive(:`).with('uname -s').and_return('Darwin')
     allow_any_instance_of(described_class).to receive(:`).with('uname -m').and_return('x86_64')
     allow(application_cache).to receive(:get).with('mountainlion/x86_64/test-uri/index.yml')
@@ -95,6 +99,10 @@ describe JavaBuildpack::Repository::RepositoryIndex do
   end
 
   it 'handles Ubuntu' do
+    allow(Pathname).to receive(:new).and_call_original
+    non_redhat = double('non-redhat', exist?: false)
+    allow(Pathname).to receive(:new).with('/etc/redhat-release').and_return(non_redhat)
+
     allow_any_instance_of(described_class).to receive(:`).with('uname -s').and_return('Linux')
     allow_any_instance_of(described_class).to receive(:`).with('uname -m').and_return('x86_64')
     allow_any_instance_of(described_class).to receive(:`).with('which lsb_release 2> /dev/null')
@@ -109,6 +117,10 @@ describe JavaBuildpack::Repository::RepositoryIndex do
   end
 
   it 'handles unknown OS' do
+    allow(Pathname).to receive(:new).and_call_original
+    non_redhat = double('non-redhat', exist?: false)
+    allow(Pathname).to receive(:new).with('/etc/redhat-release').and_return(non_redhat)
+
     allow_any_instance_of(File).to receive(:exists?).with('/etc/redhat-release').and_return(false)
     allow_any_instance_of(described_class).to receive(:`).with('uname -s').and_return('Linux')
     allow_any_instance_of(described_class).to receive(:`).with('which lsb_release 2> /dev/null').and_return('')


### PR DESCRIPTION
Non-Centos RH OSes (i.e. Fedora which is used on Jenkins) were similarly unable to test because they got trapped out in repository_index.rb. OS detection specs even on CentOS 6 would fail when doing tests for the non-RH OSes.

OS detection on CentOS 7 would fail completely due to format changes for /etc/redhat-release.

OS detection would like have detected incorrectly on >9 as only a single digit was matched by regex.

Integration tests (spec/bin/*) still fail on non-Centos 6, RHEL-based OSes, but all other tests pass now.

Related to #183

trying again