### PR TITLE
Add memory_limit context to compile tests

### DIFF
--- a/spec/bin/compile_spec.rb
+++ b/spec/bin/compile_spec.rb
@@ -16,12 +16,15 @@
 
 require 'spec_helper'
 require 'integration_helper'
+require 'memory_limit_helper'
 
 describe 'compile script', :integration do # rubocop:disable RSpec/DescribeClass
   include_context 'integration_helper'
+  include_context 'memory_limit_helper'
 
   it 'returns zero if success',
-     app_fixture: 'integration_valid' do
+     app_fixture: 'integration_valid',
+     memory_limit: '1024m' do
 
     run("bin/compile #{app_dir} #{app_dir + '.cache'}") { |status| expect(status).to be_success }
   end


### PR DESCRIPTION
Latest version of the memory calculator requires -totMemory option > 0

This is intended to fix the CI bug I'm noticing on #187 