### PR TITLE
Corrected JVM configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The buildpack supports extension through the use of Git repository forking. The 
 
 Buildpack configuration can be overridden with an environment variable matching the configuration file you wish to override minus the `.yml` extension and with a prefix of `JBP_CONFIG`. The value of the variable should be valid inline yaml. For example, to change the default version of Java to 7 and adjust the memory heuristics apply this environment variable to the application.
 
-```cf set-env my-application JBP_CONFIG_OPEN_JDK_JRE '[version: 1.7.0_+, memory_heuristics: {heap: 85, stack: 10}]'```
+```cf set-env my-application JBP_CONFIG_OPEN_JDK_JRE '[jre: {version: 1.7.0_+}, memory_calculator: {memory_heuristics: {heap: 85, stack: 10}}]'```
 
 If the key or value contains a special character such as `:` it should be escaped with double quotes. For example, to change the default repository path for the buildpack.
 


### PR DESCRIPTION
JRE version is now wrapped in a 'jre' element, and the memory_heuristics is
now wrapped in a 'memory_calculator' element.

Issue: 191