### PR TITLE
Download tar enhancement

### DIFF
--- a/lib/java_buildpack/component/base_component.rb
+++ b/lib/java_buildpack/component/base_component.rb
@@ -178,6 +178,10 @@ module JavaBuildpack
         file.path.end_with? '.gz'
       end
 
+      def bzipped?(file)
+        file.path.end_with? '.bz2'
+      end
+
     end
 
   end

--- a/lib/java_buildpack/component/base_component.rb
+++ b/lib/java_buildpack/component/base_component.rb
@@ -122,10 +122,16 @@ module JavaBuildpack
         download(version, uri, name) do |file|
           with_timing "Expanding #{name} to #{target_directory.relative_path_from(@droplet.root)}" do
             FileUtils.mkdir_p target_directory
-            shell "tar x#{gzipped?(file) ? 'x' : ''}f #{file.path} -C #{target_directory} --strip 1 2>&1"
+            if gzipped?(file)
+             shell "tar xzf #{file.path} -C #{target_directory} --strip 1 2>&1"
+            elsif bzipped?(file)
+             shell "tar xjf #{file.path} -C #{target_directory} --strip 1 2>&1"
+            else
+             shell "tar xf #{file.path} -C #{target_directory} --strip 1 2>&1"
+            end
           end
         end
-      end
+      end      
 
       # Downloads a given ZIP file and expands it.
       #


### PR DESCRIPTION
In method download_tar the logic to detect if the archive is a gzipped file (tar.gz) adds an 'x' to the tar parameters instead of a 'z'. When executed, the command results into "tar xxf" instead of "tar xzf".

The other thing is that the download_tar method currently does not handle archives with bz2 extensions.

This pull request fixes the issue for gzipped archives and adds support for bz2 files (additional handler added bor bz2 files).
