### PR TITLE
Add default values for heap and stack to support custom fixed values

### DIFF
--- a/config/open_jdk_jre.yml
+++ b/config/open_jdk_jre.yml
@@ -23,8 +23,11 @@ memory_calculator:
   version: 1.+
   repository_root: ! '{default.repository.root}/memory-calculator/{platform}/{architecture}'
   memory_sizes:
+    heap: 64m..
     metaspace: 64m..
+    native: 64m..
     permgen: 64m..
+    stack: 256k..
   memory_heuristics:
     heap: 75
     metaspace: 10


### PR DESCRIPTION
To allow fixed values to be set for heap, stack and native as per
https://github.com/cloudfoundry/java-buildpack/blob/master/docs/jre-open_jdk_jre.md#memory-sizes
default values need to be included in the configuration.

[resolves #202]