### PR TITLE
Support passing initial memory config to memory calculator.

### DIFF
--- a/config/open_jdk_jre.yml
+++ b/config/open_jdk_jre.yml
@@ -20,7 +20,7 @@ jre:
   version: 1.8.0_+
   repository_root: ! '{default.repository.root}/openjdk/{platform}/{architecture}'
 memory_calculator:
-  version: 1.+
+  version: 2.+
   repository_root: ! '{default.repository.root}/memory-calculator/{platform}/{architecture}'
   memory_sizes:
     heap: 

--- a/config/open_jdk_jre.yml
+++ b/config/open_jdk_jre.yml
@@ -34,3 +34,8 @@ memory_calculator:
     native: 10
     permgen: 10
     stack: 5
+  memory_initials:
+    heap: 100%
+    metaspace: 100%
+    permgen: 100%
+    

--- a/config/oracle_jre.yml
+++ b/config/oracle_jre.yml
@@ -23,7 +23,7 @@ jre:
   version: 1.8.0_+
   repository_root: ""
 memory_calculator:
-  version: 1.+
+  version: 2.+
   repository_root: ! '{default.repository.root}/memory-calculator/{platform}/{architecture}'
   memory_sizes:
     heap:

--- a/config/oracle_jre.yml
+++ b/config/oracle_jre.yml
@@ -37,3 +37,7 @@ memory_calculator:
     native: 10
     permgen: 10
     stack: 5
+  memory_initials:
+    heap: 100%
+    metaspace: 100%
+    permgen: 100%

--- a/docs/jre-open_jdk_jre.md
+++ b/docs/jre-open_jdk_jre.md
@@ -21,7 +21,8 @@ The JRE can be configured by modifying the [`config/open_jdk_jre.yml`][] file in
 | Name | Description
 | ---- | -----------
 | `memory_sizes` | Optional memory sizes, described below under "Memory Sizes".
-| `memory_heuristics` | Default memory size weightings, described below under "Memory Weightings.
+| `memory_heuristics` | Default memory size weightings, described below under "Memory Weightings".
+| `memory_initials` | Initial memory sizes, described below under "Memory Initials".
 | `repository_root` | The URL of the OpenJDK repository index ([details][repositories]).
 | `version` | The version of Java runtime to use.  Candidate versions can be found in the listings for [centos6][], [lucid][], [mountainlion][], and [precise][]. Note: version 1.8.0 and higher require the `memory_sizes` and `memory_heuristics` mappings to specify `metaspace` rather than `permgen`.
 
@@ -66,6 +67,21 @@ memory_heuristics:
 represent a maximum heap size three times as large as the maximum PermGen size, and so on.
 
 Memory weightings are used together with memory ranges to calculate the amount of memory for each memory type, as follows.
+
+#### Memory Initials
+Memory initials are configured in the `memory_initials` mapping of [`config/open_jdk_jre.yml`][]. Each initial is a percentage of the given type of memory. Valid memory types are `heap`, `permgen`, and `metaspace`. For example, the following initials:
+
+```yaml
+memory_initials:
+  heap: 50%
+  permgen: 25%
+```
+
+Given a maximum heap (Xmx) of 1G and a maximum permgen (-XX:MaxPermsize) of 256M an initial heap (Xms) of 512M and an initial permgen (-XX:Permsize) of 64M would be used.
+
+If no initial value is specified for a memory type the JVM default will be used.
+
+A value of 100% for each memory types is generally recommended for best performance.  Smaller values will potentially preserve unused system memory for other tenants on the same host.  Using the G1 garbage collector along with aggressive `MinHeapFreeRatio` and `MaxHeapFreeRatio` values the JVM will actually release unused heap back to the system up to the initial value.
 
 #### Memory Calculation
 Memory calculation happens before every `start` of an application and is performed by an external program, the [Java Buildpack Memory Calculator]. There is no need to `restage` an application after scaling the memory as restarting will cause the memory settings to be recalculated. 

--- a/docs/jre-oracle_jre.md
+++ b/docs/jre-oracle_jre.md
@@ -78,7 +78,7 @@ represent a maximum heap size three times as large as the maximum PermGen size, 
 Memory weightings are used together with memory ranges to calculate the amount of memory for each memory type, as follows.
 
 #### Memory Initials
-Memory initials are configured in the `memory_initials` mapping of [`config/open_jdk_jre.yml`][]. Each initial is a percentage of the given type of memory. Valid memory types are `heap`, `permgen`, and `metaspace`. For example, the following initials:
+Memory initials are configured in the `memory_initials` mapping of [`config/oracle_jre.yml`][]. Each initial is a percentage of the given type of memory. Valid memory types are `heap`, `permgen`, and `metaspace`. For example, the following initials:
 
 ```yaml
 memory_initials:

--- a/docs/jre-oracle_jre.md
+++ b/docs/jre-oracle_jre.md
@@ -30,7 +30,8 @@ The JRE can be configured by modifying the [`config/oracle_jre.yml`][] file in t
 | Name | Description
 | ---- | -----------
 | `memory_sizes` | Optional memory sizes, described below under "Memory Sizes".
-| `memory_heuristics` | Default memory size weightings, described below under "Memory Weightings.
+| `memory_heuristics` | Default memory size weightings, described below under "Memory Weightings".
+| `memory_initials` | Initial memory sizes, described below under "Memory Initials".
 | `repository_root` | The URL of the Oracle repository index ([details][repositories]).
 | `version` | The version of Java runtime to use.  Candidate versions can be found in the the repository that you have created to house the JREs. Note: version 1.8.0 and higher require the `memory_sizes` and `memory_heuristics` mappings to specify `metaspace` rather than `permgen`.
 
@@ -75,6 +76,21 @@ memory_heuristics:
 represent a maximum heap size three times as large as the maximum PermGen size, and so on.
 
 Memory weightings are used together with memory ranges to calculate the amount of memory for each memory type, as follows.
+
+#### Memory Initials
+Memory initials are configured in the `memory_initials` mapping of [`config/open_jdk_jre.yml`][]. Each initial is a percentage of the given type of memory. Valid memory types are `heap`, `permgen`, and `metaspace`. For example, the following initials:
+
+```yaml
+memory_initials:
+  heap: 50%
+  permgen: 25%
+```
+
+Given a maximum heap (Xmx) of 1G and a maximum permgen (-XX:MaxPermsize) of 256M an initial heap (Xms) of 512M and an initial permgen (-XX:Permsize) of 64M would be used.
+
+If no initial value is specified for a memory type the JVM default will be used.
+
+A value of 100% for each memory types is generally recommended for best performance.  Smaller values will potentially preserve unused system memory for other tenants on the same host.  Using the G1 garbage collector along with aggressive `MinHeapFreeRatio` and `MaxHeapFreeRatio` values the JVM will actually release unused heap back to the system up to the initial value.
 
 #### Memory Calculation
 Memory calculation happens before every `start` of an application and is performed by an external program, the [Java Buildpack Memory Calculator]. There is no need to `restage` an application after scaling the memory as restarting will cause the memory settings to be recalculated. 

--- a/lib/java_buildpack/jre/open_jdk_like_memory_calculator.rb
+++ b/lib/java_buildpack/jre/open_jdk_like_memory_calculator.rb
@@ -36,7 +36,8 @@ module JavaBuildpack
         end
 
         shell "#{qualify_path memory_calculator, Pathname.new(Dir.pwd)} -memorySizes=#{memory_sizes @configuration} " \
-              "-memoryWeights=#{memory_weights @configuration} -totMemory=$MEMORY_LIMIT"
+              "-memoryWeights=#{memory_weights @configuration} -memoryInitials=#{memory_initials @configuration} " \
+              '-totMemory=$MEMORY_LIMIT'
       end
 
       # Returns a fully qualified memory calculation command to be prepended to the buildpack's command sequence
@@ -45,7 +46,7 @@ module JavaBuildpack
       def memory_calculation_command
         "CALCULATED_MEMORY=$(#{qualify_path memory_calculator, @droplet.root} " \
         "-memorySizes=#{memory_sizes @configuration} -memoryWeights=#{memory_weights @configuration} " \
-        '-totMemory=$MEMORY_LIMIT)'
+        "-memoryInitials=#{memory_initials @configuration} -totMemory=$MEMORY_LIMIT)"
       end
 
       # (see JavaBuildpack::Component::BaseComponent#release)
@@ -73,6 +74,11 @@ module JavaBuildpack
 
       def memory_weights(configuration)
         memory_sizes = version_specific configuration['memory_heuristics']
+        memory_sizes.map { |k, v| "#{k}:#{v}" }.join(',')
+      end
+
+      def memory_initials(configuration)
+        memory_sizes = version_specific configuration['memory_initials']
         memory_sizes.map { |k, v| "#{k}:#{v}" }.join(',')
       end
 

--- a/spec/java_buildpack/jre/open_jdk_like_memory_calculator_spec.rb
+++ b/spec/java_buildpack/jre/open_jdk_like_memory_calculator_spec.rb
@@ -37,7 +37,10 @@ describe JavaBuildpack::Jre::OpenJDKLikeMemoryCalculator do
                                'metaspace' => '10',
                                'permgen'   => '10',
                                'stack'     => '5',
-                               'native'    => '10' } }
+                               'native'    => '10' },
+      'memory_initials'   => { 'heap'      => '100%',
+                               'metaspace' => '100%',
+                               'permgen'   => '100%' } }
   end
 
   it 'copies executable to bin directory',
@@ -70,6 +73,7 @@ describe JavaBuildpack::Jre::OpenJDKLikeMemoryCalculator do
 
     expect(component).to receive(:shell).with("#{memory_calculator} -memorySizes=permgen:64m.. " \
                                               '-memoryWeights=heap:75,permgen:10,stack:5,native:10 ' \
+                                              '-memoryInitials=heap:100%,permgen:100% ' \
                                               '-totMemory=$MEMORY_LIMIT')
 
     component.compile
@@ -81,7 +85,9 @@ describe JavaBuildpack::Jre::OpenJDKLikeMemoryCalculator do
 
     expect(command).to eq('CALCULATED_MEMORY=$($PWD/.java-buildpack/open_jdk_like_memory_calculator/bin/' \
                           'java-buildpack-memory-calculator-0.0.0 -memorySizes=permgen:64m.. ' \
-                          '-memoryWeights=heap:75,permgen:10,stack:5,native:10 -totMemory=$MEMORY_LIMIT)')
+                          '-memoryWeights=heap:75,permgen:10,stack:5,native:10 ' \
+                          '-memoryInitials=heap:100%,permgen:100% ' \
+                          '-totMemory=$MEMORY_LIMIT)')
   end
 
   it 'create memory calculation command for Java 8' do
@@ -90,7 +96,9 @@ describe JavaBuildpack::Jre::OpenJDKLikeMemoryCalculator do
 
     expect(command).to eq('CALCULATED_MEMORY=$($PWD/.java-buildpack/open_jdk_like_memory_calculator/bin/' \
                           'java-buildpack-memory-calculator-0.0.0 -memorySizes=metaspace:64m.. ' \
-                          '-memoryWeights=heap:75,metaspace:10,stack:5,native:10 -totMemory=$MEMORY_LIMIT)')
+                          '-memoryWeights=heap:75,metaspace:10,stack:5,native:10 ' \
+                          '-memoryInitials=heap:100%,metaspace:100% ' \
+                          '-totMemory=$MEMORY_LIMIT)')
   end
 
   it 'adds $CALCULATED_MEMORY to the JAVA_OPTS' do

--- a/spec/java_buildpack/jre/open_jdk_like_spec.rb
+++ b/spec/java_buildpack/jre/open_jdk_like_spec.rb
@@ -45,7 +45,10 @@ describe JavaBuildpack::Jre::OpenJDKLike do
                                'metaspace' => '10',
                                'permgen'   => '10',
                                'stack'     => '5',
-                               'native'    => '10' } }
+                               'native'    => '10' },
+      'memory_initials'   => { 'heap'      => '100%',
+                               'metaspace' => '100%',
+                               'permgen'   => '100%' } }
   end
 
   it 'always supports' do
@@ -67,7 +70,9 @@ describe JavaBuildpack::Jre::OpenJDKLike do
     java_home.version = version_7
     expect(component.command).to eq('CALCULATED_MEMORY=$($PWD/.java-buildpack/open_jdk_like/bin/' \
                                     'java-buildpack-memory-calculator-0.0.0 -memorySizes=permgen:64m.. ' \
-                                    '-memoryWeights=heap:75,permgen:10,stack:5,native:10 -totMemory=$MEMORY_LIMIT)')
+                                    '-memoryWeights=heap:75,permgen:10,stack:5,native:10 ' \
+                                    '-memoryInitials=heap:100%,permgen:100% ' \
+                                    '-totMemory=$MEMORY_LIMIT)')
   end
 
 end


### PR DESCRIPTION
PR for issue https://github.com/cloudfoundry/java-buildpack/issues/200

Can be merged after https://github.com/cloudfoundry/java-buildpack-memory-calculator/pull/1 is merged and released.