### PR TITLE
Allow setting of DynaTrace agent name via environment variable

### DIFF
--- a/lib/java_buildpack/framework/dyna_trace_agent.rb
+++ b/lib/java_buildpack/framework/dyna_trace_agent.rb
@@ -59,7 +59,7 @@ module JavaBuildpack
       end
 
       def agent_name
-        "#{@application.details['application_name']}_#{profile_name}"
+        ENV['DYNATRACE_AGENT_NAME'] || "#{@application.details['application_name']}_#{profile_name}"
       end
 
       def architecture

--- a/lib/java_buildpack/framework/dyna_trace_agent.rb
+++ b/lib/java_buildpack/framework/dyna_trace_agent.rb
@@ -59,7 +59,7 @@ module JavaBuildpack
       end
 
       def agent_name
-        ENV['JBP_CONFIG_DYNATRACE_AGENT_NAME'] || "#{@application.details['application_name']}_#{profile_name}"
+        ENV['JBP_CONFIG_DYNATRACE_AGENT_NAME'] || "#{@application.details['application_name']}_#{profile_name}" 
       end
 
       def architecture

--- a/lib/java_buildpack/framework/dyna_trace_agent.rb
+++ b/lib/java_buildpack/framework/dyna_trace_agent.rb
@@ -59,7 +59,7 @@ module JavaBuildpack
       end
 
       def agent_name
-        ENV['DYNATRACE_AGENT_NAME'] || "#{@application.details['application_name']}_#{profile_name}"
+        ENV['JBP_CONFIG_DYNATRACE_AGENT_NAME'] || "#{@application.details['application_name']}_#{profile_name}"
       end
 
       def architecture

--- a/spec/java_buildpack/framework/dyna_trace_agent_spec.rb
+++ b/spec/java_buildpack/framework/dyna_trace_agent_spec.rb
@@ -69,7 +69,7 @@ describe JavaBuildpack::Framework::DynaTraceAgent do
 
   context do
 
-    let(:environment) { { 'DYNATRACE_AGENT_NAME' => 'environment-set-application-name' } }
+    let(:environment) { { 'JBP_CONFIG_DYNATRACE_AGENT_NAME' => 'environment-set-application-name' } }
 
     before do
       allow(services).to receive(:one_service?).with(/dynatrace/, 'server').and_return(true)

--- a/spec/java_buildpack/framework/dyna_trace_agent_spec.rb
+++ b/spec/java_buildpack/framework/dyna_trace_agent_spec.rb
@@ -76,7 +76,7 @@ describe JavaBuildpack::Framework::DynaTraceAgent do
       allow(services).to receive(:find_service).and_return('credentials' => { 'server' => 'test-host-name' })
     end
 
-    it 'updates JAVA_OPTS with custom environment variable' do
+    it 'updates JAVA_OPTS with custom environment variable' do 
       component.release
       expect(java_opts).to include(
         '-agentpath:$PWD/.java-buildpack/dyna_trace_agent/agent/lib64/'\

--- a/spec/java_buildpack/framework/dyna_trace_agent_spec.rb
+++ b/spec/java_buildpack/framework/dyna_trace_agent_spec.rb
@@ -66,4 +66,23 @@ describe JavaBuildpack::Framework::DynaTraceAgent do
     end
 
   end
+
+  context do
+
+    let(:environment) { { 'DYNATRACE_AGENT_NAME' => 'environment-set-application-name' } }
+
+    before do
+      allow(services).to receive(:one_service?).with(/dynatrace/, 'server').and_return(true)
+      allow(services).to receive(:find_service).and_return('credentials' => { 'server' => 'test-host-name' })
+    end
+
+    it 'updates JAVA_OPTS with custom environment variable' do
+      component.release
+      expect(java_opts).to include(
+        '-agentpath:$PWD/.java-buildpack/dyna_trace_agent/agent/lib64/'\
+        'libdtagent.so=name=environment-set-application-name,server=test-host-name')
+    end
+
+  end
+
 end


### PR DESCRIPTION
A customer has asked for a non-default (that is, something different than the application name) to be used for the DynaTrace agent name.  By setting an environment variable, we can allow end users to set the agent name.

The environment variable is JBP_CONFIG_DYNATRACE_AGENT_NAME.  If it exists, the value of this environment variable will be used for the DynaTrace agent name in the JVM Options.  If it does not exist, the default behaviour (using the application name) will be used.

This is my first foray into ruby.  I used other ruby files in the buildpack as a general style guide, any feedback will be greatly appreciated.

Also, its unclear how to sign the CLA.  Should I be receiving some notification with instructions?  