### PR TITLE
Add a simple example of adding command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ cf set-env my-application JBP_CONFIG_OPEN_JDK_JRE '[jre: { version: 1.7.0_+ }]
 To add command line arguments to a Java app you can use `JBP_CONFIG_JAVA_MAIN`, like this:
 
 ```bash
-$ cf set-env my-application JBP_CONFIG_JAVA_MAIN '[arguments: "--foo=bar a b c"]'
+$ cf set-env my-application JBP_CONFIG_JAVA_MAIN '[arguments: "--server.port=\$PORT --foo=bar a b c"]'
 ```
 
 If the key or value contains a special character such as `:` it should be escaped with double quotes. For example, to change the default repository path for the buildpack.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Buildpack configuration can be overridden with an environment variable matching 
 $ cf set-env my-application JBP_CONFIG_OPEN_JDK_JRE '[jre: { version: 1.7.0_+ }]'
 ```
 
+To add command line arguments to a Java app you can use `JBP_CONFIG_JAVA_MAIN`, like this:
+
+```bash
+$ cf set-env my-application JBP_CONFIG_JAVA_MAIN '[arguments: "--foo=bar a b c"]'
+```
+
 If the key or value contains a special character such as `:` it should be escaped with double quotes. For example, to change the default repository path for the buildpack.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -27,36 +27,36 @@ The following are _very_ simple examples for deploying the artifact types that w
 ## Configuration and Extension
 The buildpack supports extension through the use of Git repository forking. The easiest way to accomplish this is to use [GitHub's forking functionality][] to create a copy of this repository.  Make the required extension changes in the copy of the repository. Then specify the URL of the new repository when pushing Cloud Foundry applications. If the modifications are generally applicable to the Cloud Foundry community, please submit a [pull request][] with the changes.
 
-Buildpack configuration can be overridden with an environment variable matching the configuration file you wish to override minus the `.yml` extension and with a prefix of `JBP_CONFIG`. It is not possible to add new configuration properties and properties with `nil` or empty values will be ignored by the buildpack. The value of the variable should be valid inline yaml, referred to as `flow style` in the yaml spec. For example, to change the default version of Java to 7 and adjust the memory heuristics apply this environment variable to the application.
+Buildpack configuration can be overridden with an environment variable matching the configuration file you wish to override minus the `.yml` extension and with a prefix of `JBP_CONFIG`. It is not possible to add new configuration properties and properties with `nil` or empty values will be ignored by the buildpack. The value of the variable should be valid inline yaml, referred to as `flow style` in the yaml spec (it's basically JSON with optional quotes). For example, to change the default version of Java to 7 and adjust the memory heuristics apply this environment variable to the application.
 
 ```bash
-$ cf set-env my-application JBP_CONFIG_OPEN_JDK_JRE '[jre: { version: 1.7.0_+ }]'
+$ cf set-env my-application JBP_CONFIG_OPEN_JDK_JRE '{jre: { version: 1.7.0_+ }}'
 ```
 
-To add command line arguments to a Java app you can use `JBP_CONFIG_JAVA_MAIN`, like this:
+If the key or value contains an environment variable that you want to bind at runtime you need to escape it from your shell. For example, to add command line arguments to a Java app you can use `JBP_CONFIG_JAVA_MAIN` and escape the `$PORT` like this:
 
 ```bash
-$ cf set-env my-application JBP_CONFIG_JAVA_MAIN '[arguments: "--server.port=\$PORT --foo=bar a b c"]'
+$ cf set-env my-application JBP_CONFIG_JAVA_MAIN '{arguments: "--server.port=\$PORT --foo=bar a b c"}'
 ```
 
 If the key or value contains a special character such as `:` it should be escaped with double quotes. For example, to change the default repository path for the buildpack.
 
 ```bash
-$ cf set-env my-application JBP_CONFIG_REPOSITORY '[default_repository_root: "http://repo.example.io"]'
+$ cf set-env my-application JBP_CONFIG_REPOSITORY '{default_repository_root: "http://repo.example.io"}'
 ```
 
 Environment variable can also be specified in the applications `manifest` file. For example, to specify an environment variable in an applications manifest file that disables Auto-reconfiguration.
 
 ```bash
   env: 
-    JBP_CONFIG_SPRING_AUTO_RECONFIGURATION: '[enabled: false]'
+    JBP_CONFIG_SPRING_AUTO_RECONFIGURATION: '{enabled: false}'
 ```
 
 This final example shows how to change the version of Tomcat that is used by the buildpack with an environment variable specified in the applications manifest file.
 
 ```bash
   env: 
-    JBP_CONFIG_TOMCAT: '[tomcat: { version: 8.0.+ }]'
+    JBP_CONFIG_TOMCAT: '{tomcat: { version: 8.0.+ }}'
 ```
 
 See the [Environment Variables][] documentation for more information.


### PR DESCRIPTION
Command line arguments are quite useful and some apps will not start without them, so this seems like a useful example. The explanation of why it needs to be an array (not a hash) is still really unclear, but at least with this example people will know what to do.