### PR TITLE
Enhancements to AppDynamics Config in Java Buildpack

### DIFF
--- a/config/app_dynamics_agent.yml
+++ b/config/app_dynamics_agent.yml
@@ -18,5 +18,5 @@
 version: 4.1.+
 repository_root: ! '{default.repository.root}/app-dynamics'
 default_application_name: 
-default_node_name: ! '$(expr "$VCAP_APPLICATION" : ''.*instance_index[": ]*\([[:digit:]]*\).*'')'
-default_tier_name: ! '$(expr "$VCAP_APPLICATION" : ''.*application_name[": ]*\([-_a-zA-Z0-9]*\).*''):$(expr "$VCAP_APPLICATION" : ''.*instance_index[": ]*\([[:digit:]]*\).*'')'
+default_node_name: ! '$(expr "$VCAP_APPLICATION" : ''.*application_name[": ]*\([-_a-zA-Z0-9]*\).*''):$(expr "$VCAP_APPLICATION" : ''.*instance_index[": ]*\([[:digit:]]*\).*'')'
+default_tier_name: ! 

--- a/config/app_dynamics_agent.yml
+++ b/config/app_dynamics_agent.yml
@@ -17,6 +17,6 @@
 ---
 version: 4.1.+
 repository_root: ! '{default.repository.root}/app-dynamics'
-default_application_name: 
+default_application_name:
 default_node_name: ! '$(expr "$VCAP_APPLICATION" : ''.*application_name[": ]*\([-_a-zA-Z0-9]*\).*''):$(expr "$VCAP_APPLICATION" : ''.*instance_index[": ]*\([[:digit:]]*\).*'')'
-default_tier_name: 
+default_tier_name:

--- a/config/app_dynamics_agent.yml
+++ b/config/app_dynamics_agent.yml
@@ -17,6 +17,6 @@
 ---
 version: 4.1.+
 repository_root: ! '{default.repository.root}/app-dynamics'
-default_application_name:
+default_application_name: 
 default_node_name: ! '$(expr "$VCAP_APPLICATION" : ''.*instance_index[": ]*\([[:digit:]]*\).*'')'
-default_tier_name:
+default_tier_name: ! '$(expr "$VCAP_APPLICATION" : ''.*application_name[": ]*\([-_a-zA-Z0-9]*\).*''):$(expr "$VCAP_APPLICATION" : ''.*instance_index[": ]*\([[:digit:]]*\).*'')'

--- a/config/app_dynamics_agent.yml
+++ b/config/app_dynamics_agent.yml
@@ -19,4 +19,4 @@ version: 4.1.+
 repository_root: ! '{default.repository.root}/app-dynamics'
 default_application_name: 
 default_node_name: ! '$(expr "$VCAP_APPLICATION" : ''.*application_name[": ]*\([-_a-zA-Z0-9]*\).*''):$(expr "$VCAP_APPLICATION" : ''.*instance_index[": ]*\([[:digit:]]*\).*'')'
-default_tier_name: ! 
+default_tier_name: 

--- a/spec/java_buildpack/framework/app_dynamics_agent_spec.rb
+++ b/spec/java_buildpack/framework/app_dynamics_agent_spec.rb
@@ -22,7 +22,7 @@ describe JavaBuildpack::Framework::AppDynamicsAgent do
   include_context 'component_helper'
 
   let(:configuration) do
-    { 'default_tier_name'        => nil,
+    { 'default_tier_name'        => "$(expr \"$VCAP_APPLICATION\" : ''.*application_name[\": ]*\\([-_a-zA-Z0-9]*\\).*''):$(expr \"$VCAP_APPLICATION\" : ''.*instance_index[\": ]*\\([[:digit:]]*\\).*'')",
       'default_node_name'        => "$(expr \"$VCAP_APPLICATION\" : '.*instance_index[\": ]*\\([[:digit:]]*\\).*')",
       'default_application_name' => nil }
   end

--- a/spec/java_buildpack/framework/app_dynamics_agent_spec.rb
+++ b/spec/java_buildpack/framework/app_dynamics_agent_spec.rb
@@ -22,7 +22,7 @@ describe JavaBuildpack::Framework::AppDynamicsAgent do
   include_context 'component_helper'
 
   let(:configuration) do
-    { 'default_tier_name'        => "$(expr \"$VCAP_APPLICATION\" : ''.*application_name[\": ]*\\([-_a-zA-Z0-9]*\\).*''):$(expr \"$VCAP_APPLICATION\" : ''.*instance_index[\": ]*\\([[:digit:]]*\\).*'')",
+    { 'default_tier_name'        => nil,
       'default_node_name'        => "$(expr \"$VCAP_APPLICATION\" : '.*instance_index[\": ]*\\([[:digit:]]*\\).*')",
       'default_application_name' => nil }
   end


### PR DESCRIPTION
These changes will incorporate the following modifications:

 1. Introduction of variable name **APPDYNAMICS_APPLICATION_NAME** which can be set using `cf set-env` command
 2. Changing the node name which was initially `<instance_index>` of the application to `<tier-name>:<instance_index>` to provide more visibility on tier-node  mapping


To understand all the changes lets consider the following two examples:
 

> **I.**  If **APPDYNAMICS_APPLICATION_NAME** is SET

    cf push abc 

    cf set-env abc APPDYNAMICS_APPLICATION_NAME xyz

|  APPDYNAMICS_APPLICATION_NAME  | Application name | Tier name  | Node name  |
| ------------- | ------------- | ------------ |------------- |
| xyz  | xyz  | abc | abc:0|


> **II.** If **APPDYNAMICS_APPLICATION_NAME** is NOT SET

    cf push abc

|  APPDYNAMICS_APPLICATION_NAME  | Application name | Tier name  | Node name  |
| ------------- | ------------- | ------------ |------------- |
| null  | abc  | abc-tier | abc-tier:0|
