### PR TITLE
Changed the value of default node name for AppDynamics

### DIFF
--- a/config/app_dynamics_agent.yml
+++ b/config/app_dynamics_agent.yml
@@ -18,5 +18,5 @@
 version: 4.1.+
 repository_root: ! '{default.repository.root}/app-dynamics'
 default_application_name:
-default_node_name: ! '$(expr "$VCAP_APPLICATION" : ''.*instance_index[": ]*\([[:digit:]]*\).*'')'
+default_node_name: ! '$(expr "$VCAP_APPLICATION" : ''.*application_name[": ]*\([-_a-zA-Z0-9]*\).*''):$(expr "$VCAP_APPLICATION" : ''.*instance_index[": ]*\([[:digit:]]*\).*'')'
 default_tier_name:


### PR DESCRIPTION
The default node name will now be "app_name:instance_index"