### PR TITLE
Upgrading gemfire version to 8.2

### DIFF
--- a/config/tomcat.yml
+++ b/config/tomcat.yml
@@ -37,16 +37,16 @@ redis_store:
   connection_pool_size: 2
 gemfire_store:
   gemfire:
-    version: 8.0.+
+    version: 8.2.+
     repository_root: ! '{default.repository.root}/gem-fire'
   gemfire_modules:
-    version: 8.0.+
+    version: 8.2.+
     repository_root: ! '{default.repository.root}/gem-fire-modules'
   gemfire_modules_tomcat7:
-    version: 8.0.+
+    version: 8.2.+
     repository_root: ! '{default.repository.root}/gem-fire-modules-tomcat7'
   gemfire_security:
-    version: 8.0.+
+    version: 8.2.+
     repository_root: ! '{default.repository.root}/gem-fire-security'
   gemfire_logging:
     version: 1.5.8


### PR DESCRIPTION
Upgraded to latest GemFire release to be used for session caching.