### PR TITLE
Added check to consider no_proxy env variable for offline caching

### DIFF
--- a/lib/java_buildpack/util/cache/download_cache.rb
+++ b/lib/java_buildpack/util/cache/download_cache.rb
@@ -233,6 +233,7 @@ module JavaBuildpack
         end
 
         def proxy(uri)
+          env_no_proxy = ENV['no_proxy'] || ENV['NO_PROXY']
           proxy_uri = if secure?(uri)
                         URI.parse(ENV['https_proxy'] || ENV['HTTPS_PROXY'] || '')
                       else
@@ -240,6 +241,9 @@ module JavaBuildpack
                       end
 
           @logger.debug { "Proxy: #{proxy_uri.host}, #{proxy_uri.port}, #{proxy_uri.user}, #{proxy_uri.password}" }
+          if env_no_proxy.include? uri.host
+            proxy_uri.host = nil
+          end
           Net::HTTP::Proxy(proxy_uri.host, proxy_uri.port, proxy_uri.user, proxy_uri.password)
         end
 


### PR DESCRIPTION
In order to build a buildpack that contains a resource behind a firewall, the no_proxy environment variable needs to be considered so that the proxy can be bypassed. Currently all resources to be cached for offline buildpack creation is retrieved using the proxy configured in the http_proxy or https_proxy environment variable. Added a check to validate whether the uri is listed in the no_proxy env variable which will then pass nill as the proxy host to bypass the proxy.

I have also emailed the signed CLA

Issue: #257 
