### PR TITLE
Fixed log statement when expanding Tomcat.

### DIFF
--- a/lib/java_buildpack/container/tomcat/tomcat_instance.rb
+++ b/lib/java_buildpack/container/tomcat/tomcat_instance.rb
@@ -87,7 +87,7 @@ module JavaBuildpack
       end
 
       def expand(file)
-        with_timing "Expanding Tomcat to #{@droplet.sandbox.relative_path_from(@droplet.root)}" do
+        with_timing "Expanding #{@component_name} to #{@droplet.sandbox.relative_path_from(@droplet.root)}" do
           FileUtils.mkdir_p @droplet.sandbox
           shell "tar xzf #{file.path} -C #{@droplet.sandbox} --strip 1 --exclude webapps 2>&1"
 


### PR DESCRIPTION
Hi,

In TomEE BP, the TomEE Instance inherits Tomcat Instance [1].

When one invokes "cf push -b https://github.com/cloudfoundry-community/tomee-buildpack"
The following will appear in the command line:

    -----> Downloading Tomee Instance 1.7.2 from https://download.run.pivotal.io/tomee/tomee-1.7.2.tar.gz
           Expanding Tomcat to .java-buildpack/tomee

As you can see there is "Expanding Tomcat" which is not correct when using TomEE BP.

With this change I would like to change the log statement in Java BP in a way that even when inherited Tomcat Instance will print the correct name i.e.:

    -----> Downloading Tomee Instance 1.7.2 from https://download.run.pivotal.io/tomee/tomee-1.7.2.tar.gz
           Expanding Tomee Instance to .java-buildpack/tomee

What do you think?

Regards,
Violeta
[1] https://github.com/cloudfoundry-community/tomee-buildpack/blob/master/lib/java_buildpack/container/tomee/tomee_instance.rb