### PR TITLE
Minor improvement to Ruxit Agent deployment

### DIFF
--- a/lib/java_buildpack/framework/ruxit_agent.rb
+++ b/lib/java_buildpack/framework/ruxit_agent.rb
@@ -121,10 +121,8 @@ module JavaBuildpack
       end
 
       def unpack_agent(root)
-        FileUtils.mkdir_p(agent_dir)
-        FileUtils.mv(root + 'agent/bin', agent_dir)
-        FileUtils.mv(root + 'agent/conf', agent_dir)
-        FileUtils.mv(root + 'agent/lib64', agent_dir)
+        FileUtils.mkdir_p(@droplet.sandbox)
+        FileUtils.mv(root + 'agent', @droplet.sandbox)
       end
 
     end


### PR DESCRIPTION
With this improvement the buildpack no longer depends on a specific directory structure in the agent ZIP file. All contents in `agent` subdirectory will be moved to droplet.