### PR TITLE
Enable Dynatrace 6.3 Agent and public repo

### DIFF
--- a/config/components.yml
+++ b/config/components.yml
@@ -39,7 +39,7 @@ frameworks:
   - "JavaBuildpack::Framework::ContainerCertificateTrustStore"
   - "JavaBuildpack::Framework::ContainerCustomizer"
   - "JavaBuildpack::Framework::Debug"
-# - "JavaBuildpack::Framework::DynaTraceAgent"
+  - "JavaBuildpack::Framework::DynaTraceAgent"
 # - "JavaBuildpack::Framework::IntroscopeAgent"
   - "JavaBuildpack::Framework::Jmx"
   - "JavaBuildpack::Framework::JrebelAgent"

--- a/config/dyna_trace_agent.yml
+++ b/config/dyna_trace_agent.yml
@@ -15,6 +15,6 @@
 
 # Configuration for the Dynatrace framework
 ---
-version: 6.1.0_+
-repository_root: ""
+version: 6.3.0_+
+repository_root: "http://downloads.dynatracesaas.com/cloudfoundry/buildpack/java"
 default_agent_name:


### PR DESCRIPTION
Added public repository containing Dynatrace Agent 6.3 and incremented agent version to 6.3

Previously Dynatrace support was baked into the buildpack but commented out due to lack of Dynatrace provided agent download location. We have addressed this. 

We have a valid/signed CLA through the Dynatrace organization. 