### PR TITLE
Add Azul Zulu as alternative jre

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ To learn how to configure various properties of the buildpack, follow the "Confi
 * Standard JREs
 	* [OpenJDK](docs/jre-open_jdk_jre.md) ([Configuration](docs/jre-open_jdk_jre.md#configuration))
 	* [Oracle](docs/jre-oracle_jre.md) ([Configuration](docs/jre-oracle_jre.md#configuration))
+	* [Azul Zulu](docs/jre-zulu_jre.md) ([Configuration](docs/jre-zulu_jre.md#configuration))
 * [Extending](docs/extending.md)
 	* [Application](docs/extending-application.md)
 	* [Droplet](docs/extending-droplet.md)

--- a/config/components.yml
+++ b/config/components.yml
@@ -27,14 +27,11 @@ containers:
 
 # In order to use Oracle JREs instead of OpenJDK, you must comment out the OpenJDK line and uncomment the Oracle line.
 # In order to use Zulu JREs instead of OpenJDK, you must comment out the OpenJDK line and uncomment the Zulu line.
-# To use Zulu JRE instead of OpenJDK without forking java-buildpack, set environment variable:
-# cf set-env <app_name> JBP_CONFIG_COMPONENTS '{jres: ["JavaBuildpack::Jre::ZuluJRE"]}'
-# cf restage <app_name>
 # Please see the documentation for more detail.
 jres:
   - "JavaBuildpack::Jre::OpenJdkJRE"
-# -  "JavaBuildpack::Jre::ZuluJRE"
 # - "JavaBuildpack::Jre::OracleJRE"
+# - "JavaBuildpack::Jre::ZuluJRE"
 
 # Frameworks are processed in order. Any Java Opts added by the JavaOpts framework will be specified in the start
 # command after any Java Opts added by previous frameworks.

--- a/config/components.yml
+++ b/config/components.yml
@@ -26,9 +26,14 @@ containers:
   - "JavaBuildpack::Container::Tomcat"
 
 # In order to use Oracle JREs instead of OpenJDK, you must comment out the OpenJDK line and uncomment the Oracle line.
+# In order to use Zulu JREs instead of OpenJDK, you must comment out the OpenJDK line and uncomment the Zulu line.
+# To use Zulu JRE instead of OpenJDK without forking java-buildpack, set environment variable:
+# cf set-env <app_name> JBP_CONFIG_COMPONENTS '{jres: ["JavaBuildpack::Jre::ZuluJRE"]}'
+# cf restage <app_name>
 # Please see the documentation for more detail.
 jres:
   - "JavaBuildpack::Jre::OpenJdkJRE"
+# -  "JavaBuildpack::Jre::ZuluJRE"
 # - "JavaBuildpack::Jre::OracleJRE"
 
 # Frameworks are processed in order. Any Java Opts added by the JavaOpts framework will be specified in the start

--- a/config/zulu_jre.yml
+++ b/config/zulu_jre.yml
@@ -21,7 +21,7 @@
 ---
 jre:
   version: 1.8.0_+
-  repository_root: "http://cdn.azul.com/zulu/bin"
+  repository_root: "https://cdn.azul.com/zulu/bin"
 memory_calculator:
   version: 2.+
   repository_root: ! '{default.repository.root}/memory-calculator/{platform}/{architecture}'

--- a/config/zulu_jre.yml
+++ b/config/zulu_jre.yml
@@ -1,0 +1,44 @@
+# Cloud Foundry Java Buildpack
+# Copyright 2016 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration for JRE repositories keyed by vendor
+# Pre Java 1.8, permgen was used instead of metaspace.  Please see the documentation for more detail.
+
+# You must specify a the repository root of an Zulu JRE repository. Please see the documentation for more detail.
+# e.g.  repository_root: "http://example.com/zulu-jre/{platform}/{architecture}"
+---
+jre:
+  version: 1.8.0_+
+  repository_root: "http://cdn.azul.com/zulu/bin"
+memory_calculator:
+  version: 2.+
+  repository_root: ! '{default.repository.root}/memory-calculator/{platform}/{architecture}'
+  stack_threads:
+  memory_sizes:
+    heap:
+    metaspace: 64m..
+    native:
+    permgen: 64m..
+    stack:
+  memory_heuristics:
+    heap: 75
+    metaspace: 10
+    native: 10
+    permgen: 10
+    stack: 5
+  memory_initials:
+    heap: 100%
+    metaspace: 100%
+    permgen: 100%

--- a/docs/jre-zulu_jre.md
+++ b/docs/jre-zulu_jre.md
@@ -13,7 +13,6 @@ Azul Zulu JRE provides Java runtimes developed by Azul team.  Versions of Java f
 </table>
 Tags are printed to standard output by the buildpack detect script.
 
-Review Azul Zulu terms of use here: http://www.azul.com/products/zulu/zulu-terms-of-use/.
 
 ## Configuration
 For general information on configuring the buildpack, including how to specify configuration values through environment variables, refer to [Configuration and Extension][].
@@ -56,9 +55,9 @@ The following optional properties may be specified in the `memory_sizes` mapping
 | Name | Description
 | ---- | -----------
 | `heap` | The maximum heap size to use. It may be a single value, such as `64m` or a range of acceptable values, such as `128m..256m`. It is used to calculate the value of the Java command-line options `-Xmx` and `-Xms`.
-| `metaspace` | The maximum Metaspace size to use. It is applicable to versions of OpenJDK from 1.8 onwards. It may be a single value, such as `64m` or a range of acceptable values, such as `128m..256m`. It is used to calculate the value of the Java command-line options `-XX:MaxMetaspaceSize=` and `-XX:MetaspaceSize=`.
+| `metaspace` | The maximum Metaspace size to use. It is applicable to versions of Zulu from Java 1.8 onwards. It may be a single value, such as `64m` or a range of acceptable values, such as `128m..256m`. It is used to calculate the value of the Java command-line options `-XX:MaxMetaspaceSize=` and `-XX:MetaspaceSize=`.
 | `native` | The amount of memory to reserve for native memory allocation. It should normally be omitted or specified as a range with no upper bound such as `100m..`. It does not correspond to a switch on the Java command line.
-| `permgen` | The maximum PermGen size to use. It is applicable to versions of OpenJDK earlier than 1.8. It may be a single value, such as `64m` or a range of acceptable values, such as `128m..256m`. It is used to calculate the value of the Java command-line options `-XX:MaxPermSize=` and `-XX:PermSize=`.
+| `permgen` | The maximum PermGen size to use. It is applicable to versions of Zulu earlier than Java 1.8. It may be a single value, such as `64m` or a range of acceptable values, such as `128m..256m`. It is used to calculate the value of the Java command-line options `-XX:MaxPermSize=` and `-XX:PermSize=`.
 | `stack` | The stack size to use. It may be a single value, such as `2m` or a range of acceptable values, such as `2m..4m`. It is used to calculate the value of the Java command-line option `-Xss`.
 
 Memory sizes together with _memory weightings_ are used to calculate the amount of memory for each memory type. The calculation is described later.

--- a/docs/jre-zulu_jre.md
+++ b/docs/jre-zulu_jre.md
@@ -1,0 +1,126 @@
+# Azul Zulu JRE
+Azul Zulu JRE provides Java runtimes developed by Azul team.  Versions of Java from the `1.6`, `1.7`, and `1.8` levels are available.  Unless otherwise configured, the version of Java that will be used is specified in [`config/zulu_jre.yml`][].
+
+<table>
+  <tr>
+    <td><strong>Detection Criterion</strong></td>
+    <td>Unconditional</td>
+  </tr>
+  <tr>
+    <td><strong>Tags</strong></td>
+    <td><tt>open-jdk-like-jre=&lang;version&rang;, open-jdk-like-memory-calculator=&lang;version&rang;</tt></td>
+  </tr>
+</table>
+Tags are printed to standard output by the buildpack detect script.
+
+Review Azul Zulu terms of use here: http://www.azul.com/products/zulu/zulu-terms-of-use/.
+
+## Configuration
+For general information on configuring the buildpack, including how to specify configuration values through environment variables, refer to [Configuration and Extension][].
+
+The JRE can be configured by modifying the [`config/zulu_jre.yml`][] file in the buildpack fork.  The JRE uses the [`Repository` utility support][repositories] and so, it supports the [version syntax][]  defined there.
+
+To use Zulu JRE instead of OpenJDK without forking java-buildpack, set environment variable:
+
+`cf set-env <app_name> JBP_CONFIG_COMPONENTS '{jres: ["JavaBuildpack::Jre::ZuluJRE"]}'`
+
+`cf restage <app_name>`
+
+| Name | Description
+| ---- | -----------
+| `memory_sizes` | Optional memory sizes, described under "Memory Sizes".
+| `memory_heuristics` | Default memory size weightings, described under "Memory Weightings".
+| `memory_initials` | Initial memory sizes, described under "Memory Initials".
+| `repository_root` | The URL of the Zulu repository index ([details][repositories]).
+| `version` | The version of Java runtime to use. Note: version 1.8.0 and higher require the `memory_sizes` and `memory_heuristics` mappings to specify `metaspace` rather than `permgen`.
+
+### Additional Resources
+The JRE can also be configured by overlaying a set of resources on the default distribution. To do this, add files to the `resources/zulu_jre` directory in the buildpack fork.
+
+#### JCE Unlimited Strength
+To add the JCE Unlimited Strength `local_policy.jar`, add your file to `resources/zulu_jre/lib/security/local_policy.jar`.  This file will be overlayed onto the Zulu distribution.
+
+#### Custom CA Certificates
+To add custom SSL certificates, add your `cacerts` file to `resources/zulu_jre/lib/security/cacerts`.  This file will be overlayed onto the Zulu distribution.
+
+### Memory
+The total available memory is specified when an application is pushed as part of its configuration. The Java buildpack uses this value to control the JRE's use of various regions of memory. The JRE memory settings can be influenced by configuring the `memory_sizes`, `memory_heuristics`, `memory_initials`, and/or `stack_threads` mappings.
+
+Note: If the total available memory is scaled up or down, the Java buildpack will re-calculate the JRE memory settings next time the application is started.
+
+Note: If setting an initial Stack size, depending on the version of Java and the operating system used by Cloud Foundry, the JRE will require a minimum `-Xss` value. This value tends to be between `100k` and `250k`.
+
+#### Memory Sizes
+The following optional properties may be specified in the `memory_sizes` mapping.
+
+| Name | Description
+| ---- | -----------
+| `heap` | The maximum heap size to use. It may be a single value, such as `64m` or a range of acceptable values, such as `128m..256m`. It is used to calculate the value of the Java command-line options `-Xmx` and `-Xms`.
+| `metaspace` | The maximum Metaspace size to use. It is applicable to versions of OpenJDK from 1.8 onwards. It may be a single value, such as `64m` or a range of acceptable values, such as `128m..256m`. It is used to calculate the value of the Java command-line options `-XX:MaxMetaspaceSize=` and `-XX:MetaspaceSize=`.
+| `native` | The amount of memory to reserve for native memory allocation. It should normally be omitted or specified as a range with no upper bound such as `100m..`. It does not correspond to a switch on the Java command line.
+| `permgen` | The maximum PermGen size to use. It is applicable to versions of OpenJDK earlier than 1.8. It may be a single value, such as `64m` or a range of acceptable values, such as `128m..256m`. It is used to calculate the value of the Java command-line options `-XX:MaxPermSize=` and `-XX:PermSize=`.
+| `stack` | The stack size to use. It may be a single value, such as `2m` or a range of acceptable values, such as `2m..4m`. It is used to calculate the value of the Java command-line option `-Xss`.
+
+Memory sizes together with _memory weightings_ are used to calculate the amount of memory for each memory type. The calculation is described later.
+
+Memory sizes consist of a non-negative integer followed by a unit (`k` for kilobytes, `m` for megabytes, `g` for gigabytes; the case is not significant). Only the memory size `0` may be specified without a unit.
+
+The above memory size properties may be omitted with an empty value, specified as a single value, or specified as a range. Ranges use the syntax `<lower bound>..<upper bound>`, although either bound may be omitted in which case the defaults of zero and the total available memory are used for the lower bound and upper bound, respectively. Examples of ranges are `100m..200m` (any value between 100 and 200 megabytes, inclusive) and `100m..` (any value greater than or equal to 100 megabytes).
+
+Each form of memory size is equivalent to a range. Omitting a memory size is equivalent to specifying the range `0..`. Specifying a single value is equivalent to specifying the range with that value as both the lower and upper bound, for example `128m` is equivalent to the range `128m..128m`.
+
+#### Memory Weightings
+Memory weightings are configured in the `memory_heuristics` mapping of [`config/zulu_jre.yml`][]. Each weighting is a non-negative number and represents a proportion of the total available memory (represented by the sum of all the weightings),- for example:
+
+```yaml
+memory_heuristics:
+  heap: 15
+  native: 2
+  permgen: 5
+  stack: 1
+```
+
+represent a maximum heap size three times as large as the maximum PermGen size, and so on.
+
+Memory weightings are used together with memory ranges to calculate the amount of memory for each memory type, as follows.
+
+#### Memory Initials
+Memory initials are configured in the `memory_initials` mapping of [`config/zulu_jre.yml`][]. Each initial is a percentage of the given type of memory. Valid memory types are `heap`, `permgen`, and `metaspace`. For example, the following initials:
+
+```yaml
+memory_initials:
+  heap: 50%
+  permgen: 25%
+```
+
+Given a maximum heap (`Xmx`) of 1G and a maximum permgen (`-XX:MaxPermsize`) of 256M an initial heap (`Xms`) of 512M and an initial permgen (`-XX:Permsize`) of 64M would be used.
+
+If no initial value is specified for a memory type, the JVM default will be used.
+
+A value of 100% for each memory types is generally recommended for best performance.  Smaller values will potentially preserve unused system memory for other tenants on the same host.  Using the G1 garbage collector along with aggressive `MinHeapFreeRatio` and `MaxHeapFreeRatio` values the JVM will actually release unused heap back to the system up to the initial value.
+
+#### Stack Threads
+
+The amount of memory that should be allocated to the stack is given as an amount of memory per thread with the command-line option `-Xss`. The default behaviour is to use an estimate of the number of threads based on the total memory for the application. If an explicit number of threads should be used for the calculation of stack memory, then it should be specified like in the following example:
+
+```yaml
+stack_threads: 500
+```
+
+#### Memory Calculation
+Memory calculation happens before every `start` of an application and it is performed by an external program, the [Java Buildpack Memory Calculator]. There is no need to `restage` an application after scaling the memory as restarting will cause the memory settings to be recalculated.
+
+The total available memory is allocated into heap, Metaspace, or PermGen (depending on the version of Java), stack, and native memory types.
+
+The total available memory is first allocated to each memory type in proportion to its weighting (this is called 'balancing'). If the resultant size of any memory type lies outside its range, the size is constrained to the range, the constrained size is excluded from the remaining memory, and no further calculation is required for that memory type. The remaining memory is then balanced against the memory types that are left, and the check is repeated until no calculated memory sizes lie outside their ranges. The remaining memory is then allocated to the remaining memory types according to the last balance step. This iteration terminates when none of the sizes of the remaining memory types is constrained by their corresponding ranges.
+
+Termination is guaranteed since there is a finite number of memory types and in each iteration either none of the remaining memory sizes is constrained by the corresponding range and allocation terminates or at least one memory size is constrained by the corresponding range and it is omitted from the next iteration.
+
+[`config/components.yml`]: ../config/components.yml
+[`config/zulu_jre.yml`]: ../config/zulu_jre.yml
+[Configuration and Extension]: ../README.md#configuration-and-extension
+[Java Buildpack Memory Calculator]: https://github.com/cloudfoundry/java-buildpack-memory-calculator
+[Zulu JRE]: jre-zulu_jre.md
+[Azul Zulu]: https://www.azul.com/products/zulu/
+[repositories]: extending-repositories.md
+[version syntax]: extending-repositories.md#version-syntax-and-ordering

--- a/lib/java_buildpack/jre/zulu_jre.rb
+++ b/lib/java_buildpack/jre/zulu_jre.rb
@@ -1,0 +1,29 @@
+# Encoding: utf-8
+# Cloud Foundry Java Buildpack
+# Copyright 2016 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'fileutils'
+require 'java_buildpack/jre'
+require 'java_buildpack/jre/open_jdk_like'
+
+module JavaBuildpack
+  module Jre
+
+    # Encapsulates the detect, compile, and release functionality for selecting an Zulu JRE.
+    class ZuluJRE < OpenJDKLike
+    end
+
+  end
+end

--- a/resources/zulu_jre/bin/killjava.sh
+++ b/resources/zulu_jre/bin/killjava.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Encoding: utf-8
+# Cloud Foundry Java Buildpack
+# Copyright (c) 2013-2016 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Kill script for use as the parameter of OpenJDK's -XX:OnOutOfMemoryError
+
+set -e
+
+echo "
+Process Status (Before)
+=======================
+$(ps -ef)
+
+ulimit (Before)
+===============
+$(ulimit -a)
+
+Free Disk Space (Before)
+========================
+$(df -h)
+"
+
+pkill -9 -f .*-XX:OnOutOfMemoryError=.*killjava.*
+
+echo "
+Process Status (After)
+======================
+$(ps -ef)
+
+ulimit (After)
+==============
+$(ulimit -a)
+
+Free Disk Space (After)
+=======================
+$(df -h)
+"


### PR DESCRIPTION
Zulu is a tested and certified build of OpenJDK, see zulu.org for more
details.

In order to use Zulu JREs instead of OpenJDK, you must comment out the
OpenJDK line and uncomment the Zulu line in config/components.yml file.

To use Zulu JRE instead of OpenJDK without forking java-buildpack,
set environment variable:

```
cf set-env <app_name> JBP_CONFIG_COMPONENTS
'{jres: ["JavaBuildpack::Jre::ZuluJRE"]}'

cf restage <app_name>
```
Issue: #303