### PR TITLE
TomcatLoggingSupport should ensure that java.endorsed.dirs is declared

### DIFF
--- a/lib/java_buildpack/container/tomcat/tomcat_logging_support.rb
+++ b/lib/java_buildpack/container/tomcat/tomcat_logging_support.rb
@@ -29,6 +29,8 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::BaseComponent#release)
       def release
+        @droplet.java_opts.add_system_property 'java.endorsed.dirs',
+                                               "$PWD/#{endorsed.relative_path_from(@droplet.root)}"
       end
 
       protected

--- a/spec/java_buildpack/container/tomcat/tomcat_logging_support_spec.rb
+++ b/spec/java_buildpack/container/tomcat/tomcat_logging_support_spec.rb
@@ -35,8 +35,10 @@ describe JavaBuildpack::Container::TomcatLoggingSupport do
     expect(sandbox + "endorsed/tomcat_logging_support-#{version}.jar").to exist
   end
 
-  it 'does nothing during release' do
+  it 'sets java.endorsed.dirs during release' do
     component.release
+
+    expect(java_opts).to include('-Djava.endorsed.dirs=$PWD/.java-buildpack/tomcat/endorsed')
   end
 
 end


### PR DESCRIPTION
Hi,

The following exception appears when java buildpack is configured to use Tomcat 8.5.x

```
java.lang.ClassNotFoundException: com.gopivotal.cloudfoundry.tomcat.logging.CloudFoundryConsoleHandler
at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
at org.apache.juli.ClassLoaderLogManager.readConfiguration(ClassLoaderLogManager.java:563)
at org.apache.juli.ClassLoaderLogManager.readConfiguration(ClassLoaderLogManager.java:506)
at org.apache.juli.ClassLoaderLogManager.readConfiguration(ClassLoaderLogManager.java:309)
at java.util.logging.LogManager$3.run(LogManager.java:399)
at java.util.logging.LogManager$3.run(LogManager.java:396)
at java.security.AccessController.doPrivileged(Native Method)
at java.util.logging.LogManager.readPrimordialConfiguration(LogManager.java:396)
at java.util.logging.LogManager.access$800(LogManager.java:145)
at java.util.logging.LogManager$2.run(LogManager.java:345)
at java.security.AccessController.doPrivileged(Native Method)
at java.util.logging.LogManager.ensureLogManagerInitialized(LogManager.java:338)
at java.util.logging.LogManager.getLogManager(LogManager.java:378)
at java.util.logging.Logger.demandLogger(Logger.java:448)
at java.util.logging.Logger.getLogger(Logger.java:502)
at org.apache.juli.logging.DirectJDKLog.<init>(DirectJDKLog.java:67)
at org.apache.juli.logging.DirectJDKLog.getInstance(DirectJDKLog.java:187)
at org.apache.juli.logging.LogFactory.getInstance(LogFactory.java:117)
at org.apache.juli.logging.LogFactory.getInstance(LogFactory.java:141)
at org.apache.juli.logging.LogFactory.getLog(LogFactory.java:196)
at org.apache.catalina.startup.Bootstrap.<clinit>(Bootstrap.java:52)
```

This is because Tomcat 8.5.x/9 does not declare ```java.endorsed.dirs``` by default [1].

The issue can be reproduced with ```web-application``` available here [2].
One should add the following environment variable to the ```manifest.yml```

```
env:
   JBP_CONFIG_TOMCAT: '{tomcat: {version: 8.5.4}}'
```

Can you please review the proposed fix?

Thanks,
Violeta

[1] https://github.com/apache/tomcat/commit/40d6e8345e365e55adb38f4c4bf7a14629095c1d
[2] https://github.com/cloudfoundry/java-test-applications/tree/master/web-application