### PR TITLE
AppDynamics Docs Update

### DIFF
--- a/docs/framework-app_dynamics_agent.md
+++ b/docs/framework-app_dynamics_agent.md
@@ -15,18 +15,18 @@ Tags are printed to standard output by the buildpack detect script
 ## User-Provided Service
 When binding AppDynamics using a user-provided service, it must have name or tag with `app-dynamics` or `appdynamics` in it. The credential payload can contain the following entries:
 
-`NOTE:` ***** marked fields are `Optional` for java agent versions prior to 4.2. However, for agent versions 4.2 and above, these fields are `Required`. Please check `/config/app_dynamics_agent.yml` file for appropriate version.
+`NOTE:` For agent versions 4.2 and above, * marked fields are no longer `Optional`, they are `Required`. Check `/config/app_dynamics_agent.yml` file for appropriate agent version.
 
 | Name | Description
 | ---- | -----------
-| `account-access-key` *| The account access key to use when authenticating with the controller
-| `account-name` *| The account name to use when authenticating with the controller
-| `application-name` *| the application's name
+| `account-access-key`* | (Optional) The account access key to use when authenticating with the controller
+| `account-name`* | (Optional) The account name to use when authenticating with the controller
+| `application-name`* | (Optional) the application's name
 | `host-name` | The controller host name
 | `node-name` | (Optional) the application's node name
-| `port` *| The controller port
-| `ssl-enabled` *| Whether or not to use an SSL connection to the controller
-| `tier-name` *| the application's tier name
+| `port`* | (Optional) The controller port
+| `ssl-enabled`* | (Optional) Whether or not to use an SSL connection to the controller
+| `tier-name`* | (Optional) the application's tier name
 
 To provide more complex values such as the `tier-name`, using the interactive mode when creating a user-provided service will manage the character escaping automatically. For example, the default `tier-name` could be set with a value of `Tier-$(expr "$VCAP_APPLICATION" : '.*instance_index[": ]*\([[:digit:]]*\).*')` to calculate a value from the Cloud Foundry instance index.
 

--- a/docs/framework-app_dynamics_agent.md
+++ b/docs/framework-app_dynamics_agent.md
@@ -17,14 +17,14 @@ When binding AppDynamics using a user-provided service, it must have name or tag
 
 | Name | Description
 | ---- | -----------
-| `account-access-key` | (Optional) The account access key to use when authenticating with the controller
-| `account-name` | (Optional) The account name to use when authenticating with the controller
-| `application-name` | (Optional) the application's name
+| `account-access-key` | The account access key to use when authenticating with the controller
+| `account-name` | The account name to use when authenticating with the controller
+| `application-name` | the application's name
 | `host-name` | The controller host name
 | `node-name` | (Optional) the application's node name
-| `port` | (Optional) The controller port
-| `ssl-enabled` | (Optional) Whether or not to use an SSL connection to the controller
-| `tier-name` | (Optional) the application's tier name
+| `port` | The controller port
+| `ssl-enabled` | Whether or not to use an SSL connection to the controller
+| `tier-name` | the application's tier name
 
 To provide more complex values such as the `tier-name`, using the interactive mode when creating a user-provided service will manage the character escaping automatically. For example, the default `tier-name` could be set with a value of `Tier-$(expr "$VCAP_APPLICATION" : '.*instance_index[": ]*\([[:digit:]]*\).*')` to calculate a value from the Cloud Foundry instance index.
 

--- a/docs/framework-app_dynamics_agent.md
+++ b/docs/framework-app_dynamics_agent.md
@@ -15,16 +15,18 @@ Tags are printed to standard output by the buildpack detect script
 ## User-Provided Service
 When binding AppDynamics using a user-provided service, it must have name or tag with `app-dynamics` or `appdynamics` in it. The credential payload can contain the following entries:
 
+`NOTE:` ***** marked fields are `Optional` for java agent versions prior to 4.2. However, for agent versions 4.2 and above, these fields are `Required`. Please check `/config/app_dynamics_agent.yml` file for appropriate version.
+
 | Name | Description
 | ---- | -----------
-| `account-access-key` | The account access key to use when authenticating with the controller
-| `account-name` | The account name to use when authenticating with the controller
-| `application-name` | the application's name
+| `account-access-key` *| The account access key to use when authenticating with the controller
+| `account-name` *| The account name to use when authenticating with the controller
+| `application-name` *| the application's name
 | `host-name` | The controller host name
 | `node-name` | (Optional) the application's node name
-| `port` | The controller port
-| `ssl-enabled` | Whether or not to use an SSL connection to the controller
-| `tier-name` | the application's tier name
+| `port` *| The controller port
+| `ssl-enabled` *| Whether or not to use an SSL connection to the controller
+| `tier-name` *| the application's tier name
 
 To provide more complex values such as the `tier-name`, using the interactive mode when creating a user-provided service will manage the character escaping automatically. For example, the default `tier-name` could be set with a value of `Tier-$(expr "$VCAP_APPLICATION" : '.*instance_index[": ]*\([[:digit:]]*\).*')` to calculate a value from the Cloud Foundry instance index.
 


### PR DESCRIPTION
The `account-access-key`, `account-name` are credentials to your controller. And it is a required parameter.
Its highly recommended that one specifies the remaining parameters except the `node-name`