### PR TITLE
Introduce ‘apiurl’ parameter in Dynatrace framework

### DIFF
--- a/docs/framework-dynatrace_one_agent.md
+++ b/docs/framework-dynatrace_one_agent.md
@@ -25,9 +25,10 @@ The credential payload of the service may contain the following entries:
 
 | Name | Description
 | ---- | -----------
-| `environmentid` | Your Dynatrace environment ID is the unique identifier of your Dynatrace environment. You can find it easily by looking at the URL in your browser when you are logged into your Dynatrace environment. The subdomain `<environmentId>` in `https://<environmentId>.live.dynatrace.com` represents your environment ID. The `environmentid` replaces deprecated ~~`tenant`~~ option.
+| `environmentid` | Your Dynatrace environment ID is the unique identifier of your Dynatrace environment. You can find it in the deploy Dynatrace section within your environment. The `environmentid` replaces deprecated ~~`tenant`~~ option.
 | `apitoken` | The token for integrating your Dynatrace environment with Cloud Foundry. You can find it in the deploy Dynatrace section within your environment. The `apitoken` replaces deprecated ~~`tenanttoken`~~ option.
-| `endpoint` | (Optional) The Dynatrace connection endpoint to connect to. By default this is the endpoint of Dynatrace SaaS. If you are using Dynatrace Managed please specify the endpoint properly, e.g. `https://<your-managed-server-url>/e/<environmentId>`. The `endpoint` replaces deprecated ~~`server`~~ option.
+| `apiurl` | (Optional) The base URL of the Dynatrace API. If you are using Dynatrace Managed you will need to set this property to `https://<your-managed-server-url>/e/<environmentId>/api`. If you are using Dynatrace SaaS you don't need to set this property.
+| `endpoint`  | (Deprecated) The Dynatrace connection endpoint the agent connects to. Please use `apiurl` in combination with `apitoken` for Dynatrace Managed.
 
 ## Configuration
 For general information on configuring the buildpack, including how to specify configuration values through environment variables, refer to [Configuration and Extension][].

--- a/lib/java_buildpack/framework/dynatrace_one_agent.rb
+++ b/lib/java_buildpack/framework/dynatrace_one_agent.rb
@@ -86,12 +86,14 @@ module JavaBuildpack
 
       APITOKEN = 'apitoken'.freeze
 
+      APIURL = 'apiurl'.freeze
+
       ENVIRONMENTID = 'environmentid'.freeze
 
       ENDPOINT = 'endpoint'.freeze
 
       private_constant :FILTER, :RUXIT_APPLICATION_ID, :RUXIT_HOST_ID, :SERVER, :TENANT, :TENANTTOKEN, :APITOKEN
-      private_constant :ENVIRONMENTID, :ENDPOINT
+      private_constant :ENVIRONMENTID, :ENDPOINT, :APIURL
 
       def agent_dir
         @droplet.sandbox + 'agent'
@@ -105,10 +107,17 @@ module JavaBuildpack
 
       def agent_download_url
         credentials = @application.services.find_service(FILTER)['credentials']
-        download_uri = server(credentials).gsub('/communication', '').gsub(':8443', '').gsub(':443', '')
-        download_uri += '/api/v1/deployment/installer/agent/unix/paas/latest?include=java&bitness=64&'
+        download_uri = "#{api_base_url}/v1/deployment/installer/agent/unix/paas/latest?include=java&bitness=64&"
         download_uri += "Api-Token=#{credentials[APITOKEN]}"
         ['latest', download_uri]
+      end
+
+      def api_base_url
+        credentials = @application.services.find_service(FILTER)['credentials']
+        return credentials[APIURL] unless credentials[APIURL].nil?
+        base_url = credentials[ENDPOINT] || credentials[SERVER] || "https://#{tenant(credentials)}.live.dynatrace.com"
+        base_url = base_url.gsub('/communication', '').concat('/api').gsub(':8443', '').gsub(':443', '')
+        base_url
       end
 
       def application_id
@@ -130,7 +139,13 @@ module JavaBuildpack
       end
 
       def server(credentials)
-        credentials[ENDPOINT] || credentials[SERVER] || "https://#{tenant(credentials)}.live.dynatrace.com"
+        given_endp = credentials[ENDPOINT] || credentials[SERVER] || "https://#{tenant(credentials)}.live.dynatrace.com"
+        supports_apitoken? ? server_from_api : given_endp
+      end
+
+      def server_from_api
+        endpoints = JSON.parse(File.read(@droplet.sandbox + 'manifest.json'))['communicationEndpoints']
+        endpoints.join('\;')
       end
 
       def tenant(credentials)

--- a/spec/java_buildpack/framework/dynatrace_one_agent_spec.rb
+++ b/spec/java_buildpack/framework/dynatrace_one_agent_spec.rb
@@ -61,8 +61,8 @@ describe JavaBuildpack::Framework::DynatraceOneAgent do
       component.release
 
       expect(java_opts).to include('-agentpath:$PWD/.java-buildpack/dynatrace_one_agent/agent/lib64/' \
-      'liboneagentloader.so=server=https://test-tenant.live.dynatrace.com,tenant=test-tenant,' \
-      'tenanttoken=token-from-file')
+      'liboneagentloader.so=server=https://endpoint1/communication\\;https://endpoint2/communication,' \
+      'tenant=test-tenant,tenanttoken=token-from-file')
     end
 
     it 'updates JAVA_OPTS with custom server and deprecated tenanttoken',
@@ -85,8 +85,8 @@ describe JavaBuildpack::Framework::DynatraceOneAgent do
       component.release
 
       expect(java_opts).to include('-agentpath:$PWD/.java-buildpack/dynatrace_one_agent/agent/lib64/' \
-      'liboneagentloader.so=server=test-server,tenant=test-tenant,' \
-      'tenanttoken=token-from-file')
+      'liboneagentloader.so=server=https://endpoint1/communication\\;https://endpoint2/communication,' \
+      'tenant=test-tenant,tenanttoken=token-from-file')
     end
 
     it 'updates environment variables',


### PR DESCRIPTION
In this PR we introduce an optional parameter to specify the base URL for the agent installer download API. This parameter is needed for Dynatrace Managed clusters where cluster nodes likely are not directly accessible from CF but via Security Gateways.