### PR TITLE
Update the JRebel framework.

### DIFF
--- a/config/jrebel_agent.yml
+++ b/config/jrebel_agent.yml
@@ -15,5 +15,5 @@
 
 # Configuration for the JRebel framework
 ---
-version: 6.+
+version: 7.+
 repository_root: https://dl.zeroturnaround.com/jrebel

--- a/lib/java_buildpack/framework/jrebel_agent.rb
+++ b/lib/java_buildpack/framework/jrebel_agent.rb
@@ -40,7 +40,6 @@ module JavaBuildpack
           .java_opts
           .add_agentpath(@droplet.sandbox + ('lib/' + lib_name))
           .add_system_property('rebel.remoting_plugin', true)
-          .add_system_property('rebel.log', true)
           .add_system_property('rebel.cloud.platform', 'cloudfoundry/java-buildpack')
       end
 

--- a/spec/java_buildpack/framework/jrebel_agent_spec.rb
+++ b/spec/java_buildpack/framework/jrebel_agent_spec.rb
@@ -46,7 +46,6 @@ describe JavaBuildpack::Framework::JrebelAgent do
 
     component.compile
 
-    expect(sandbox + 'lib/jrebel.jar').to exist
     expect(sandbox + 'lib/libjrebel64.so').to exist
     expect(sandbox + 'lib/libjrebel32.so').to exist
   end
@@ -61,7 +60,6 @@ describe JavaBuildpack::Framework::JrebelAgent do
 
     expect(java_opts).to include('-agentpath:$PWD/.java-buildpack/jrebel_agent/lib/libjrebel64.so')
     expect(java_opts).to include('-Drebel.remoting_plugin=true')
-    expect(java_opts).to include('-Drebel.log=true')
     expect(java_opts).to include('-Drebel.cloud.platform=cloudfoundry/java-buildpack')
   end
 


### PR DESCRIPTION
Use the 7.x release which has logging enabled by default, so no need to explictly set it. Also 'lib/jrebel.jar' doesn't exist anymore so removed it from the expectations.