### PR TITLE
Fix wildcard resolving for version qualifier

### DIFF
--- a/lib/java_buildpack/util/tokenized_version.rb
+++ b/lib/java_buildpack/util/tokenized_version.rb
@@ -121,7 +121,7 @@ module JavaBuildpack
       end
 
       def qualifier_compare(a, b)
-        comparison = 0
+        comparison = a[/^\d+/].to_i <=> b[/^\d+/].to_i
 
         i = 0
         until comparison.nonzero? || i == minimum_qualifier_length(a, b)

--- a/spec/java_buildpack/repository/version_resolver_spec.rb
+++ b/spec/java_buildpack/repository/version_resolver_spec.rb
@@ -22,7 +22,9 @@ require 'java_buildpack/util/tokenized_version'
 describe JavaBuildpack::Repository::VersionResolver do
   include_context 'logging_helper'
 
-  let(:versions) { %w(1.6.0_26 1.6.0_27 1.6.1_14 1.7.0_19 1.7.0_21 1.8.0_M-7 1.8.0_05 2.0.0 2.0.0a) }
+  let(:versions) do
+    %w(1.6.0_26 1.6.0_27 1.6.0_112 1.6.0_102 1.6.0_45RELEASE 1.6.1_14 1.7.0_19 1.7.0_21 1.8.0_M-7 1.8.0_05 2.0.0 2.0.0a)
+  end
 
   it 'resolves the default version if no candidate is supplied' do
     expect(described_class.resolve(nil, versions)).to eq(tokenized_version('2.0.0'))
@@ -41,7 +43,7 @@ describe JavaBuildpack::Repository::VersionResolver do
   end
 
   it 'resolves a wildcard qualifier' do
-    expect(described_class.resolve(tokenized_version('1.6.0_+'), versions)).to eq(tokenized_version('1.6.0_27'))
+    expect(described_class.resolve(tokenized_version('1.6.0_+'), versions)).to eq(tokenized_version('1.6.0_112'))
     expect(described_class.resolve(tokenized_version('1.8.0_+'), versions)).to eq(tokenized_version('1.8.0_05'))
   end
 


### PR DESCRIPTION
Added a new criteria for qualifier comparison. If the qualifier has a number at the beginning of it's string, that number is used for comparing. Otherwise, if there is no numeric symbols in the beginning of qualifier's string, or those symbols represent equal numbers, then the old criteria applies, meaning that the qualifiers are compared as strings.

Issue: #397