### PR TITLE
Add clean to ensure proper cache.yml config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ To pin the version of dependencies used by the buildpack to the ones currently r
 
 ```bash
 $ bundle install
-$ bundle exec rake package OFFLINE=true PINNED=true
+$ bundle exec rake clean package OFFLINE=true PINNED=true
 ...
 Creating build/java-buildpack-offline-cfd6b17.zip
 ```


### PR DESCRIPTION
Without the `clean` rake task, the offline buildpack `config/cache.yml` may contain `remote_downloads: enabled`