### PR TITLE
Add support for binary proxies (like Artifactory/Nexus)

### DIFF
--- a/docs/extending-repositories.md
+++ b/docs/extending-repositories.md
@@ -73,6 +73,15 @@ Access to repositories may be affected by the existence of network proxies.  In 
 ```bash
 cf set-env <APP_NAME> http_proxy http://username:password@host:port
 ```
+## Mirroring proxies
+In some cases you may want to mirror https://java-buildpack.cloudfoundry.org or another
+binary repository using a repository manager like artifactory or nexus without modifying the `index.yml` files under the repository. To do so
+add the following to [`config/repository.yml`][] replacing nexus with your mirror
+```
+binary_proxies:
+- from: https://java-buildpack.cloudfoundry.org
+  to: http://nexus:8081/repository/pcf-javabuildpack
+```
 
 ## Version Syntax and Ordering
 Versions are composed of major, minor, micro, and optional qualifier parts (`<major>.<minor>.<micro>[_<qualifier>]`).  The major, minor, and micro parts must be numeric.  The qualifier part is composed of letters, digits, and hyphens.  The lexical ordering of the qualifier is:
@@ -96,4 +105,3 @@ In addition to declaring a specific versions to use, you can also specify a boun
 [`JavaBuildpack::Repository::ConfiguredItem`]: ../lib/java_buildpack/repository/configured_item.rb
 [Configuration and Extension]: ../README.md#configuration-and-extension
 [example]: http://download.pivotal.io.s3.amazonaws.com/openjdk/trusty/x86_64/index.yml
-

--- a/lib/java_buildpack/component/base_component.rb
+++ b/lib/java_buildpack/component/base_component.rb
@@ -20,7 +20,7 @@ require 'java_buildpack/util/format_duration'
 require 'java_buildpack/util/shell'
 require 'java_buildpack/util/space_case'
 require 'java_buildpack/util/sanitizer'
-
+require 'java_buildpack/util/binary_proxy'
 module JavaBuildpack
   module Component
 
@@ -85,6 +85,7 @@ module JavaBuildpack
       # @param [String] name an optional name for the download.  Defaults to +@component_name+.
       # @return [Void]
       def download(version, uri, name = @component_name)
+        uri = JavaBuildpack::Util::BinaryProxy.proxy_for(uri)
         download_start_time = Time.now
         print "-----> Downloading #{name} #{version} from #{uri.sanitize_uri} "
 

--- a/lib/java_buildpack/util/binary_proxy.rb
+++ b/lib/java_buildpack/util/binary_proxy.rb
@@ -1,0 +1,51 @@
+# Cloud Foundry Java Buildpack
+# Copyright 2013-2017 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'pathname'
+require 'java_buildpack/util'
+require 'java_buildpack/util/configuration_utils'
+require 'java_buildpack/logging/logger_factory'
+require 'shellwords'
+require 'yaml'
+
+module JavaBuildpack
+  module Util
+
+    # Utility for loading configuration
+    class BinaryProxy
+
+      private_class_method :new
+
+      class << self
+
+        # Checks to see if a proxy exists for a URI. If it does, replace it
+        # with the proxy uri.
+        #
+        # @param [String] URI to check for proxies
+        # @return [String] The URI as-is or converted to the proxy if applicable
+        def proxy_for(uri)
+          repository = JavaBuildpack::Util::ConfigurationUtils.load('repository')
+          return uri unless repository.key?('binary_proxies')
+          repository['binary_proxies'].each do |proxy|
+            return uri.sub(proxy['from'], proxy['to']) if uri.start_with?(proxy['from'])
+          end
+          uri
+        end
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
This is designed to allow enterprises using artifactory
and nexus type mirroring solutions to use the online JBP
without having to have offline processing jobs to modify
the index.yml files

Syntax is add a stanza like
```
binary_proxies:
- from: https://java-buildpack.cloudfoundry.org
  to: http://nexus:8081/repository/pcf-javabuildpack
```
to the `config/repository.yml`