### PR TITLE
Readme detail: MariaDB support also includes MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ To learn how to configure various properties of the buildpack, follow the "Confi
 	* [JRebel Agent](docs/framework-jrebel_agent.md) ([Configuration](docs/framework-jrebel_agent.md#configuration))
 	* [JMX](docs/framework-jmx.md) ([Configuration](docs/framework-jmx.md#configuration))
 	* [Luna Security Provider](docs/framework-luna_security_provider.md) ([Configuration](docs/framework-luna_security_provider.md#configuration))
-	* [MariaDB JDBC](docs/framework-maria_db_jdbc.md) ([Configuration](docs/framework-maria_db_jdbc.md#configuration))
+	* [MariaDB JDBC](docs/framework-maria_db_jdbc.md) ([Configuration](docs/framework-maria_db_jdbc.md#configuration)) (also supports MySQL)
 	* [Metric Writer](docs/framework-metric_writer.md) ([Configuration](docs/framework-metric_writer.md#configuration))
 	* [New Relic Agent](docs/framework-new_relic_agent.md) ([Configuration](docs/framework-new_relic_agent.md#configuration))
 	* [Play Framework Auto Reconfiguration](docs/framework-play_framework_auto_reconfiguration.md) ([Configuration](docs/framework-play_framework_auto_reconfiguration.md#configuration))


### PR DESCRIPTION
For readers who are looking for information about MySQL support, they may not be familiar with MariaDB and understand that they are related/similar. (I wasn't familiar with this until just now. :) ) This suggestion adds a tiny note to the readme mentioning MySQL next to the MariaDB item, so that readers skimming the page for MySQL info can easily identify that they should click that item for more details.