### PR TITLE
Added Contrast Security framework support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ To learn how to configure various properties of the buildpack, follow the "Confi
 * Standard Frameworks
 	* [AppDynamics Agent](docs/framework-app_dynamics_agent.md) ([Configuration](docs/framework-app_dynamics_agent.md#configuration))
 	* [Container Customizer](docs/framework-container_customizer.md) ([Configuration](docs/framework-container_customizer.md#configuration))
+	* [Contrast Security Agent](docs/framework-contrast_security_agent.md) ([Configuration](docs/framework-contrast_security_agent.md#configuration))
 	* [Debug](docs/framework-debug.md) ([Configuration](docs/framework-debug.md#configuration))
 	* [Dyadic EKM Security Provider](docs/framework-dyadic_ekm_security_provider.md) ([Configuration](docs/framework-dyadic_ekm_security_provider.md#configuration))
 	* [Dynatrace Appmon Agent](docs/framework-dynatrace_appmon_agent.md) ([Configuration](docs/framework-dynatrace_appmon_agent.md#configuration))

--- a/config/components.yml
+++ b/config/components.yml
@@ -39,6 +39,7 @@ frameworks:
   - "JavaBuildpack::Framework::AppDynamicsAgent"
   - "JavaBuildpack::Framework::ContainerCustomizer"
   - "JavaBuildpack::Framework::ContainerSecurityProvider"
+  - "JavaBuildpack::Framework::ContrastSecurityAgent"
   - "JavaBuildpack::Framework::Debug"
   - "JavaBuildpack::Framework::DyadicEkmSecurityProvider"
   - "JavaBuildpack::Framework::DynatraceAppmonAgent"

--- a/config/contrast_security_agent.yml
+++ b/config/contrast_security_agent.yml
@@ -1,0 +1,20 @@
+# Cloud Foundry Java Buildpack
+# Copyright 2013-2017 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration for the ContrastSecurity framework
+---
+enabled: true
+version: 3.+
+repository_root: "https://artifacts.contrastsecurity.com/agents/java/"

--- a/config/contrast_security_agent.yml
+++ b/config/contrast_security_agent.yml
@@ -15,6 +15,5 @@
 
 # Configuration for the ContrastSecurity framework
 ---
-enabled: true
 version: 3.+
 repository_root: "https://artifacts.contrastsecurity.com/agents/java/"

--- a/docs/framework-contrast_security_agent.md
+++ b/docs/framework-contrast_security_agent.md
@@ -3,7 +3,7 @@ The Contrast Security Agent Framework causes an application to be automatically 
 
 <table>
   <tr>
-    <td><strong>Detection Criterion</strong></td><td>Existence of a single bound Contrast Security service. The existence of an Contrast Security service defined by the <a href="http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES"><code>VCAP_SERVICES</code></a> payload containing a service name, label or tag with <code>contrast-security</code> or <code>contrastsecurity</code> as a substring.
+    <td><strong>Detection Criterion</strong></td><td>Existence of a single bound Contrast Security service. The existence of an Contrast Security service defined by the <a href="http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES"><code>VCAP_SERVICES</code></a> payload containing a service name, label or tag with <code>contrast-security</code> as a substring.
 </td>
   </tr>
 </table>
@@ -14,11 +14,11 @@ When binding ContrastSecurity using a user-provided service, it must have name o
 
 | Name | Description
 | ---- | -----------
-| `teamserver_url` | (Optional) The base URL in which your user has access to and the URL to which the Agent will report. ex: https://app.contrastsecurity.com
-| `username` | (Required) The account name to use when downloading the agent
-| `org_uuid` | (Required) The org uuid to send app information to, this is the org that your bound application will appear within
-| `api_key` | (Required) Your user's api key
-| `service_key` | (Required) Your user's service key
+| `teamserver_url` | The base URL in which your user has access to and the URL to which the Agent will report. ex: https://app.contrastsecurity.com
+| `username` | The account name to use when downloading the agent
+| `org_uuid` | The org uuid to send app information to, this is the org that your bound application will appear within
+| `api_key` | Your user's api key
+| `service_key` | Your user's service key
 
 
 ## Configuration

--- a/docs/framework-contrast_security_agent.md
+++ b/docs/framework-contrast_security_agent.md
@@ -10,7 +10,7 @@ The Contrast Security Agent Framework causes an application to be automatically 
 Tags are printed to standard output by the buildpack detect script
 
 ## User-Provided Service
-When binding ContrastSecurity using a user-provided service, it must have name or tag with `contrast-security` or `contrastsecurity` in it. The credential payload can contain the following entries:
+When binding ContrastSecurity using a user-provided service, it must have name or tag with `contrast-security` in it. The credential payload can contain the following entries:
 
 | Name | Description
 | ---- | -----------

--- a/docs/framework-contrast_security_agent.md
+++ b/docs/framework-contrast_security_agent.md
@@ -1,0 +1,41 @@
+# Contrast Security Agent Framework
+The Contrast Security Agent Framework causes an application to be automatically configured to work with a bound [Contrast Security Service][].
+
+<table>
+  <tr>
+    <td><strong>Detection Criterion</strong></td><td>Existence of a single bound Contrast Security service. The existence of an Contrast Security service defined by the <a href="http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES"><code>VCAP_SERVICES</code></a> payload containing a service name, label or tag with <code>contrast-security</code> or <code>contrastsecurity</code> as a substring.
+</td>
+  </tr>
+</table>
+Tags are printed to standard output by the buildpack detect script
+
+## User-Provided Service
+When binding ContrastSecurity using a user-provided service, it must have name or tag with `contrast-security` or `contrastsecurity` in it. The credential payload can contain the following entries:
+
+| Name | Description
+| ---- | -----------
+| `teamserver_url` | (Optional) The base URL in which your user has access to and the URL to which the Agent will report. ex: https://app.contrastsecurity.com
+| `username` | (Required) The account name to use when downloading the agent
+| `org_uuid` | (Required) The org uuid to send app information to, this is the org that your bound application will appear within
+| `api_key` | (Required) Your user's api key
+| `service_key` | (Required) Your user's service key
+
+
+## Configuration
+For general information on configuring the buildpack, including how to specify configuration values through environment variables, refer to [Configuration and Extension][].
+
+The framework can be configured by modifying the [`config/contrast_security_agent.yml`][] file in the buildpack fork. The framework uses the [`Repository` utility support][repositories] and so it supports the [version syntax][] defined there.
+
+| Name | Description
+| ---- | -----------
+| `repository_root` | The URL of the Contrast Security repository index ([details][repositories]).
+| `version` | The version of Contrast Security to use. Candidate versions can be found in [this listing][].
+
+[Contrast Security]: https://www.contrastsecurity.com
+[Configuration and Extension]: ../README.md#configuration-and-extension
+[Contrast Security Service]: https://www.contrastsecurity.com
+[`config/contrast_security_agent.yml`]: ../config/contrast_security_agent.yml
+[Configuration and Extension]: ../README.md#configuration-and-extension
+[repositories]: extending-repositories.md
+[this listing]: https://artifacts.contrastsecurity.com/agents/java/index.yml
+[version syntax]: extending-repositories.md#version-syntax-and-ordering

--- a/lib/java_buildpack/framework/contrast_security_agent.rb
+++ b/lib/java_buildpack/framework/contrast_security_agent.rb
@@ -1,0 +1,114 @@
+# Encoding: utf-8
+
+# Cloud Foundry Java Buildpack
+# Copyright 2013-2017 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'fileutils'
+require 'open-uri'
+require 'rexml/document'
+require 'java_buildpack/component/versioned_dependency_component'
+require 'java_buildpack/framework'
+require 'base64'
+
+module JavaBuildpack
+  module Framework
+
+    # Encapsulates the functionality for running the Contrast Security Agent support.
+    class ContrastSecurityAgent < JavaBuildpack::Component::VersionedDependencyComponent
+
+      # (see JavaBuildpack::Component::BaseComponent#compile)
+      def compile
+        load_credentials
+        FileUtils.mkdir_p(@droplet.sandbox)
+        @dir = @droplet.sandbox
+        download_jar(boot_class_name)
+        build_contrast_configuration
+        @droplet.copy_resources
+      end
+
+      # (see JavaBuildpack::Component::BaseComponent#release)
+      def release
+        app_name = @application.details['application_name'] || 'ROOT'
+        java_opts = @droplet.java_opts
+        java_opts.add_system_property('contrast.dir', '/tmp')
+        java_opts.add_system_property('contrast.override.appname', app_name)
+        path = java_opts.qualify_path(@droplet.sandbox)
+        java_opts.add_preformatted_options("-javaagent:#{path}/#{boot_class_name}=#{path}/contrast.config")
+      end
+
+      protected
+
+      # (see JavaBuildpack::Component::VersionedDependencyComponent#supports?)
+      def supports?
+        @application.services.one_service?(CONTRAST_FILTER, [TEAMSERVER_URL, USERNAME, API_KEY, SERVICE_KEY])
+      end
+
+      private
+
+      CONTRAST_FILTER = /contrast[-]?security/
+      private_constant :CONTRAST_FILTER
+
+      TEAMSERVER_URL = 'teamserver_url'.freeze
+      USERNAME = 'username'.freeze
+      API_KEY = 'api_key'.freeze
+      SERVICE_KEY = 'service_key'.freeze
+
+      PLUGIN_PACKAGE = 'com.aspectsecurity.contrast.runtime.agent.plugins.'.freeze
+
+      def load_credentials
+        credentials = @application.services.find_service(CONTRAST_FILTER)['credentials']
+        @teamserver_url = credentials[TEAMSERVER_URL]
+        @username = credentials[USERNAME]
+        @api_key = credentials[API_KEY]
+        @service_key = credentials[SERVICE_KEY]
+      end
+
+      def boot_class_name
+        version = @version.to_s.split('_')[0]
+        "contrast-engine-#{version}.jar"
+      end
+
+      def build_contrast_configuration
+        doc = REXML::Document.new
+        contrast = doc.add_element('contrast')
+        (contrast.add_element 'id').add_text('default')
+        (contrast.add_element 'global-key').add_text(@api_key)
+        user = contrast.add_element('user')
+        (user.add_element 'id').add_text(@username)
+        (user.add_element 'key').add_text(@service_key)
+        (contrast.add_element 'url').add_text("#{@teamserver_url}/Contrast/s/")
+        (contrast.add_element 'results-mode').add_text('never')
+
+        add_plugins(contrast)
+
+        File.open(File.join(@dir, 'contrast.config'), 'w+') do |file|
+          file.puts doc
+        end
+      end
+
+      def add_plugins(config)
+        plugin_group = config.add_element('plugins')
+        (plugin_group.add_element 'plugin').add_text("#{PLUGIN_PACKAGE}.security.SecurityPlugin")
+        (plugin_group.add_element 'plugin').add_text("#{PLUGIN_PACKAGE}.architecture.ArchitecturePlugin")
+        (plugin_group.add_element 'plugin').add_text("#{PLUGIN_PACKAGE}.appupdater.ApplicationUpdatePlugin")
+        (plugin_group.add_element 'plugin').add_text("#{PLUGIN_PACKAGE}.sitemap.SitemapPlugin")
+        (plugin_group.add_element 'plugin').add_text("#{PLUGIN_PACKAGE}.frameworks.FrameworkSupportPlugin")
+        (plugin_group.add_element 'plugin').add_text("#{PLUGIN_PACKAGE}.http.HttpPlugin")
+      end
+
+    end
+
+  end
+end

--- a/spec/java_buildpack/framework/contrast_security_agent_spec.rb
+++ b/spec/java_buildpack/framework/contrast_security_agent_spec.rb
@@ -37,7 +37,7 @@ describe JavaBuildpack::Framework::ContrastSecurityAgent do
   context do
     before do
       allow(services).to receive(:one_service?).with(/contrast[-]?security/,
-                                                     %w[teamserver_url username api_key service_key]).and_return(true)
+                                                     'teamserver_url','username', 'api_key', 'service_key').and_return(true)
       allow(services).to receive(:find_service).and_return('credentials' => :configuration)
     end
 
@@ -57,7 +57,7 @@ describe JavaBuildpack::Framework::ContrastSecurityAgent do
 
       expect(java_opts).to include('-javaagent:$PWD/.java-buildpack/contrast_security_agent/contrast-engine-0.0.0.jar'\
         '=$PWD/.java-buildpack/contrast_security_agent/contrast.config')
-      expect(java_opts).to include('-Dcontrast.dir=/tmp')
+      expect(java_opts).to include('-Dcontrast.dir=$TMPDIR')
       expect(java_opts).to include('-Dcontrast.override.appname=test-application-name')
     end
 

--- a/spec/java_buildpack/framework/contrast_security_agent_spec.rb
+++ b/spec/java_buildpack/framework/contrast_security_agent_spec.rb
@@ -1,0 +1,71 @@
+# Encoding: utf-8
+
+# Cloud Foundry Java Buildpack
+# Copyright 2013-2016 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'component_helper'
+require 'java_buildpack/framework/contrast_security_agent'
+require 'java_buildpack/util/tokenized_version'
+
+describe JavaBuildpack::Framework::ContrastSecurityAgent do
+  include_context 'component_helper'
+  let(:configuration) do
+    { 'teamserver_url' => 'a_url',
+      'org_uuid' => '12345',
+      'username' => 'contrast_user',
+      'api_key' => 'api_test',
+      'service_key' => 'service_test' }
+  end
+
+  it 'does not detect without contrastsecurity service' do
+    expect(component.detect).to be_nil
+  end
+
+  context do
+    before do
+      allow(services).to receive(:one_service?).with(/contrast[-]?security/,
+                                                     %w[teamserver_url username api_key service_key]).and_return(true)
+      allow(services).to receive(:find_service).and_return('credentials' => :configuration)
+    end
+
+    it 'detects with contrastsecurity service' do
+      expect(component.detect).to eq("contrast-security-agent=#{version}")
+    end
+
+    it 'downloads Contrast Security agent JAR',
+       cache_fixture: 'stub-contrast-security-agent.jar' do
+
+      component.compile
+      expect(sandbox + 'contrast-engine-0.0.0.jar').to exist
+    end
+
+    it 'updates JAVA_OPTS' do
+      component.release
+
+      expect(java_opts).to include('-javaagent:$PWD/.java-buildpack/contrast_security_agent/contrast-engine-0.0.0.jar'\
+        '=$PWD/.java-buildpack/contrast_security_agent/contrast.config')
+      expect(java_opts).to include('-Dcontrast.dir=/tmp')
+      expect(java_opts).to include('-Dcontrast.override.appname=test-application-name')
+    end
+
+    it 'created contrast.config',
+       cache_fixture: 'stub-contrast-security-agent.jar' do
+      component.compile
+      expect(sandbox + 'contrast.config').to exist
+    end
+  end
+
+end


### PR DESCRIPTION
This commit adds support for using Contrast Security's Java agent. 
A bound service will be used to create a configuration file for the agent, as well as set some Java system properties.