### PR TITLE
Fix agentManager.url.1 property, add support for related older properties, enable introscope agent by default and update default repository_root

### DIFF
--- a/config/components.yml
+++ b/config/components.yml
@@ -47,7 +47,7 @@ frameworks:
   - "JavaBuildpack::Framework::DynatraceAppmonAgent"
   - "JavaBuildpack::Framework::DynatraceOneAgent"
   - "JavaBuildpack::Framework::GoogleStackdriverDebugger"
-# - "JavaBuildpack::Framework::IntroscopeAgent"
+  - "JavaBuildpack::Framework::IntroscopeAgent"
   - "JavaBuildpack::Framework::JavaMemoryAssistant"
   - "JavaBuildpack::Framework::Jmx"
   - "JavaBuildpack::Framework::JrebelAgent"

--- a/config/introscope_agent.yml
+++ b/config/introscope_agent.yml
@@ -15,6 +15,6 @@
 
 # Configuration for the CA Wily framework
 ---
-repository_root: "https://bintray.com/ca/apm-agents/download_file?file_path="
+repository_root: "https://ca.bintray.com/apm-agents"
 version: 10.+
 default_agent_name: ! '$(ruby -e "require ''json'' ; puts JSON.parse(ENV[''VCAP_APPLICATION''])[''application_name'']")'

--- a/config/introscope_agent.yml
+++ b/config/introscope_agent.yml
@@ -15,6 +15,6 @@
 
 # Configuration for the CA Wily framework
 ---
-repository_root: ""
-version: 9.7.+
+repository_root: "https://bintray.com/ca/apm-agents/download_file?file_path="
+version: 10.+
 default_agent_name: ! '$(ruby -e "require ''json'' ; puts JSON.parse(ENV[''VCAP_APPLICATION''])[''application_name'']")'

--- a/docs/framework-introscope_agent.md
+++ b/docs/framework-introscope_agent.md
@@ -1,5 +1,5 @@
-# Introscope Agent Framework
-The Introscope Agent Framework causes an application to be automatically configured to work with a bound [Introscope service][].  **Note:** This framework is disabled by default.
+# CA APM Framework
+The CA APM Framework causes an application to be automatically configured to work with a bound [Introscope service][].
 
 <table>
   <tr>
@@ -24,9 +24,8 @@ The credential payload of the service may contain the following entries:
 | Name | Description
 | ---- | -----------
 | `agent-name` | (Optional) The name that should be given to this instance of the Introscope agent
-| `host-name` | The host name of the Introscope Enterprise Manager server
-| `ssl` | (Optional) Whether or not to use an SSL connection to the Introscope Enterprise Manager server
-| `port` | (Optional) The port of the Introscope Enterprise Manager server
+| `url` | The url of the Introscope Enterprise Manager server
+
 
 To provide more complex values such as the `agent-name`, using the interactive mode when creating a user-provided service will manage the character escaping automatically. For example, the default `agent-name` could be set with a value of `agent-$(expr "$VCAP_APPLICATION" : '.*application_name[": ]*\([[:word:]]*\).*')` to calculate a value from the Cloud Foundry application name.
 

--- a/docs/framework-introscope_agent.md
+++ b/docs/framework-introscope_agent.md
@@ -1,5 +1,5 @@
-# CA APM Framework
-The CA APM Framework causes an application to be automatically configured to work with a bound [Introscope service][].
+# CA Introscope APM Framework
+The CA Introscope APM Framework causes an application to be automatically configured to work with a bound [Introscope service][].
 
 <table>
   <tr>

--- a/lib/java_buildpack/framework/introscope_agent.rb
+++ b/lib/java_buildpack/framework/introscope_agent.rb
@@ -41,18 +41,15 @@ module JavaBuildpack
           .add_system_property('introscope.agent.hostName', agent_host_name)
           .add_system_property('com.wily.introscope.agent.agentName', agent_name(credentials))
           .add_system_property('introscope.agent.defaultProcessName', default_process_name)
-          .add_system_property('introscope.agent.enterprisemanager.transport.tcp.host.DEFAULT', host_name(credentials))
-          .add_system_property('agentManager.url.1', agent_manager(credentials))
 
-        add_port(credentials, java_opts)
-        add_socket_factory(credentials, java_opts)
+        add_url(credentials, java_opts)
       end
 
       protected
 
       # (see JavaBuildpack::Component::VersionedDependencyComponent#supports?)
       def supports?
-        @application.services.one_service? FILTER, 'host-name'
+        @application.services.one_service? FILTER, 'url'
       end
 
       private
@@ -60,17 +57,6 @@ module JavaBuildpack
       FILTER = /introscope/
 
       private_constant :FILTER
-
-      def add_port(credentials, java_opts)
-        port = port(credentials)
-        java_opts.add_system_property('introscope.agent.enterprisemanager.transport.tcp.port.DEFAULT', port) if port
-      end
-
-      def add_socket_factory(credentials, java_opts)
-        return unless ssl?(credentials)
-        java_opts.add_system_property('introscope.agent.enterprisemanager.transport.tcp.socketfactory.DEFAULT',
-                                      'com.wily.isengard.postofficehub.link.net.SSLSocketFactory')
-      end
 
       def agent_host_name
         @application.details['application_uris'][0]
@@ -80,12 +66,27 @@ module JavaBuildpack
         @droplet.sandbox + 'Agent.jar'
       end
 
-      def agent_manager(credentials)
-        agent_manager = ssl?(credentials) ? 'https://' : 'http://'
-        agent_manager += host_name(credentials)
+      def add_url(credentials, java_opts)
+        agent_manager = url(credentials)
 
-        port = port(credentials)
-        port ? "#{agent_manager}:#{port}" : agent_manager
+        host, port, socket_factory = parse_url(agent_manager)
+        java_opts.add_system_property('agentManager.url.1', agent_manager)
+        java_opts.add_system_property('introscope.agent.enterprisemanager.transport.tcp.host.DEFAULT', host)
+        java_opts.add_system_property('introscope.agent.enterprisemanager.transport.tcp.port.DEFAULT', port)
+        java_opts.add_system_property('introscope.agent.enterprisemanager.transport.tcp.socketfactory.DEFAULT',
+                                      socket_factory)
+      end
+
+      # Parse the agent manager url, split first by '://', and then with ':'
+      # components is of the format [host, port, socket_factory]
+      def parse_url(url)
+        components = url.split('://')
+        components.unshift('') if components.length == 1
+        components[1] = components[1].split(':')
+        components.flatten!
+        components.push(protocol_mapping(components[0]))
+        components.shift
+        components
       end
 
       def agent_name(credentials)
@@ -100,18 +101,22 @@ module JavaBuildpack
         @application.details['application_name']
       end
 
-      def host_name(credentials)
-        credentials['host-name']
+      def protocol_mapping(protocol)
+        socket_factory_base = 'com.wily.isengard.postofficehub.link.net.'
+
+        protocol_socket_factory = {
+          '' => socket_factory_base + 'DefaultSocketFactory',
+          'ssl' => socket_factory_base + 'SSLSocketFactory',
+          'http' => socket_factory_base + 'HttpTunnelingSocketFactory',
+          'https' => socket_factory_base + 'HttpsTunnelingSocketFactory'
+        }
+
+        protocol_socket_factory[protocol] || protocol
       end
 
-      def port(credentials)
-        credentials['port']
+      def url(credentials)
+        credentials['url']
       end
-
-      def ssl?(credentials)
-        credentials['ssl'].to_b
-      end
-
     end
   end
 end


### PR DESCRIPTION
Before this commit, the Introscope agent framework had support for the new agent manager url, but it was missing a few cases. The framework was also disabled by default, so changes had to be made to enable it. The `config/introscope_agent.yml` file had an empty repository_root.

The biggest change was for the `agentManager.url.1` property. Since it is now just a url, separate properties for host, port, and ssl do not need to be maintained. All information is encapsulated in the url. The user provides the url, and to allow backwards-compatability, the previous EM connection properties will also be populated with the various components
from the agentManager url.

After this commit, the buildpack simplifies the user-input so that the user only needs to provide the url, and not the host-name and port. This way, the detection criteria has also been changed so that the url must be provided, and not the host-name. The previous versions of the buildpack were missing support for different socket factories, and with this commit, all socket factories and connection methods (tcp, ssl, http, https) are now supported. Finally, the introscope agent has been enabled out of the box, and the repository root now contains a link to the `index.yml` file.
The documentation has also been updated to reflect these changes.