### PR TITLE
Add "skiperror" flag for Dynatrace One Agent

### DIFF
--- a/docs/framework-dynatrace_one_agent.md
+++ b/docs/framework-dynatrace_one_agent.md
@@ -29,6 +29,7 @@ The credential payload of the service may contain the following entries:
 | `apitoken` | The token for integrating your Dynatrace environment with Cloud Foundry. You can find it in the deploy Dynatrace section within your environment. The `apitoken` replaces deprecated ~~`tenanttoken`~~ option.
 | `apiurl` | (Optional) The base URL of the Dynatrace API. If you are using Dynatrace Managed you will need to set this property to `https://<your-managed-server-url>/e/<environmentId>/api`. If you are using Dynatrace SaaS you don't need to set this property.
 | `endpoint`  | (Deprecated) The Dynatrace connection endpoint the agent connects to. Please use `apiurl` in combination with `apitoken` for Dynatrace Managed.
+| `skiperrors` | (Optional, default=false) Should errors during one agent download be skipped or not. Possible values are 'true' and 'false' |
 
 ## Configuration
 For general information on configuring the buildpack, including how to specify configuration values through environment variables, refer to [Configuration and Extension][].

--- a/spec/java_buildpack/framework/dynatrace_one_agent_spec.rb
+++ b/spec/java_buildpack/framework/dynatrace_one_agent_spec.rb
@@ -53,6 +53,31 @@ describe JavaBuildpack::Framework::DynatraceOneAgent do
       expect(sandbox + 'manifest.json').to exist
     end
 
+    it 'do not skip errors on default',
+       app_fixture: 'framework_dynatrace_one_agent' do
+
+      # allow(File).to receive(:file?).and_return(true)
+      allow(application_cache).to receive(:get)
+        .with('test-server/api/v1/deployment/installer/agent/unix/paas/latest?include=java&bitness=64&' \
+        'Api-Token=test-apitoken')
+        .and_raise(RuntimeError.new('error'))
+      expect { component.compile }.to raise_error(RuntimeError)
+    end
+
+    it 'skiperrors durring download',
+       app_fixture: 'framework_dynatrace_one_agent' do
+      allow(services).to receive(:find_service).and_return('credentials' => { 'apitoken'   => 'test-apitoken',
+                                                                              'tenant'     => 'test-tenant',
+                                                                              'server'     => 'test-server',
+                                                                              'skiperrors' => 'true' })
+      # allow(File).to receive(:file?).and_return(true)
+      allow(application_cache).to receive(:get)
+        .with('test-server/api/v1/deployment/installer/agent/unix/paas/latest?include=java&bitness=64&' \
+        'Api-Token=test-apitoken')
+        .and_raise(RuntimeError.new('error'))
+      component.compile
+    end
+
     it 'does update JAVA_OPTS with environmentid and apitoken',
        app_fixture: 'framework_dynatrace_one_agent' do
       allow(services).to receive(:find_service).and_return('credentials' => { 'environmentid' => 'test-tenant',


### PR DESCRIPTION
Add `skiperrors` flag to user-provided service for dynatrace one agent.
This flag provides the possibility of a robust startup if the download
of the one agent fails due to any circumstances.

Possible values for skiperrors are:
- false (default) will abbort the staging process
- true will continue staging with a deactivated dynatrace service 