### PR TITLE
Prepare Contrast framework for boot class path change

### DIFF
--- a/lib/java_buildpack/framework/contrast_security_agent.rb
+++ b/lib/java_buildpack/framework/contrast_security_agent.rb
@@ -39,9 +39,9 @@ module JavaBuildpack
       # (see JavaBuildpack::Component::BaseComponent#release)
       def release
         @droplet.java_opts
-                .add_system_property('contrast.dir', '$TMPDIR')
-                .add_system_property('contrast.override.appname', application_name)
-                .add_preformatted_options("-javaagent:#{qualify_path(@droplet.sandbox + jar_name, @droplet.root)}=" \
+          .add_system_property('contrast.dir', '$TMPDIR')
+          .add_system_property('contrast.override.appname', application_name)
+          .add_preformatted_options("-javaagent:#{qualify_path(@droplet.sandbox + jar_name, @droplet.root)}=" \
                                           "#{qualify_path(contrast_config, @droplet.root)}")
       end
 
@@ -49,7 +49,11 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::VersionedDependencyComponent#jar_name)
       def jar_name
-        "contrast-engine-#{@version.to_s.split('_')[0]}.jar"
+        if @version < JAVA_AGENT_VERSION
+          "contrast-engine-#{@version[0]}.#{@version[1]}.#{@version[2]}.jar"
+        else
+          "java-agent-#{@version[0]}.#{@version[1]}.#{@version[2]}.jar"
+        end
       end
 
       # (see JavaBuildpack::Component::VersionedDependencyComponent#supports?)
@@ -63,7 +67,9 @@ module JavaBuildpack
 
       CONTRAST_FILTER = 'contrast-security'.freeze
 
-      PLUGIN_PACKAGE = 'com.aspectsecurity.contrast.runtime.agent.plugins.'.freeze
+      JAVA_AGENT_VERSION = JavaBuildpack::Util::TokenizedVersion.new('3.4.3').freeze
+
+      PLUGIN_PACKAGE = 'com.aspectsecurity.contrast.runtime.agent.plugins'.freeze
 
       SERVICE_KEY = 'service_key'.freeze
 
@@ -71,7 +77,7 @@ module JavaBuildpack
 
       USERNAME = 'username'.freeze
 
-      private_constant :API_KEY, :CONTRAST_FILTER, :PLUGIN_PACKAGE, :SERVICE_KEY, :TEAMSERVER_URL, :USERNAME
+      private_constant :API_KEY, :CONTRAST_FILTER, :PLUGIN_PACKAGE, :SERVICE_KEY, :TEAMSERVER_URL, :USERNAME, :JAVA_AGENT_VERSION
 
       def add_contrast(doc, credentials)
         contrast = doc.add_element('contrast')

--- a/spec/java_buildpack/framework/contrast_security_agent_spec.rb
+++ b/spec/java_buildpack/framework/contrast_security_agent_spec.rb
@@ -33,7 +33,6 @@ describe JavaBuildpack::Framework::ContrastSecurityAgent do
       allow(services).to receive(:one_service?).with(/contrast-security/, 'api_key', 'service_key', 'teamserver_url',
                                                      'username').and_return(true)
       allow(services).to receive(:find_service).and_return('credentials' => { 'teamserver_url' => 'a_url',
-                                                                              'org_uuid'       => '12345',
                                                                               'username'       => 'contrast_user',
                                                                               'api_key'        => 'api_test',
                                                                               'service_key'    => 'service_test' })
@@ -48,6 +47,27 @@ describe JavaBuildpack::Framework::ContrastSecurityAgent do
 
       component.compile
       expect(sandbox + 'contrast-engine-0.0.0.jar').to exist
+    end
+
+    it 'uses contrast-engine for versions < 3.4.3' do
+
+      tokenized_version = JavaBuildpack::Util::TokenizedVersion.new('3.4.2_756')
+      allow(JavaBuildpack::Repository::ConfiguredItem).to receive(:find_item) do |&block|
+        block.call(tokenized_version) if block
+      end.and_return([tokenized_version, uri])
+
+      component.release
+      expect(java_opts.to_s).to include('contrast-engine-3.4.2.jar')
+    end
+
+    it 'uses java-agent for versions >= 3.4.3' do
+      tokenized_version = JavaBuildpack::Util::TokenizedVersion.new('3.4.3_000')
+      allow(JavaBuildpack::Repository::ConfiguredItem).to receive(:find_item) do |&block|
+        block.call(tokenized_version) if block
+      end.and_return([tokenized_version, uri])
+
+      component.release
+      expect(java_opts.to_s).to include('java-agent-3.4.3.jar')
     end
 
     it 'updates JAVA_OPTS' do


### PR DESCRIPTION
With our next on premise release(3.4.3) the Contrast Java agent's boot class path will be
`java-agent-#{major.minor.patch}.jar`

In order to support previous versions 3.4.0 - 3.4.2 we need to be able to continue using: `contrast-engine-#{major.minor.patch}.jar` and for new versions(3.4.3+) use `java-agent-#{major.minor.patch}.jar`