### PR TITLE
Change service detection for dynatrace integration

### DIFF
--- a/docs/framework-dynatrace_one_agent.md
+++ b/docs/framework-dynatrace_one_agent.md
@@ -7,7 +7,7 @@ The Dynatrace SaaS/Managed OneAgent Framework causes an application to be automa
   <tr>
     <td><strong>Detection Criterion</strong></td><td>Existence of a single bound Dynatrace SaaS/Managed service.
       <ul>
-        <li>Existence of a Dynatrace SaaS/Managed service is defined as the <a href="http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES"><code>VCAP_SERVICES</code></a> payload containing a service who's name, label or tag has <code>dynatrace</code> as a substring.</li>
+        <li>Existence of a Dynatrace SaaS/Managed service is defined as the <a href="http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES"><code>VCAP_SERVICES</code></a> payload containing a service who's name, label or tag has <code>dynatrace</code> as a substring with at least `environmentid` and `apitoken` set as credentials.</li>
       </ul>
     </td>
   </tr>
@@ -25,10 +25,9 @@ The credential payload of the service may contain the following entries:
 
 | Name | Description
 | ---- | -----------
-| `environmentid` | Your Dynatrace environment ID is the unique identifier of your Dynatrace environment. You can find it in the deploy Dynatrace section within your environment. The `environmentid` replaces deprecated ~~`tenant`~~ option.
-| `apitoken` | The token for integrating your Dynatrace environment with Cloud Foundry. You can find it in the deploy Dynatrace section within your environment. The `apitoken` replaces deprecated ~~`tenanttoken`~~ option.
+| `environmentid` | Your Dynatrace environment ID is the unique identifier of your Dynatrace environment. You can find it in the deploy Dynatrace section within your environment.
+| `apitoken` | The token for integrating your Dynatrace environment with Cloud Foundry. You can find it in the deploy Dynatrace section within your environment.
 | `apiurl` | (Optional) The base URL of the Dynatrace API. If you are using Dynatrace Managed you will need to set this property to `https://<your-managed-server-url>/e/<environmentId>/api`. If you are using Dynatrace SaaS you don't need to set this property.
-| `endpoint`  | (Deprecated) The Dynatrace connection endpoint the agent connects to. Please use `apiurl` in combination with `apitoken` for Dynatrace Managed.
 
 ## Configuration
 For general information on configuring the buildpack, including how to specify configuration values through environment variables, refer to [Configuration and Extension][].

--- a/lib/java_buildpack/framework/dynatrace_one_agent.rb
+++ b/lib/java_buildpack/framework/dynatrace_one_agent.rb
@@ -30,7 +30,7 @@ module JavaBuildpack
       # @param [Hash] context a collection of utilities used the component
       def initialize(context)
         super(context)
-        @version, @uri = agent_download_url if supports? && supports_apitoken?
+        @version, @uri = agent_download_url if supports?
       end
 
       # (see JavaBuildpack::Component::BaseComponent#compile)
@@ -46,48 +46,43 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::BaseComponent#release)
       def release
-        credentials = @application.services.find_service(FILTER)['credentials']
+        credentials = service['credentials']
 
-        @droplet.java_opts.add_agentpath_with_props(agent_path,
-                                                    SERVER      => server(credentials),
-                                                    TENANT      => tenant(credentials),
-                                                    TENANTTOKEN => tenanttoken(credentials))
+        @droplet.java_opts.add_agentpath(agent_path)
 
         environment           = @application.environment
         environment_variables = @droplet.environment_variables
 
-        unless environment.key?(RUXIT_APPLICATION_ID)
-          environment_variables.add_environment_variable(RUXIT_APPLICATION_ID, application_id)
+        unless environment.key?(DT_APPLICATION_ID)
+          environment_variables.add_environment_variable(DT_APPLICATION_ID, application_id)
         end
 
-        environment_variables.add_environment_variable(RUXIT_HOST_ID, host_id) unless environment.key?(RUXIT_HOST_ID)
+        environment_variables.add_environment_variable(DT_HOST_ID, host_id) unless environment.key?(DT_HOST_ID)
+        environment_variables.add_environment_variable(DT_TENANT, tenant(credentials))
+        environment_variables.add_environment_variable(DT_TENANTTOKEN, tenanttoken)
+        environment_variables.add_environment_variable(DT_CONNECTION_POINT, endpoints)
       end
 
       protected
 
       # (see JavaBuildpack::Component::VersionedDependencyComponent#supports?)
       def supports?
-        @application.services.one_service? FILTER, [ENVIRONMENTID, TENANT], [APITOKEN, TENANTTOKEN]
-      end
-
-      def supports_apitoken?
-        credentials = @application.services.find_service(FILTER)['credentials']
-        credentials[APITOKEN] ? true : false
+        !service.nil?
       end
 
       private
 
-      FILTER = /ruxit|dynatrace/
+      FILTER = /dynatrace/
 
-      RUXIT_APPLICATION_ID = 'RUXIT_APPLICATIONID'.freeze
+      DT_APPLICATION_ID = 'DT_APPLICATIONID'.freeze
 
-      RUXIT_HOST_ID = 'RUXIT_HOST_ID'.freeze
+      DT_HOST_ID = 'DT_HOST_ID'.freeze
 
-      SERVER = 'server'.freeze
+      DT_TENANT = 'DT_TENANT'.freeze
 
-      TENANT = 'tenant'.freeze
+      DT_TENANTTOKEN = 'DT_TENANTTOKEN'.freeze
 
-      TENANTTOKEN = 'tenanttoken'.freeze
+      DT_CONNECTION_POINT = 'DT_CONNECTION_POINT'.freeze
 
       APITOKEN = 'apitoken'.freeze
 
@@ -95,34 +90,35 @@ module JavaBuildpack
 
       ENVIRONMENTID = 'environmentid'.freeze
 
-      ENDPOINT = 'endpoint'.freeze
+      private_constant :FILTER, :DT_APPLICATION_ID, :DT_HOST_ID
+      private_constant :DT_TENANT, :DT_TENANTTOKEN, :DT_CONNECTION_POINT
+      private_constant :ENVIRONMENTID, :APITOKEN
 
-      private_constant :FILTER, :RUXIT_APPLICATION_ID, :RUXIT_HOST_ID, :SERVER, :TENANT, :TENANTTOKEN, :APITOKEN
-      private_constant :ENVIRONMENTID, :ENDPOINT, :APIURL
+      def service
+        candidates = @application.services.select do |candidate|
+          candidate['name'] =~ FILTER && candidate['credentials'][ENVIRONMENTID] && candidate['credentials'][APITOKEN]
+        end
 
-      def agent_dir
-        @droplet.sandbox + 'agent'
+        candidates.one? ? candidates.first : nil
       end
 
       def agent_path
-        libpath = agent_dir + 'lib64/liboneagentloader.so'
-        libpath = agent_dir + 'lib64/libruxitagentloader.so' unless File.file?(libpath)
-        libpath
+        technologies = JSON.parse(File.read(@droplet.sandbox + 'manifest.json'))['technologies']
+        java_binaries = technologies['java']['linux-x86-64']
+        loader = java_binaries.find { |bin| bin['binarytype'] == 'loader' }
+        @droplet.sandbox + loader['path']
       end
 
       def agent_download_url
-        credentials = @application.services.find_service(FILTER)['credentials']
+        credentials = service['credentials']
         download_uri = "#{api_base_url}/v1/deployment/installer/agent/unix/paas/latest?include=java&bitness=64&"
         download_uri += "Api-Token=#{credentials[APITOKEN]}"
         ['latest', download_uri]
       end
 
       def api_base_url
-        credentials = @application.services.find_service(FILTER)['credentials']
-        return credentials[APIURL] unless credentials[APIURL].nil?
-        base_url = credentials[ENDPOINT] || credentials[SERVER] || "https://#{tenant(credentials)}.live.dynatrace.com"
-        base_url = base_url.gsub('/communication', '').concat('/api').gsub(':8443', '').gsub(':443', '')
-        base_url
+        credentials = service['credentials']
+        credentials[APIURL] || "https://#{credentials[ENVIRONMENTID]}.live.dynatrace.com/api"
       end
 
       def application_id
@@ -143,26 +139,16 @@ module JavaBuildpack
         "#{@application.details['application_name']}_${CF_INSTANCE_INDEX}"
       end
 
-      def server(credentials)
-        given_endp = credentials[ENDPOINT] || credentials[SERVER] || "https://#{tenant(credentials)}.live.dynatrace.com"
-        supports_apitoken? ? server_from_api : given_endp
-      end
-
-      def server_from_api
-        endpoints = JSON.parse(File.read(@droplet.sandbox + 'manifest.json'))['communicationEndpoints']
-        endpoints.join('\;')
-      end
-
       def tenant(credentials)
         credentials[ENVIRONMENTID] || credentials[TENANT]
       end
 
-      def tenanttoken(credentials)
-        supports_apitoken? ? tenanttoken_from_api : credentials[TENANTTOKEN]
+      def tenanttoken
+        JSON.parse(File.read(@droplet.sandbox + 'manifest.json'))['tenantToken']
       end
 
-      def tenanttoken_from_api
-        JSON.parse(File.read(@droplet.sandbox + 'manifest.json'))['tenantToken']
+      def endpoints
+        '"' + JSON.parse(File.read(@droplet.sandbox + 'manifest.json'))['communicationEndpoints'].join(';') + '"'
       end
 
       def unpack_agent(root)

--- a/spec/fixtures/framework_dynatrace_one_agent/.java-buildpack/dynatrace_one_agent/manifest.json
+++ b/spec/fixtures/framework_dynatrace_one_agent/.java-buildpack/dynatrace_one_agent/manifest.json
@@ -1,4 +1,14 @@
 {
+  "technologies" : {
+    "java" : {
+      "linux-x86-64" : [
+          {
+            "path": "agent/lib64/liboneagentloader.so",
+            "binarytype" : "loader"
+          }
+      ]
+    }
+  },
   "version" : "1.105.147.20160930-153457",
   "tenantUUID" : "tenant",
   "tenantToken" : "token-from-file",

--- a/spec/java_buildpack/framework/dynatrace_one_agent_spec.rb
+++ b/spec/java_buildpack/framework/dynatrace_one_agent_spec.rb
@@ -21,21 +21,22 @@ require 'java_buildpack/util/tokenized_version'
 describe JavaBuildpack::Framework::DynatraceOneAgent do
   include_context 'component_helper'
 
-  it 'does not detect without dynatrace|ruxit-n/a service' do
+  it 'does not detect without dynatrace-n/a service' do
     expect(component.detect).to be_nil
   end
 
   context do
 
     before do
-      allow(services).to receive(:one_service?).with(/ruxit|dynatrace/, %w[environmentid tenant],
-                                                     %w[apitoken tenanttoken]).and_return(true)
-      allow(services).to receive(:find_service).and_return('credentials' => { 'apitoken' => 'test-apitoken',
-                                                                              'tenant'   => 'test-tenant',
-                                                                              'server'   => 'test-server' })
+      services << { 'name' => 'dynatrace-real', 'credentials' => { 'environmentid' => 'test-environmentid',
+                                                                   'apiurl' => 'test-apiurl',
+                                                                   'apitoken' => 'test-apitoken' } }
+      services << { 'name' => 'dynatrace-tags', 'credentials' => { 'tag:sometag' => 'tag-value',
+                                                                   'tag:othertag' => 'othertag-value' } }
+
       # allow(File).to receive(:file?).and_return(true)
       allow(application_cache).to receive(:get)
-        .with('test-server/api/v1/deployment/installer/agent/unix/paas/latest?include=java&bitness=64&' \
+        .with('test-apiurl/v1/deployment/installer/agent/unix/paas/latest?include=java&bitness=64&' \
         'Api-Token=test-apitoken')
         .and_yield(Pathname.new('spec/fixtures/stub-dynatrace-one-agent.zip').open, false)
     end
@@ -53,66 +54,42 @@ describe JavaBuildpack::Framework::DynatraceOneAgent do
       expect(sandbox + 'manifest.json').to exist
     end
 
-    it 'does update JAVA_OPTS with environmentid and apitoken',
+    it 'updates JAVA_OPTS with agent loader',
        app_fixture: 'framework_dynatrace_one_agent' do
-      allow(services).to receive(:find_service).and_return('credentials' => { 'environmentid' => 'test-tenant',
-                                                                              'apitoken'      => 'test-apitoken' })
+
       component.release
 
       expect(java_opts).to include('-agentpath:$PWD/.java-buildpack/dynatrace_one_agent/agent/lib64/' \
-      'liboneagentloader.so=server=https://endpoint1/communication\\;https://endpoint2/communication,' \
-      'tenant=test-tenant,tenanttoken=token-from-file')
-    end
-
-    it 'updates JAVA_OPTS with custom server and deprecated tenanttoken',
-       app_fixture: 'framework_dynatrace_one_agent' do
-      allow(services).to receive(:find_service).and_return('credentials' => { 'server'      => 'test-server',
-                                                                              'tenant'      => 'test-tenant',
-                                                                              'tenanttoken' => 'test-token' })
-      component.release
-
-      expect(java_opts).to include('-agentpath:$PWD/.java-buildpack/dynatrace_one_agent/agent/lib64/' \
-      'liboneagentloader.so=server=test-server,tenant=test-tenant,' \
-      'tenanttoken=test-token')
-    end
-
-    it 'updates JAVA_OPTS with custom server and apitoken',
-       app_fixture: 'framework_dynatrace_one_agent' do
-      allow(services).to receive(:find_service).and_return('credentials' => { 'server'        => 'test-server',
-                                                                              'environmentid' => 'test-tenant',
-                                                                              'apitoken'      => 'test-apitoken' })
-      component.release
-
-      expect(java_opts).to include('-agentpath:$PWD/.java-buildpack/dynatrace_one_agent/agent/lib64/' \
-      'liboneagentloader.so=server=https://endpoint1/communication\\;https://endpoint2/communication,' \
-      'tenant=test-tenant,tenanttoken=token-from-file')
+        'liboneagentloader.so')
     end
 
     it 'updates environment variables',
        app_fixture: 'framework_dynatrace_one_agent' do
-      allow(services).to receive(:find_service).and_return('credentials' => { 'environmentid'   => 'test-tenant',
-                                                                              'apitoken'        => 'test-apitoken' })
+
       component.release
 
-      expect(environment_variables).to include('RUXIT_APPLICATIONID=test-application-name')
-      expect(environment_variables).to include('RUXIT_HOST_ID=test-application-name_${CF_INSTANCE_INDEX}')
+      expect(environment_variables).to include('DT_APPLICATIONID=test-application-name')
+      expect(environment_variables).to include('DT_HOST_ID=test-application-name_${CF_INSTANCE_INDEX}')
+      expect(environment_variables).to include('DT_TENANT=test-environmentid')
+      expect(environment_variables).to include('DT_TENANTTOKEN=token-from-file')
+      expect(environment_variables).to include('DT_CONNECTION_POINT=' \
+        '"https://endpoint1/communication;https://endpoint2/communication"')
     end
 
     context do
 
       let(:environment) do
-        { 'RUXIT_APPLICATIONID' => 'test-application-id',
-          'RUXIT_HOST_ID'       => 'test-host-id' }
+        { 'DT_APPLICATIONID' => 'test-application-id',
+          'DT_HOST_ID'       => 'test-host-id' }
       end
 
       it 'does not update environment variables if they exist',
          app_fixture: 'framework_dynatrace_one_agent' do
-        allow(services).to receive(:find_service).and_return('credentials' => { 'environmentid'   => 'test-tenant',
-                                                                                'apitoken'        => 'test-apitoken' })
+
         component.release
 
-        expect(environment_variables).not_to include(/RUXIT_APPLICATIONID/)
-        expect(environment_variables).not_to include(/RUXIT_HOST_ID/)
+        expect(environment_variables).not_to include(/DT_APPLICATIONID/)
+        expect(environment_variables).not_to include(/DT_HOST_ID/)
       end
 
     end


### PR DESCRIPTION
Things done:
* Service detection also takes the required credentials into account
* Removed deprecated integration option
* Determine agent loader location via manifest
* Renamed the environment variables from RUXIT_* to DT_*

Why?
The integration using "server", "tentanttoken", etc was deprecated quite some time ago and is now removed in favor of the "environmentid", "apitoken" (and optional "apiurl") integration option.
It is possible to define multiple services containing "dynatrace" (no "ruxit" anymore) in order to be able to attach application tags which are read by the agent (tests include multiple services). The only one service containing "environmentid" and "apitoken" is used for the agent integration. The integration is only done iff one service containing these credentials is present (just like before, but also working in release stage now).
Also the agent properties are now also read from environment variables. Instead of parameters on the java agent path.

I also have already contributed to other CF buildpacks and therefore have signed the CLA.