### PR TITLE
Dynatrace OneAgent integration skiperrors flag

### DIFF
--- a/docs/framework-dynatrace_one_agent.md
+++ b/docs/framework-dynatrace_one_agent.md
@@ -28,6 +28,7 @@ The credential payload of the service may contain the following entries:
 | `apitoken` | The token for integrating your Dynatrace environment with Cloud Foundry. You can find it in the deploy Dynatrace section within your environment.
 | `apiurl` | (Optional) The base URL of the Dynatrace API. If you are using Dynatrace Managed you will need to set this property to `https://<your-managed-server-url>/e/<environmentId>/api`. If you are using Dynatrace SaaS you don't need to set this property.
 | `environmentid` | Your Dynatrace environment ID is the unique identifier of your Dynatrace environment. You can find it in the deploy Dynatrace section within your environment.
+| `skiperrors` | (Optional) The errors during agent download are skipped and the injection is disabled. Use this option at your own risk. Possible values are 'true' and 'false'. This option is disabled by default!
 
 ## Configuration
 For general information on configuring the buildpack, including how to specify configuration values through environment variables, refer to [Configuration and Extension][].


### PR DESCRIPTION
Hi,

we got the request to include a "skiperrors" flag from some of our large customers which have the Dynatrace Managed (on premise) solution installed on their servers and use it to monitor their CF applications.

Basically the thing is that they wanted to be able to skip download errors which might occur during upgrades, etc. The main thing here is that we only give the possibility to skip monitoring in case the download fails. It will never be enabled by default. Additionally there are a lot of warnings in to signalize the user that this should only be used if there is no other possibility for the customer and also he does not care about monitoring being disabled for some time. It lies in the customers responsibility to NOT use the option if there are critical use cases based on the monitoring.

We also have the same mechanism in on the nodejs-buildpack and would like to streamline all our integrations to have the same options available.

Best,
stipx
