### PR TITLE
Overops support improvement

### DIFF
--- a/config/components.yml
+++ b/config/components.yml
@@ -39,6 +39,7 @@ jres:
 # The JavaOpts is last in order to allow any user-defined JAVA_OPTS to override contributions from earlier frameworks
 frameworks:
   - "JavaBuildpack::Framework::MultiBuildpack"
+  - "JavaBuildpack::Framework::TakipiAgent"
   - "JavaBuildpack::Framework::AppDynamicsAgent"
   - "JavaBuildpack::Framework::AspectjWeaverAgent"
   - "JavaBuildpack::Framework::ClientCertificateMapper"
@@ -63,6 +64,5 @@ frameworks:
   - "JavaBuildpack::Framework::SpringAutoReconfiguration"
   - "JavaBuildpack::Framework::SpringInsight"
   - "JavaBuildpack::Framework::YourKitProfiler"
-  - "JavaBuildpack::Framework::TakipiAgent"
   - "JavaBuildpack::Framework::JavaSecurity"
   - "JavaBuildpack::Framework::JavaOpts"

--- a/docs/framework-takipi_agent.md
+++ b/docs/framework-takipi_agent.md
@@ -41,6 +41,10 @@ Currently, you can get the Takipi agent logs using `cf files` command:
 cf files app_name app/.java-buildpack/takipi_agent/log/
 ```
 
+## Troubleshooting
+
+If your container is running out of memory and exited with status 137, then you should setup and use a remote collector as explained in the `User-Provided Service` above section.
+
 [`config/takipi_agent.yml`]: ../config/takipi_agent.yml
 [Configuration and Extension]: ../README.md#configuration-and-extension
 [repositories]: extending-repositories.md


### PR DESCRIPTION
Add a troubleshooting section related to issue #534 

Loading the Takipi agent after NewRelic or AppDynamics will slow the app startup and could cause a timeout. Now the OverOps agent is loading before any APM.
