### PR TITLE
add support for Tomcat internalProxies configuration

### DIFF
--- a/config/tomcat.yml
+++ b/config/tomcat.yml
@@ -18,11 +18,11 @@
 tomcat:
   version: 8.5.+
   repository_root: "{default.repository.root}/tomcat"
-  context_path: 
+  context_path:
   external_configuration_enabled: false
 external_configuration:
   version: 1.+
-  repository_root: 
+  repository_root:
 lifecycle_support:
   version: 3.+
   repository_root: "{default.repository.root}/tomcat-lifecycle-support"
@@ -42,3 +42,7 @@ redis_store:
 geode_store:
   version: 0.+
   repository_root: https://repo.spring.io/ext-release-local/geode-store
+internal_proxies:
+  version: 0.+
+  repository_root:
+  regex:

--- a/lib/java_buildpack/container/tomcat.rb
+++ b/lib/java_buildpack/container/tomcat.rb
@@ -22,6 +22,7 @@ require 'java_buildpack/container/tomcat/tomcat_external_configuration'
 require 'java_buildpack/container/tomcat/tomcat_geode_store'
 require 'java_buildpack/container/tomcat/tomcat_insight_support'
 require 'java_buildpack/container/tomcat/tomcat_instance'
+require 'java_buildpack/container/tomcat/tomcat_internal_proxies'
 require 'java_buildpack/container/tomcat/tomcat_lifecycle_support'
 require 'java_buildpack/container/tomcat/tomcat_logging_support'
 require 'java_buildpack/container/tomcat/tomcat_redis_store'
@@ -58,6 +59,7 @@ module JavaBuildpack
           TomcatLifecycleSupport.new(sub_configuration_context(context, 'lifecycle_support')),
           TomcatLoggingSupport.new(sub_configuration_context(context, 'logging_support')),
           TomcatRedisStore.new(sub_configuration_context(context, 'redis_store')),
+          TomcatInternalProxies.new(sub_configuration_context(context, 'internal_proxies')),
           TomcatInsightSupport.new(context)
         ]
 

--- a/lib/java_buildpack/container/tomcat/tomcat_internal_proxies.rb
+++ b/lib/java_buildpack/container/tomcat/tomcat_internal_proxies.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+# Cloud Foundry Java Buildpack
+# Copyright 2013-2018 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'java_buildpack/component/versioned_dependency_component'
+require 'java_buildpack/container'
+require 'java_buildpack/container/tomcat/tomcat_utils'
+require 'java_buildpack/logging/logger_factory'
+
+module JavaBuildpack
+  module Container
+
+    # Encapsulates the detect, compile, and release functionality for Tomcat Internal Proxies support.
+    class TomcatInternalProxies < JavaBuildpack::Component::BaseComponent
+      include JavaBuildpack::Container
+
+      # (see JavaBuildpack::Component::BaseComponent#detect)
+      def detect; end
+
+      # (see JavaBuildpack::Component::BaseComponent#compile)
+      def compile
+        return unless supports?
+
+        mutate_server if @configuration.key?('regex')
+      end
+
+      # (see JavaBuildpack::Component::BaseComponent#release)
+      def release; end
+
+      protected
+
+      # (see JavaBuildpack::Component::VersionedDependencyComponent#supports?)
+      def supports?
+        true
+      end
+
+      private
+
+      def add_proxies(server)
+        valve = REXML::XPath.match(server, '//Valve[@className="org.apache.catalina.valves.RemoteIpValve"]').first
+        valve.add_attribute 'internalProxies', @configuration['regex']
+      end
+
+      def formatter
+        formatter         = REXML::Formatters::Pretty.new(4)
+        formatter.compact = true
+        formatter
+      end
+
+      def mutate_server
+        puts '       Adding Internal Proxies'
+
+        document = read_xml server_xml
+        server   = REXML::XPath.match(document, '/Server').first
+
+        add_proxies server
+
+        write_xml server_xml, document
+      end
+
+    end
+
+  end
+end

--- a/spec/fixtures/container_tomcat_internal_proxies/.java-buildpack/tomcat/conf/server.xml
+++ b/spec/fixtures/container_tomcat_internal_proxies/.java-buildpack/tomcat/conf/server.xml
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  ~ Copyright 2013-2018 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Server port='-1'>
+    <Service name='Catalina'>
+        <Connector port='${http.port}' bindOnInit='false' connectionTimeout='20000'/>
+        <Engine defaultHost='localhost' name='Catalina'>
+            <Valve className='org.apache.catalina.valves.RemoteIpValve' protocolHeader='x-forwarded-proto'/>
+            <Valve className='org.cloudfoundry.tomcat.logging.access.CloudFoundryAccessLoggingValve' pattern='[ACCESS] %{org.apache.catalina.AccessLog.RemoteAddr}r %l %t %D %F %B %S vcap_request_id:%{X-Vcap-Request-Id}i' enabled='${access.logging.enabled}'/>
+            <Host name='localhost' failCtxIfServletStartFails='true'>
+                <Listener className='org.cloudfoundry.tomcat.lifecycle.ApplicationStartupFailureDetectingLifecycleListener'/>
+            </Host>
+        </Engine>
+    </Service>
+</Server>

--- a/spec/fixtures/container_tomcat_internal_proxies_server_after.xml
+++ b/spec/fixtures/container_tomcat_internal_proxies_server_after.xml
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  ~ Copyright 2013-2018 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Server port='-1'>
+    <Service name='Catalina'>
+        <Connector port='${http.port}' bindOnInit='false' connectionTimeout='20000'/>
+        <Engine defaultHost='localhost' name='Catalina'>
+            <Valve className='org.apache.catalina.valves.RemoteIpValve' protocolHeader='x-forwarded-proto' internalProxies='1.2.3.4'/>
+            <Valve className='org.cloudfoundry.tomcat.logging.access.CloudFoundryAccessLoggingValve' pattern='[ACCESS] %{org.apache.catalina.AccessLog.RemoteAddr}r %l %t %D %F %B %S vcap_request_id:%{X-Vcap-Request-Id}i' enabled='${access.logging.enabled}'/>
+            <Host name='localhost' failCtxIfServletStartFails='true'>
+                <Listener className='org.cloudfoundry.tomcat.lifecycle.ApplicationStartupFailureDetectingLifecycleListener'/>
+            </Host>
+        </Engine>
+    </Service>
+</Server>

--- a/spec/fixtures/container_tomcat_internal_proxies_server_unmodified.xml
+++ b/spec/fixtures/container_tomcat_internal_proxies_server_unmodified.xml
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  ~ Copyright 2013-2018 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Server port='-1'>
+    <Service name='Catalina'>
+        <Connector port='${http.port}' bindOnInit='false' connectionTimeout='20000'/>
+        <Engine defaultHost='localhost' name='Catalina'>
+            <Valve className='org.apache.catalina.valves.RemoteIpValve' protocolHeader='x-forwarded-proto'/>
+            <Valve className='org.cloudfoundry.tomcat.logging.access.CloudFoundryAccessLoggingValve' pattern='[ACCESS] %{org.apache.catalina.AccessLog.RemoteAddr}r %l %t %D %F %B %S vcap_request_id:%{X-Vcap-Request-Id}i' enabled='${access.logging.enabled}'/>
+            <Host name='localhost' failCtxIfServletStartFails='true'>
+                <Listener className='org.cloudfoundry.tomcat.lifecycle.ApplicationStartupFailureDetectingLifecycleListener'/>
+            </Host>
+        </Engine>
+    </Service>
+</Server>

--- a/spec/java_buildpack/container/tomcat/tomcat_internal_proxies_spec.rb
+++ b/spec/java_buildpack/container/tomcat/tomcat_internal_proxies_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Cloud Foundry Java Buildpack
+# Copyright 2013-2018 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'component_helper'
+require 'java_buildpack/container/tomcat/tomcat_internal_proxies'
+
+describe JavaBuildpack::Container::TomcatInternalProxies do
+  include_context 'with component help'
+
+  let(:component_id) { 'tomcat' }
+
+  context 'when no internal proxies regex is specified' do
+
+    it 'does not mutate server.xml',
+       app_fixture: 'container_tomcat_internal_proxies' do
+      component.compile
+
+      expect((sandbox + 'conf/server.xml').read)
+        .to eq(Pathname.new('spec/fixtures/container_tomcat_internal_proxies_server_unmodified.xml').read)
+    end
+
+  end
+
+  context 'when internal proxies regex is specified' do
+
+    let(:configuration) do
+      { 'regex' => '1.2.3.4' }
+    end
+
+    it 'mutates server.xml',
+       app_fixture: 'container_tomcat_internal_proxies' do
+      component.compile
+
+      expect((sandbox + 'conf/server.xml').read)
+        .to eq(Pathname.new('spec/fixtures/container_tomcat_internal_proxies_server_after.xml').read)
+    end
+
+  end
+
+end

--- a/spec/java_buildpack/container/tomcat_spec.rb
+++ b/spec/java_buildpack/container/tomcat_spec.rb
@@ -23,6 +23,7 @@ require 'java_buildpack/container/tomcat/tomcat_access_logging_support'
 require 'java_buildpack/container/tomcat/tomcat_geode_store'
 require 'java_buildpack/container/tomcat/tomcat_insight_support'
 require 'java_buildpack/container/tomcat/tomcat_instance'
+require 'java_buildpack/container/tomcat/tomcat_internal_proxies'
 require 'java_buildpack/container/tomcat/tomcat_lifecycle_support'
 require 'java_buildpack/container/tomcat/tomcat_logging_support'
 require 'java_buildpack/container/tomcat/tomcat_redis_store'
@@ -39,6 +40,7 @@ describe JavaBuildpack::Container::Tomcat do
       'lifecycle_support'      => lifecycle_support_configuration,
       'logging_support'        => logging_support_configuration,
       'redis_store'            => redis_store_configuration,
+      'internal_proxies'       => internal_proxies_configuration,
       'tomcat'                 => tomcat_configuration }
   end
 
@@ -55,6 +57,8 @@ describe JavaBuildpack::Container::Tomcat do
   let(:tomcat_configuration) { { 'external_configuration_enabled' => false } }
 
   let(:tomcat_external_configuration) { instance_double('tomcat_external_configuration') }
+
+  let(:internal_proxies_configuration) { instance_double('internal_proxies_configuration') }
 
   it 'detects WEB-INF',
      app_fixture: 'container_tomcat' do
@@ -88,6 +92,8 @@ describe JavaBuildpack::Container::Tomcat do
       .to receive(:new).with(sub_configuration_context(logging_support_configuration))
     allow(JavaBuildpack::Container::TomcatRedisStore)
       .to receive(:new).with(sub_configuration_context(redis_store_configuration))
+    allow(JavaBuildpack::Container::TomcatInternalProxies)
+      .to receive(:new).with(sub_configuration_context(internal_proxies_configuration))
 
     component.sub_components context
   end


### PR DESCRIPTION
Allows to configure internal proxies for Tomcat.

Signed-off-by: Fabio Berchtold <fabio.berchtold@swisscom.com>