### PR TITLE
Add support for agentManager.credential property

### DIFF
--- a/docs/framework-introscope_agent.md
+++ b/docs/framework-introscope_agent.md
@@ -23,9 +23,9 @@ The credential payload of the service may contain the following entries:
 
 | Name | Description
 | ---- | -----------
-| `agent-name` | (Optional) The name that should be given to this instance of the Introscope agent
 | `url` | The url of the Introscope Enterprise Manager server
-
+| `credential`| (Optional) The credential that is used to connect to the Enterprise Manager server
+| `agent_name` | (Optional) The name that should be given to this instance of the Introscope agent
 
 To provide more complex values such as the `agent-name`, using the interactive mode when creating a user-provided service will manage the character escaping automatically. For example, the default `agent-name` could be set with a value of `agent-$(expr "$VCAP_APPLICATION" : '.*application_name[": ]*\([[:word:]]*\).*')` to calculate a value from the Cloud Foundry application name.
 

--- a/docs/framework-introscope_agent.md
+++ b/docs/framework-introscope_agent.md
@@ -23,11 +23,11 @@ The credential payload of the service may contain the following entries:
 
 | Name | Description
 | ---- | -----------
-| `url` | The url of the Introscope Enterprise Manager server
-| `credential`| (Optional) The credential that is used to connect to the Enterprise Manager server
 | `agent_name` | (Optional) The name that should be given to this instance of the Introscope agent
+| `credential`| (Optional) The credential that is used to connect to the Enterprise Manager server
+| `url` | The url of the Introscope Enterprise Manager server
 
-To provide more complex values such as the `agent-name`, using the interactive mode when creating a user-provided service will manage the character escaping automatically. For example, the default `agent-name` could be set with a value of `agent-$(expr "$VCAP_APPLICATION" : '.*application_name[": ]*\([[:word:]]*\).*')` to calculate a value from the Cloud Foundry application name.
+To provide more complex values such as the `agent_name`, using the interactive mode when creating a user-provided service will manage the character escaping automatically. For example, the default `agent_name` could be set with a value of `agent-$(expr "$VCAP_APPLICATION" : '.*application_name[": ]*\([[:word:]]*\).*')` to calculate a value from the Cloud Foundry application name.
 
 ## Configuration
 For general information on configuring the buildpack, including how to specify configuration values through environment variables, refer to [Configuration and Extension][].

--- a/lib/java_buildpack/framework/introscope_agent.rb
+++ b/lib/java_buildpack/framework/introscope_agent.rb
@@ -44,8 +44,7 @@ module JavaBuildpack
           .add_system_property('com.wily.introscope.agent.agentName', agent_name(credentials))
           .add_system_property('introscope.agent.defaultProcessName', default_process_name)
 
-        java_opts.add_system_property('agentManager.credential', credential(credentials)) unless
-        credential(credentials).nil?
+        java_opts.add_system_property('agentManager.credential', credential(credentials)) if credential(credentials)
         add_url(credentials, java_opts)
       end
 

--- a/lib/java_buildpack/framework/introscope_agent.rb
+++ b/lib/java_buildpack/framework/introscope_agent.rb
@@ -44,6 +44,8 @@ module JavaBuildpack
           .add_system_property('com.wily.introscope.agent.agentName', agent_name(credentials))
           .add_system_property('introscope.agent.defaultProcessName', default_process_name)
 
+        java_opts.add_system_property('agentManager.credential', credential(credentials)) unless
+        credential(credentials).nil?
         add_url(credentials, java_opts)
       end
 
@@ -92,7 +94,7 @@ module JavaBuildpack
       end
 
       def agent_name(credentials)
-        credentials['agent-name'] || @configuration['default_agent_name']
+        credentials['agent_name'] || @configuration['default_agent_name']
       end
 
       def agent_profile
@@ -118,6 +120,10 @@ module JavaBuildpack
 
       def url(credentials)
         credentials['url']
+      end
+
+      def credential(credentials)
+        credentials['credential']
       end
     end
   end

--- a/spec/java_buildpack/framework/introscope_agent_spec.rb
+++ b/spec/java_buildpack/framework/introscope_agent_spec.rb
@@ -56,9 +56,9 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
     end
 
     context do
-      let(:credentials) { { 'agent-name' => 'another-test-agent-name', 'url' => 'default-host:5001' } }
+      let(:credentials) { { 'agent_name' => 'another-test-agent-name', 'url' => 'default-host:5001' } }
 
-      it 'adds agent-name from credentials to JAVA_OPTS if specified' do
+      it 'adds agent_name from credentials to JAVA_OPTS if specified' do
         component.release
 
         expect(java_opts).to include('-Dcom.wily.introscope.agent.agentName=another-test-agent-name')
@@ -157,5 +157,31 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
                                       '\'.*application_name[": ]*\\([A-Za-z0-9_-]*\\).*\')')
       end
     end
+
+    context do
+      let(:credentials) { { 'url' => 'https://test-host-name:8444', 'credential' => 'test-credential-cccf-88-ae' } }
+
+      it 'sets the url and also the agent manager credential' do
+        component.release
+
+        expect(java_opts).to include('-javaagent:$PWD/.java-buildpack/introscope_agent/Agent.jar')
+        expect(java_opts).to include('-Dcom.wily.introscope.agentProfile=$PWD/.java-buildpack/introscope_agent/core' \
+                                     '/config/IntroscopeAgent.profile')
+        expect(java_opts).to include('-Dintroscope.agent.defaultProcessName=test-application-name')
+        expect(java_opts).to include('-Dintroscope.agent.hostName=test-application-uri-0')
+
+        expect(java_opts).to include('-DagentManager.url.1=https://test-host-name:8444')
+        expect(java_opts).to include('-Dintroscope.agent.enterprisemanager.transport.tcp.host.DEFAULT=test-host-name')
+        expect(java_opts).to include('-Dintroscope.agent.enterprisemanager.transport.tcp.port.DEFAULT=8444')
+        expect(java_opts).to include('-Dintroscope.agent.enterprisemanager.transport.tcp.socketfactory.DEFAULT=' \
+                                     'com.wily.isengard.postofficehub.link.net.HttpsTunnelingSocketFactory')
+
+        expect(java_opts).to include('-Dcom.wily.introscope.agent.agentName=$(expr "$VCAP_APPLICATION" : ' \
+                                      '\'.*application_name[": ]*\\([A-Za-z0-9_-]*\\).*\')')
+        expect(java_opts).to include('-DagentManager.credential=test-credential-cccf-88-ae')
+
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Before this commit, the buildpack did not have support for the agentManager.credential property.
After this commit, a new, optional property is added to the buildpack. One more unit test was added and the corresponding doc was updated.