### PR TITLE
Check JAVA_OPTS for contrast.override.appname before using the settin…

### DIFF
--- a/lib/java_buildpack/framework/contrast_security_agent.rb
+++ b/lib/java_buildpack/framework/contrast_security_agent.rb
@@ -39,9 +39,9 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::BaseComponent#release)
       def release
+        @droplet.java_opts.add_system_property('contrast.override.appname', application_name) unless app_name_defined?
         @droplet.java_opts
                 .add_system_property('contrast.dir', '$TMPDIR')
-                .add_system_property('contrast.override.appname', application_name)
                 .add_preformatted_options("-javaagent:#{qualify_path(@droplet.sandbox + jar_name, @droplet.root)}=" \
                                           "#{qualify_path(contrast_config, @droplet.root)}")
       end
@@ -107,6 +107,10 @@ module JavaBuildpack
 
       def application_name
         @application.details['application_name'] || 'ROOT'
+      end
+
+      def app_name_defined?
+        @droplet.java_opts.as_env_var.include?('contrast.override.appname')
       end
 
       def contrast_config

--- a/spec/java_buildpack/framework/contrast_security_agent_spec.rb
+++ b/spec/java_buildpack/framework/contrast_security_agent_spec.rb
@@ -90,6 +90,7 @@ describe JavaBuildpack::Framework::ContrastSecurityAgent do
       java_opts.add_system_property('contrast.override.appname', 'NAME_ALREADY_OVERRIDDEN')
       component.release
       expect(java_opts).to include('-Dcontrast.override.appname=NAME_ALREADY_OVERRIDDEN')
+      expect(java_opts).to_not include('-Dcontrast.override.appname=test-application-name')
     end
 
   end

--- a/spec/java_buildpack/framework/contrast_security_agent_spec.rb
+++ b/spec/java_buildpack/framework/contrast_security_agent_spec.rb
@@ -86,6 +86,12 @@ describe JavaBuildpack::Framework::ContrastSecurityAgent do
       expect(sandbox + 'contrast.config').to exist
     end
 
+    it 'doesn\'t override app name if there is an existing appname' do
+      java_opts.add_system_property('contrast.override.appname', 'NAME_ALREADY_OVERRIDDEN')
+      component.release
+      expect(java_opts).to include('-Dcontrast.override.appname=NAME_ALREADY_OVERRIDDEN')
+    end
+
   end
 
 end


### PR DESCRIPTION
The `contrast_security_agent` framework was previously setting the 'contrast.override.appname option explicitly which was overriding any value that was provided by the user in the JAVA_OPTS env var.  

This checks the JAVA_OPTS env var for the 'contrast.override.appname' system property and if found it doesn't use the app name provided.