### PR TITLE
Update property names to be consistent with internal agent properties

### DIFF
--- a/docs/framework-introscope_agent.md
+++ b/docs/framework-introscope_agent.md
@@ -23,9 +23,9 @@ The credential payload of the service may contain the following entries:
 
 | Name | Description
 | ---- | -----------
-| `agent_name` | (Optional) The name that should be given to this instance of the Introscope agent
-| `credential`| (Optional) The credential that is used to connect to the Enterprise Manager server
-| `url` | The url of the Introscope Enterprise Manager server
+| `agent_name` | (Optional) The name that should be given to this instance of the Introscope agent.
+| `agent_manager_credential`| (Optional) The credential that is used to connect to the Enterprise Manager server.
+| `agent_manager_url` | The url of the Enterprise Manager server.
 
 To provide more complex values such as the `agent_name`, using the interactive mode when creating a user-provided service will manage the character escaping automatically. For example, the default `agent_name` could be set with a value of `agent-$(expr "$VCAP_APPLICATION" : '.*application_name[": ]*\([[:word:]]*\).*')` to calculate a value from the Cloud Foundry application name.
 

--- a/docs/framework-introscope_agent.md
+++ b/docs/framework-introscope_agent.md
@@ -24,8 +24,8 @@ The credential payload of the service may contain the following entries:
 | Name | Description
 | ---- | -----------
 | `agent_name` | (Optional) The name that should be given to this instance of the Introscope agent.
-| `agent_manager_credential`| (Optional) The credential that is used to connect to the Enterprise Manager server.
-| `agent_manager_url` | The url of the Enterprise Manager server.
+| `credential`| (Optional) <b> Deprecated </b> Please use the <b> "agent_manager_credential" </b> property instead. The credential that is used to connect to the Enterprise Manager server. 
+| `url` | <b> Deprecated </b> Please use the <b> "agent_manager_url" </b> property instead. The url of the Enterprise Manager server. 
 
 To provide more complex values such as the `agent_name`, using the interactive mode when creating a user-provided service will manage the character escaping automatically. For example, the default `agent_name` could be set with a value of `agent-$(expr "$VCAP_APPLICATION" : '.*application_name[": ]*\([[:word:]]*\).*')` to calculate a value from the Cloud Foundry application name.
 

--- a/lib/java_buildpack/framework/introscope_agent.rb
+++ b/lib/java_buildpack/framework/introscope_agent.rb
@@ -34,7 +34,7 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::BaseComponent#release)
       def release
-        credentials = @application.services.find_service(FILTER)['credentials']
+        credentials = @application.services.find_service(FILTER, ['agent_manager_url', 'url'])['credentials']
         java_opts   = @droplet.java_opts
 
         java_opts
@@ -52,7 +52,7 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::VersionedDependencyComponent#supports?)
       def supports?
-        @application.services.one_service? FILTER
+        @application.services.one_service? FILTER, ['agent_manager_url', 'url']
       end
 
       private

--- a/lib/java_buildpack/framework/introscope_agent.rb
+++ b/lib/java_buildpack/framework/introscope_agent.rb
@@ -34,7 +34,7 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::BaseComponent#release)
       def release
-        credentials = @application.services.find_service(FILTER, 'url')['credentials']
+        credentials = @application.services.find_service(FILTER)['credentials']
         java_opts   = @droplet.java_opts
 
         java_opts
@@ -44,7 +44,7 @@ module JavaBuildpack
           .add_system_property('com.wily.introscope.agent.agentName', agent_name(credentials))
           .add_system_property('introscope.agent.defaultProcessName', default_process_name)
 
-        java_opts.add_system_property('agentManager.credential', credential(credentials)) if credential(credentials)
+        java_opts.add_system_property('agentManager.credential', agent_manager_credential(credentials)) if agent_manager_credential(credentials)
         add_url(credentials, java_opts)
       end
 
@@ -52,7 +52,7 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::VersionedDependencyComponent#supports?)
       def supports?
-        @application.services.one_service? FILTER, 'url'
+        @application.services.one_service? FILTER, 'agent_manager_url'
       end
 
       private
@@ -70,7 +70,7 @@ module JavaBuildpack
       end
 
       def add_url(credentials, java_opts)
-        agent_manager = url(credentials)
+        agent_manager = agent_manager_url(credentials)
 
         host, port, socket_factory = parse_url(agent_manager)
         java_opts.add_system_property('agentManager.url.1', agent_manager)
@@ -117,12 +117,12 @@ module JavaBuildpack
         protocol_socket_factory[protocol] || protocol
       end
 
-      def url(credentials)
-        credentials['url']
+      def agent_manager_url(credentials)
+        credentials['agent_manager_url']
       end
 
-      def credential(credentials)
-        credentials['credential']
+      def agent_manager_credential(credentials)
+        credentials['agent_manager_credential']
       end
     end
   end

--- a/lib/java_buildpack/framework/introscope_agent.rb
+++ b/lib/java_buildpack/framework/introscope_agent.rb
@@ -52,7 +52,7 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::VersionedDependencyComponent#supports?)
       def supports?
-        @application.services.one_service? FILTER, 'agent_manager_url'
+        @application.services.one_service? FILTER
       end
 
       private
@@ -118,11 +118,11 @@ module JavaBuildpack
       end
 
       def agent_manager_url(credentials)
-        credentials['agent_manager_url']
+        credentials['agent_manager_url'] || credentials['url']
       end
 
       def agent_manager_credential(credentials)
-        credentials['agent_manager_credential']
+        credentials['agent_manager_credential'] || credentials['credential']
       end
     end
   end

--- a/spec/java_buildpack/framework/introscope_agent_spec.rb
+++ b/spec/java_buildpack/framework/introscope_agent_spec.rb
@@ -40,7 +40,7 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
     let(:credentials) { {} }
 
     before do
-      allow(services).to receive(:one_service?).with(/introscope/, 'url').and_return(true)
+      allow(services).to receive(:one_service?).with(/introscope/, 'agent_manager_url').and_return(true)
       allow(services).to receive(:find_service).and_return('credentials' => credentials)
     end
 
@@ -56,7 +56,7 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
     end
 
     context do
-      let(:credentials) { { 'agent_name' => 'another-test-agent-name', 'url' => 'default-host:5001' } }
+      let(:credentials) { { 'agent_name' => 'another-test-agent-name', 'agent_manager_url' => 'default-host:5001' } }
 
       it 'adds agent_name from credentials to JAVA_OPTS if specified' do
         component.release
@@ -67,9 +67,9 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
 
     context do
 
-      let(:credentials) { { 'url' => 'test-host-name:5001' } }
+      let(:credentials) { { 'agent_manager_url' => 'test-host-name:5001' } }
 
-      it 'parses the url and sets host port and default socket factory' do
+      it 'parses the agent_manager_url and sets host port and default socket factory' do
         component.release
 
         expect(java_opts).to include('-javaagent:$PWD/.java-buildpack/introscope_agent/Agent.jar')
@@ -90,9 +90,9 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
     end
 
     context do
-      let(:credentials) { { 'url' => 'ssl://test-host-name:5443' } }
+      let(:credentials) { { 'agent_manager_url' => 'ssl://test-host-name:5443' } }
 
-      it 'parses the url and sets host, port, and ssl socket factory' do
+      it 'parses the agent_manager_url and sets host, port, and ssl socket factory' do
         component.release
 
         expect(java_opts).to include('-javaagent:$PWD/.java-buildpack/introscope_agent/Agent.jar')
@@ -113,9 +113,9 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
     end
 
     context do
-      let(:credentials) { { 'url' => 'http://test-host-name:8081' } }
+      let(:credentials) { { 'agent_manager_url' => 'http://test-host-name:8081' } }
 
-      it 'parses the url and sets host, port, and http socket factory' do
+      it 'parses the agent_manager_url and sets host, port, and http socket factory' do
         component.release
 
         expect(java_opts).to include('-javaagent:$PWD/.java-buildpack/introscope_agent/Agent.jar')
@@ -136,9 +136,9 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
     end
 
     context do
-      let(:credentials) { { 'url' => 'https://test-host-name:8444' } }
+      let(:credentials) { { 'agent_manager_url' => 'https://test-host-name:8444' } }
 
-      it 'parses the url and sets host, port, and https socket factory' do
+      it 'parses the agent_manager_url and sets host, port, and https socket factory' do
         component.release
 
         expect(java_opts).to include('-javaagent:$PWD/.java-buildpack/introscope_agent/Agent.jar')
@@ -159,9 +159,9 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
     end
 
     context do
-      let(:credentials) { { 'url' => 'https://test-host-name:8444', 'credential' => 'test-credential-cccf-88-ae' } }
+      let(:credentials) { { 'agent_manager_url' => 'https://test-host-name:8444', 'agent_manager_credential' => 'test-credential-cccf-88-ae' } }
 
-      it 'sets the url and also the agent manager credential' do
+      it 'sets the agent_manager_url and also the agent_manager_credential' do
         component.release
 
         expect(java_opts).to include('-javaagent:$PWD/.java-buildpack/introscope_agent/Agent.jar')

--- a/spec/java_buildpack/framework/introscope_agent_spec.rb
+++ b/spec/java_buildpack/framework/introscope_agent_spec.rb
@@ -40,7 +40,7 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
     let(:credentials) { {} }
 
     before do
-      allow(services).to receive(:one_service?).with(/introscope/, 'agent_manager_url').and_return(true)
+      allow(services).to receive(:one_service?).with(/introscope/).and_return(true)
       allow(services).to receive(:find_service).and_return('credentials' => credentials)
     end
 

--- a/spec/java_buildpack/framework/introscope_agent_spec.rb
+++ b/spec/java_buildpack/framework/introscope_agent_spec.rb
@@ -40,7 +40,7 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
     let(:credentials) { {} }
 
     before do
-      allow(services).to receive(:one_service?).with(/introscope/).and_return(true)
+      allow(services).to receive(:one_service?).with(/introscope/, ['agent_manager_url', 'url']).and_return(true)
       allow(services).to receive(:find_service).and_return('credentials' => credentials)
     end
 
@@ -183,5 +183,80 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
       end
     end
 
+    # the three test cases below are for backwards compatibility between old and new credential properties
+    context do
+      let(:credentials) { { 'url' => 'test-host-name:5001', 'agent_manager_credential' => 'test-credential-cccf-88-ae' } }
+
+      it 'sets the agent_manager_url and also the agent_manager_credential' do
+        component.release
+
+        expect(java_opts).to include('-javaagent:$PWD/.java-buildpack/introscope_agent/Agent.jar')
+        expect(java_opts).to include('-Dcom.wily.introscope.agentProfile=$PWD/.java-buildpack/introscope_agent/core' \
+                                     '/config/IntroscopeAgent.profile')
+        expect(java_opts).to include('-Dintroscope.agent.defaultProcessName=test-application-name')
+        expect(java_opts).to include('-Dintroscope.agent.hostName=test-application-uri-0')
+
+        expect(java_opts).to include('-DagentManager.url.1=test-host-name:5001')
+        expect(java_opts).to include('-Dintroscope.agent.enterprisemanager.transport.tcp.host.DEFAULT=test-host-name')
+        expect(java_opts).to include('-Dintroscope.agent.enterprisemanager.transport.tcp.port.DEFAULT=5001')
+        expect(java_opts).to include('-Dintroscope.agent.enterprisemanager.transport.tcp.socketfactory.DEFAULT=' \
+                                     'com.wily.isengard.postofficehub.link.net.DefaultSocketFactory')
+
+        expect(java_opts).to include('-Dcom.wily.introscope.agent.agentName=$(expr "$VCAP_APPLICATION" : ' \
+                                      '\'.*application_name[": ]*\\([A-Za-z0-9_-]*\\).*\')')
+        expect(java_opts).to include('-DagentManager.credential=test-credential-cccf-88-ae')
+
+      end
+    end
+
+    context do
+      let(:credentials) { { 'url' => 'test-host-name:5001', 'credential' => 'test-credential-cccf-88-ae' } }
+
+      it 'sets the agent_manager_url and also the agent_manager_credential' do
+        component.release
+
+        expect(java_opts).to include('-javaagent:$PWD/.java-buildpack/introscope_agent/Agent.jar')
+        expect(java_opts).to include('-Dcom.wily.introscope.agentProfile=$PWD/.java-buildpack/introscope_agent/core' \
+                                     '/config/IntroscopeAgent.profile')
+        expect(java_opts).to include('-Dintroscope.agent.defaultProcessName=test-application-name')
+        expect(java_opts).to include('-Dintroscope.agent.hostName=test-application-uri-0')
+
+        expect(java_opts).to include('-DagentManager.url.1=test-host-name:5001')
+        expect(java_opts).to include('-Dintroscope.agent.enterprisemanager.transport.tcp.host.DEFAULT=test-host-name')
+        expect(java_opts).to include('-Dintroscope.agent.enterprisemanager.transport.tcp.port.DEFAULT=5001')
+        expect(java_opts).to include('-Dintroscope.agent.enterprisemanager.transport.tcp.socketfactory.DEFAULT=' \
+                                     'com.wily.isengard.postofficehub.link.net.DefaultSocketFactory')
+
+        expect(java_opts).to include('-Dcom.wily.introscope.agent.agentName=$(expr "$VCAP_APPLICATION" : ' \
+                                      '\'.*application_name[": ]*\\([A-Za-z0-9_-]*\\).*\')')
+        expect(java_opts).to include('-DagentManager.credential=test-credential-cccf-88-ae')
+
+      end
+    end
+
+    context do
+      let(:credentials) { { 'agent_manager_url' => 'test-host-name:5001', 'credential' => 'test-credential-cccf-88-ae' } }
+
+      it 'sets the agent_manager_url and also the agent_manager_credential' do
+        component.release
+
+        expect(java_opts).to include('-javaagent:$PWD/.java-buildpack/introscope_agent/Agent.jar')
+        expect(java_opts).to include('-Dcom.wily.introscope.agentProfile=$PWD/.java-buildpack/introscope_agent/core' \
+                                     '/config/IntroscopeAgent.profile')
+        expect(java_opts).to include('-Dintroscope.agent.defaultProcessName=test-application-name')
+        expect(java_opts).to include('-Dintroscope.agent.hostName=test-application-uri-0')
+
+        expect(java_opts).to include('-DagentManager.url.1=test-host-name:5001')
+        expect(java_opts).to include('-Dintroscope.agent.enterprisemanager.transport.tcp.host.DEFAULT=test-host-name')
+        expect(java_opts).to include('-Dintroscope.agent.enterprisemanager.transport.tcp.port.DEFAULT=5001')
+        expect(java_opts).to include('-Dintroscope.agent.enterprisemanager.transport.tcp.socketfactory.DEFAULT=' \
+                                     'com.wily.isengard.postofficehub.link.net.DefaultSocketFactory')
+
+        expect(java_opts).to include('-Dcom.wily.introscope.agent.agentName=$(expr "$VCAP_APPLICATION" : ' \
+                                      '\'.*application_name[": ]*\\([A-Za-z0-9_-]*\\).*\')')
+        expect(java_opts).to include('-DagentManager.credential=test-credential-cccf-88-ae')
+
+      end
+    end
   end
 end


### PR DESCRIPTION
Before this commit, property names were inconsistent and did not convey the right information to the user. After this commit, the property names are in tandem with internal names.