### PR TITLE
Adding support for TCPKeepAlive config setting in Luna Security Provider

### DIFF
--- a/config/luna_security_provider.yml
+++ b/config/luna_security_provider.yml
@@ -19,3 +19,4 @@ version: 6.+
 repository_root: http://files.cf-hsm.io/luna-installer
 ha_logging_enabled: true
 logging_enabled: false
+tcp_keep_alive_enabled: false

--- a/docs/framework-luna_security_provider.md
+++ b/docs/framework-luna_security_provider.md
@@ -93,6 +93,7 @@ The framework can be configured by modifying the [`config/luna_security_provider
 | ---- | -----------
 | `ha_logging_enabled` | Whether to enable HA logging for the Luna Security Provider.  Defaults to `true`.
 | `logging_enabled` | Whether to enable the logging wrapper for the Luna Security Provider.  Defaults to `false`.
+| `tcp_keep_alive_enabled` | Whether to enable the client TCP keep alive setting for the Luna Security Provider.  Defaults to `false`.
 | `repository_root` | The URL of the Luna Security Provider repository index ([details][repositories]).
 | `version` | Version of the Luna Security Provider to use.
 

--- a/lib/java_buildpack/framework/luna_security_provider.rb
+++ b/lib/java_buildpack/framework/luna_security_provider.rb
@@ -113,6 +113,10 @@ module JavaBuildpack
         @configuration['ha_logging_enabled']
       end
 
+      def tcp_keep_alive
+        @configuration['tcp_keep_alive_enabled'] ? 1 : 0
+      end
+
       def padded_index(index)
         index.to_s.rjust(2, '0')
       end
@@ -223,6 +227,7 @@ module JavaBuildpack
         f.write <<~CLIENT
 
           LunaSA Client = {
+            TCPKeepAlive = #{tcp_keep_alive};
             NetClient = 1;
 
             ClientCertFile    = #{relative(client_certificate)};

--- a/spec/fixtures/framework_luna_security_provider_logging/Chrystoki.conf
+++ b/spec/fixtures/framework_luna_security_provider_logging/Chrystoki.conf
@@ -25,6 +25,7 @@ CkLog2 = {
 }
 
 LunaSA Client = {
+  TCPKeepAlive = 0;
   NetClient = 1;
 
   ClientCertFile    = .java-buildpack/luna_security_provider/client-certificate.pem;

--- a/spec/fixtures/framework_luna_security_provider_tcp_keep_alive/Chrystoki.conf
+++ b/spec/fixtures/framework_luna_security_provider_tcp_keep_alive/Chrystoki.conf
@@ -13,11 +13,19 @@ Misc = {
 }
 
 Chrystoki2 = {
-  LibUNIX64 = .java-buildpack/luna_security_provider/libs/64/libCryptoki2.so;
+  LibUNIX64 = .java-buildpack/luna_security_provider/libs/64/libcklog2.so;
+}
+
+CkLog2 = {
+  Enabled      = 1;
+  LibUNIX64    = .java-buildpack/luna_security_provider/libs/64/libCryptoki2.so;
+  LoggingMask  = ALL_FUNC;
+  LogToStreams = 1;
+  NewFormat    = 1;
 }
 
 LunaSA Client = {
-  TCPKeepAlive = 0;
+  TCPKeepAlive = 1;
   NetClient = 1;
 
   ClientCertFile    = .java-buildpack/luna_security_provider/client-certificate.pem;
@@ -50,6 +58,8 @@ HAConfiguration = {
   AutoReconnectInterval = 60;
   HAOnly = 1;
   reconnAtt = -1;
+haLogStatus = enabled;
+haLogToStdout = enabled;
 }
 
 HASynchronize = {

--- a/spec/fixtures/framework_luna_security_provider_tcp_keep_alive/client-certificate.pem
+++ b/spec/fixtures/framework_luna_security_provider_tcp_keep_alive/client-certificate.pem
@@ -1,0 +1,3 @@
+-----BEGIN CERTIFICATE-----
+test-client-cert
+-----END CERTIFICATE-----

--- a/spec/fixtures/framework_luna_security_provider_tcp_keep_alive/client-private-key.pem
+++ b/spec/fixtures/framework_luna_security_provider_tcp_keep_alive/client-private-key.pem
@@ -1,0 +1,3 @@
+-----BEGIN RSA PRIVATE KEY-----
+test-client-private-key
+-----END RSA PRIVATE KEY-----

--- a/spec/fixtures/framework_luna_security_provider_tcp_keep_alive/server-certificates.pem
+++ b/spec/fixtures/framework_luna_security_provider_tcp_keep_alive/server-certificates.pem
@@ -1,0 +1,6 @@
+-----BEGIN CERTIFICATE-----
+test-server-1-cert
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+test-server-2-cert
+-----END CERTIFICATE-----

--- a/spec/java_buildpack/framework/luna_security_provider_spec.rb
+++ b/spec/java_buildpack/framework/luna_security_provider_spec.rb
@@ -159,7 +159,13 @@ describe JavaBuildpack::Framework::LunaSecurityProvider do
     end
 
     context do
-      let(:configuration) { { 'logging_enabled' => true, 'ha_logging_enabled' => true } }
+      let(:configuration) do
+        {
+          'logging_enabled' => true,
+          'ha_logging_enabled' => true,
+          'tcp_keep_alive_enabled' => false
+        }
+      end
 
       it 'writes configuration',
          cache_fixture: 'stub-luna-security-provider.tar' do
@@ -169,6 +175,26 @@ describe JavaBuildpack::Framework::LunaSecurityProvider do
         expect(sandbox + 'Chrystoki.conf').to exist
         check_file_contents(sandbox + 'Chrystoki.conf',
                             'spec/fixtures/framework_luna_security_provider_logging/Chrystoki.conf')
+      end
+    end
+
+    context do
+      let(:configuration) do
+        {
+          'logging_enabled' => true,
+          'ha_logging_enabled' => true,
+          'tcp_keep_alive_enabled' => true
+        }
+      end
+
+      it 'writes configuration with client tcp keep alive',
+         cache_fixture: 'stub-luna-security-provider.tar' do
+
+        component.compile
+
+        expect(sandbox + 'Chrystoki.conf').to exist
+        check_file_contents(sandbox + 'Chrystoki.conf',
+                            'spec/fixtures/framework_luna_security_provider_tcp_keep_alive/Chrystoki.conf')
       end
     end
 


### PR DESCRIPTION
This enhancement supports configuring the TCPKeepAlive setting in Luna
Security Provider.  Configuration is done by setting the
tcp_keep_alive_enabled configuration parameter to true of false (default
is false) which sets the TCPKeelAlive setting in the Chrystoki.conf to 0 or 1 (0 false, 1 true).  Default behavior sets the TCPKeepAlive Luna client parameter
to 0 which is the default setting if the paramter is not present in the
Chrystoki.conf file.

A more complete description of the issue can be found in the submitting issue in GitHub tracker.  More information is also available on cf-def discussion board:  https://lists.cloudfoundry.org/g/cf-dev/topic/proposal_network_connection/18127295

Issue:  #584 