### PR TITLE
Update introscope agent process name property

### DIFF
--- a/docs/framework-introscope_agent.md
+++ b/docs/framework-introscope_agent.md
@@ -23,7 +23,7 @@ The credential payload of the service may contain the following entries:
 
 | Name | Description
 | ---- | -----------
-|`agent_process_name`| (Optional) The name that is specified for the agent process. If not specified, default value is the application name.
+|`agent_defaultProcessName`| (Optional) The name that is specified for the agent process. If not specified, default value is the application name.
 | `agent_manager_credential` | (Optional) The credential that is used to connect to the Enterprise Manager server
 | `agent_manager_url` | The url of the Enterprise Manager server
 | `agent_name` | (Optional) The name that should be given to this instance of the Introscope agent

--- a/docs/framework-introscope_agent.md
+++ b/docs/framework-introscope_agent.md
@@ -23,6 +23,7 @@ The credential payload of the service may contain the following entries:
 
 | Name | Description
 | ---- | -----------
+|`agent_process_name`| (Optional) The name that is specified for the agent process. If not specified, default value is the application name.
 | `agent_manager_credential` | (Optional) The credential that is used to connect to the Enterprise Manager server
 | `agent_manager_url` | The url of the Enterprise Manager server
 | `agent_name` | (Optional) The name that should be given to this instance of the Introscope agent

--- a/lib/java_buildpack/framework/introscope_agent.rb
+++ b/lib/java_buildpack/framework/introscope_agent.rb
@@ -42,7 +42,7 @@ module JavaBuildpack
           .add_system_property('com.wily.introscope.agentProfile', agent_profile)
           .add_system_property('introscope.agent.hostName', agent_host_name)
           .add_system_property('com.wily.introscope.agent.agentName', agent_name(credentials))
-          .add_system_property('introscope.agent.defaultProcessName', default_process_name)
+          .add_system_property('introscope.agent.defaultProcessName', default_process_name(credentials))
 
         if agent_manager_credential(credentials)
           java_opts.add_system_property('agentManager.credential', agent_manager_credential(credentials))
@@ -103,8 +103,8 @@ module JavaBuildpack
         @droplet.sandbox + 'core/config/IntroscopeAgent.profile'
       end
 
-      def default_process_name
-        @application.details['application_name']
+      def default_process_name(credentials)
+        credentials['agent_process_name'] || @application.details['application_name']
       end
 
       def protocol_mapping(protocol)

--- a/lib/java_buildpack/framework/introscope_agent.rb
+++ b/lib/java_buildpack/framework/introscope_agent.rb
@@ -104,7 +104,7 @@ module JavaBuildpack
       end
 
       def default_process_name(credentials)
-        credentials['agent_process_name'] || @application.details['application_name']
+        credentials['agent_defaultProcessName'] || @application.details['application_name']
       end
 
       def protocol_mapping(protocol)

--- a/spec/java_buildpack/framework/introscope_agent_spec.rb
+++ b/spec/java_buildpack/framework/introscope_agent_spec.rb
@@ -306,7 +306,7 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
       let(:credentials) do
         { 'agent_manager_url'        => 'https://test-host-name:8444',
           'agent_manager_credential' => 'test-credential-cccf-88-ae',
-          'agent_process_name' => 'TestProcess'}
+          'agent_defaultProcessName' => 'TestProcess'}
       end
 
       it 'sets the agent_manager_url, agent_manager_credential, and agent_process_name' do

--- a/spec/java_buildpack/framework/introscope_agent_spec.rb
+++ b/spec/java_buildpack/framework/introscope_agent_spec.rb
@@ -302,5 +302,33 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
       end
     end
 
+    context do
+      let(:credentials) do
+        { 'agent_manager_url'        => 'https://test-host-name:8444',
+          'agent_manager_credential' => 'test-credential-cccf-88-ae',
+          'agent_process_name' => 'TestProcess'}
+      end
+
+      it 'sets the agent_manager_url, agent_manager_credential, and agent_process_name' do
+        component.release
+
+        expect(java_opts).to include('-javaagent:$PWD/.java-buildpack/introscope_agent/Agent.jar')
+        expect(java_opts).to include('-Dcom.wily.introscope.agentProfile=$PWD/.java-buildpack/introscope_agent/core' \
+                                     '/config/IntroscopeAgent.profile')
+        expect(java_opts).to include('-Dintroscope.agent.defaultProcessName=TestProcess')
+        expect(java_opts).to include('-Dintroscope.agent.hostName=test-application-uri-0')
+
+        expect(java_opts).to include('-DagentManager.url.1=https://test-host-name:8444')
+        expect(java_opts).to include('-Dintroscope.agent.enterprisemanager.transport.tcp.host.DEFAULT=test-host-name')
+        expect(java_opts).to include('-Dintroscope.agent.enterprisemanager.transport.tcp.port.DEFAULT=8444')
+        expect(java_opts).to include('-Dintroscope.agent.enterprisemanager.transport.tcp.socketfactory.DEFAULT=' \
+                                     'com.wily.isengard.postofficehub.link.net.HttpsTunnelingSocketFactory')
+
+        expect(java_opts).to include('-Dcom.wily.introscope.agent.agentName=$(expr "$VCAP_APPLICATION" : ' \
+                                      '\'.*application_name[": ]*\\([A-Za-z0-9_-]*\\).*\')')
+        expect(java_opts).to include('-DagentManager.credential=test-credential-cccf-88-ae')
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This change tweaks the existing property for the agent process name to make it configurable.
 This property is passed via the service credential payload. Before this change, the user could not specify the process name for the agent, and after this change, the user can optionally specify the process name, or let it default to the application name.