### PR TITLE
added riverbed to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The buildpack supports extension through the use of Git repository forking. The 
   * [New Relic Agent](docs/framework-new_relic_agent.md) ([Configuration](docs/framework-new_relic_agent.md#configuration))
   * [PostgreSQL JDBC](docs/framework-postgresql_jdbc.md) ([Configuration](docs/framework-postgresql_jdbc.md#configuration))
   * [ProtectApp Security Provider](docs/framework-protect_app_security_provider.md) ([Configuration](docs/framework-protect_app_security_provider.md#configuration))
+  * [Riverbed AppInternals Agent](docs/framework-riverbed_appinternals_agent.md) ([Configuration](docs/framework-riverbed_appinternals_agent.md#configuration))
   * [Spring Auto Reconfiguration](docs/framework-spring_auto_reconfiguration.md) ([Configuration](docs/framework-spring_auto_reconfiguration.md#configuration))
   * [Spring Insight](docs/framework-spring_insight.md)
   * [SkyWalking Agent](docs/framework-sky_walking_agent.md) ([Configuration](docs/framework-sky_walking_agent.md#configuration))


### PR DESCRIPTION
**Riverbed’s SteelCentral AppInternals software is hereby expressly designated as “NOT A CONTRIBUTION”, notwithstanding the fact that Riverbed may provide a URL or other references in its Contributions that direct the user to a copy of SteelCentral AppInternals software. Riverbed’s provision of such URL or references will not constitute a Contribution of the SteelCentral AppInternals software.**

Sorry i have to paste those lines everytime i do a pull request.

This PR adds riverbed appinternals to the readme file.

In addition, thanks for approving the initial contribution, a few things i'd like mention: 

- In terms of testing, please let me know when you want to test.

- I noticed  "AppInternals" was spelled as "AppInterals" in yesterday's [commit message](https://github.com/cloudfoundry/java-buildpack/commit/ce0c64d5b6578dd3e47d17cab4d2dfb234bfba79)  that you wrote. sorry for bothering but please use the correct spelling next time, e.g. writing release note ;)

- Is Riverbed agent support slated for 4.13? Is there anything we need to do on our side now? 
