### PR TITLE
Basic support for OpenJDK OpenJ9

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The buildpack supports extension through the use of Git repository forking. The 
   * [Azul Zulu](docs/jre-zulu_jre.md) ([Configuration](docs/jre-zulu_jre.md#configuration))
   * [IBM® SDK, Java™ Technology Edition](docs/jre-ibm_jre.md) ([Configuration](docs/jre-ibm_jre.md#configuration))
   * [OpenJDK](docs/jre-open_jdk_jre.md) ([Configuration](docs/jre-open_jdk_jre.md#configuration))
+  * [OpenJDK with Eclipse OpenJ9](docs/jre-open_jdk_open_j9.md) ([Configuration](docs/jre-open_jdk_open_j9.md#configuration))
   * [Oracle](docs/jre-oracle_jre.md) ([Configuration](docs/jre-oracle_jre.md#configuration))
   * [SapMachine](docs/jre-sap_machine_jre.md) ([Configuration](docs/jre-sap_machine_jre.md#configuration))
 * [Extending](docs/extending.md)

--- a/config/components.yml
+++ b/config/components.yml
@@ -34,6 +34,7 @@ jres:
 # - "JavaBuildpack::Jre::OracleJRE"
 # - "JavaBuildpack::Jre::ZuluJRE"
 # - "JavaBuildpack::Jre::SapMachineJRE"
+# - "JavaBuildpack::Jre::OpenJdkOpenJ9"
 
 # Frameworks are processed in order.
 # The MultiBuildpack framework is first in order to allow any framework to override contributions from earlier buildpacks

--- a/config/open_jdk_open_j9.yml
+++ b/config/open_jdk_open_j9.yml
@@ -1,0 +1,22 @@
+# Cloud Foundry Java Buildpack
+# Copyright 2013-2018 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+jre:
+  version: 0.9.+
+  repository_root: "{default.repository.root}/openjdk/{platform}/{architecture}"
+jvmkill_agent:
+  version: 1.+
+  repository_root: "{default.repository.root}/jvmkill/{platform}/{architecture}"

--- a/config/open_jdk_open_j9.yml
+++ b/config/open_jdk_open_j9.yml
@@ -16,7 +16,7 @@
 ---
 jre:
   version: 0.9.+
-  repository_root: "{default.repository.root}/openjdk/{platform}/{architecture}"
+  repository_root: "{default.repository.root}/openjdkj9/{platform}/{architecture}"
 jvmkill_agent:
   version: 1.+
   repository_root: "{default.repository.root}/jvmkill/{platform}/{architecture}"

--- a/docs/jre-open_jdk_open_j9.md
+++ b/docs/jre-open_jdk_open_j9.md
@@ -1,4 +1,4 @@
-# OpenJDK JRE
+# OpenJDK JRE with Eclipse OpenJ9
 The OpenJDK JRE with [Eclipse OpenJ9][] provides a Java runtimes from the [OpenJDK][] project that utilizes the Eclipse OpenJ9 JVM.  Versions of Java from the `1.8` and `1.11` lines are available.  Unless otherwise configured, the version of Java that will be used is specified in [`config/open_jdk_open_j9.yml`][].  For more information about [Eclipse OpenJ9][], see the Eclipse Foundation page.
 
 <table>
@@ -39,7 +39,7 @@ To use OpenJDK JRE with [Eclipse OpenJ9][] instead of OpenJDK without forking ja
 The JRE can also be configured by overlaying a set of resources on the default distribution. To do this, add files to the `resources/open_jdk_open_j9` directory in the buildpack fork.
 
 #### Custom CA Certificates
-To add custom SSL certificates, add your `cacerts` file to `resources/open_jdk_open_j9/jre/jre/lib/security/cacerts`.  This file will be overlayed onto the OpenJDK distribution.
+To add custom SSL certificates, add your `cacerts` file to `resources/open_jdk_open_j9/jre/lib/security/cacerts`.  This file will be overlayed onto the OpenJDK distribution.
 
 ### `jvmkill`
 The `jvmkill` agent runs when an application has experience a resource exhaustion event.  When this event occurs, the agent will print out a histogram of the first 100 largest types by total number of bytes.

--- a/docs/jre-open_jdk_open_j9.md
+++ b/docs/jre-open_jdk_open_j9.md
@@ -1,0 +1,99 @@
+# OpenJDK JRE
+The OpenJDK JRE with [Eclipse OpenJ9][] provides a Java runtimes from the [OpenJDK][] project that utilizes the Eclipse OpenJ9 JVM.  Versions of Java from the `1.8` and `1.11` lines are available.  Unless otherwise configured, the version of Java that will be used is specified in [`config/open_jdk_open_j9.yml`][].  For more information about [Eclipse OpenJ9][], see the Eclipse Foundation page.
+
+<table>
+  <tr>
+    <td><strong>Detection Criterion</strong></td>
+    <td>Unconditional.  Existence of a single bound Volume Service will result in Terminal heap dumps being written.
+      <ul>
+        <li>Existence of a Volume Service service is defined as the <a href="http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES"><code>VCAP_SERVICES</code></a> payload containing a service who's name, label or tag has <code>heap-dump</code> as a substring.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Tags</strong></td>
+    <td><tt>open-jdk-open-j9-initializer=&lang;version&rang;, jvmkill=&lang;version&rang;</tt></td>
+  </tr>
+</table>
+Tags are printed to standard output by the buildpack detect script
+
+## Configuration
+For general information on configuring the buildpack, including how to specify configuration values through environment variables, refer to [Configuration and Extension][].
+
+The JRE can be configured by modifying the [`config/open_jdk_open_j9.yml`][] file in the buildpack fork.  The JRE uses the [`Repository` utility support][repositories] and so it supports the [version syntax][]  defined there.
+
+To use OpenJDK JRE with [Eclipse OpenJ9][] instead of OpenJDK without forking java-buildpack, set environment variable:
+
+`cf set-env <app_name> JBP_CONFIG_COMPONENTS '{jres: ["JavaBuildpack::Jre::OpenJdkOpenJ9"]}'`
+
+`cf restage <app_name>`
+
+| Name | Description
+| ---- | -----------
+| `jre.repository_root` | The URL of the OpenJDK repository index ([details][repositories]).
+| `jre.version` | The version of Java runtime to use. Candidate versions can be found on [AdoptOpenJDK][].
+| `jvmkill.repository_root` | The URL of the `jvmkill` repository index ([details][repositories]).
+| `jvmkill.version` | The version of `jvmkill` to use.  Candidate versions can be found in the listings for [mountainlion][jvmkill-mountainlion] and [trusty][jvmkill-trusty].
+
+### Additional Resources
+The JRE can also be configured by overlaying a set of resources on the default distribution. To do this, add files to the `resources/open_jdk_open_j9` directory in the buildpack fork.
+
+#### Custom CA Certificates
+To add custom SSL certificates, add your `cacerts` file to `resources/open_jdk_open_j9/jre/jre/lib/security/cacerts`.  This file will be overlayed onto the OpenJDK distribution.
+
+### `jvmkill`
+The `jvmkill` agent runs when an application has experience a resource exhaustion event.  When this event occurs, the agent will print out a histogram of the first 100 largest types by total number of bytes.
+
+```plain
+Resource exhaustion event: the JVM was unable to allocate memory from the heap.
+ResourceExhausted! (1/0)
+| Instance Count | Total Bytes | Class Name                                    |
+| 18273          | 313157136   | [B                                            |
+| 47806          | 7648568     | [C                                            |
+| 14635          | 1287880     | Ljava/lang/reflect/Method;                    |
+| 46590          | 1118160     | Ljava/lang/String;                            |
+| 8413           | 938504      | Ljava/lang/Class;                             |
+| 28573          | 914336      | Ljava/util/concurrent/ConcurrentHashMap$Node; |
+```
+
+It will also print out a summary of all of the memory spaces in the JVM.
+
+```plain
+Memory usage:
+   Heap memory: init 65011712, used 332392888, committed 351797248, max 351797248
+   Non-heap memory: init 2555904, used 63098592, committed 64815104, max 377790464
+Memory pool usage:
+   Code Cache: init 2555904, used 14702208, committed 15007744, max 251658240
+   PS Eden Space: init 16252928, used 84934656, committed 84934656, max 84934656
+   PS Survivor Space: init 2621440, used 0, committed 19398656, max 19398656
+   Compressed Class Space: init 0, used 5249512, committed 5505024, max 19214336
+   Metaspace: init 0, used 43150616, committed 44302336, max 106917888
+   PS Old Gen: init 43515904, used 247459792, committed 247463936, max 247463936
+```
+
+If a [Volume Service][] with the string `heap-dump` in its name or tag is bound to the application, terminal heap dumps will be written with the pattern `<CONTAINER_DIR>/<SPACE_NAME>-<SPACE_ID[0,8]>/<APPLICATION_NAME>-<APPLICATION_ID[0,8]>/<INSTANCE_INDEX>-<TIMESTAMP>-<INSTANCE_ID[0,8]>.hprof`
+
+```plain
+Heapdump written to /var/vcap/data/9ae0b817-1446-4915-9990-74c1bb26f147/pcfdev-space-e91c5c39/java-main-application-892f20ab/0-2017-06-13T18:31:29+0000-7b23124e.hprof
+```
+
+### Memory
+The total available memory for the application's container is specified when an application is pushed. For this JRE, The Java buildpack does *not* use this value to control the JRE's use of various regions of memory. This is left up to [OpenJ9 defaults][], which may or may not work for your app.
+
+The user can change the container's total memory available and the user can specify [custom memory settings][] like the heap size (`-Xmx`) using Java option. Increasing or decreasing the total memory available to the container makes more memory available for heap & non-heap usage. The total memory limit for the app needs to be large enough to encompass all segments of the memory used by the JVM, not just heap space.
+
+
+[`config/open_jdk_open_j9.yml`]: ../config/open_jdk_open_j9.yml
+[Configuration and Extension]: ../README.md#configuration-and-extension
+[Java Buildpack Memory Calculator]: https://github.com/cloudfoundry/java-buildpack-memory-calculator
+[jvmkill-mountainlion]: http://download.pivotal.io.s3.amazonaws.com/jvmkill/mountainlion/x86_64/index.yml
+[jvmkill-trusty]: http://download.pivotal.io.s3.amazonaws.com/jvmkill/trusty/x86_64/index.yml
+[Memory Calculator's README]: https://github.com/cloudfoundry/java-buildpack-memory-calculator
+[OpenJDK]: http://openjdk.java.net
+[repositories]: extending-repositories.md
+[version syntax]: extending-repositories.md#version-syntax-and-ordering
+[Volume Service]: https://docs.cloudfoundry.org/devguide/services/using-vol-services.html
+[Eclipse OpenJ9]: https://www.eclipse.org/openj9/
+[OpenJ9 defaults]: https://www.eclipse.org/openj9/docs/openj9_defaults/
+[custom memory settings]: https://www.eclipse.org/openj9/docs/x_jvm_commands/
+[AdoptOpenJDK]: https://adoptopenjdk.net/

--- a/lib/java_buildpack/jre/open_jdk_open_j9.rb
+++ b/lib/java_buildpack/jre/open_jdk_open_j9.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Cloud Foundry Java Buildpack
+# Copyright 2018 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'java_buildpack/component/modular_component'
+require 'java_buildpack/jre'
+require 'java_buildpack/jre/open_jdk_open_j9_initializer'
+require 'java_buildpack/jre/jvmkill_agent'
+require 'java_buildpack/jre/open_jdk_like_security_providers'
+
+module JavaBuildpack
+  module Jre
+
+    # Encapsulates the detect, compile, and release functionality for selecting a JRE.
+    class OpenJdkOpenJ9 < JavaBuildpack::Component::ModularComponent
+
+      protected
+
+      # (see JavaBuildpack::Component::ModularComponent#command)
+      def command
+        # no command need to be executed
+      end
+
+      # (see JavaBuildpack::Component::ModularComponent#sub_components)
+      def sub_components(context)
+        [
+          OpenJdkOpenJ9Initializer.new(sub_configuration_context(context, 'jre')
+                                        .merge(component_name: self.class.to_s.space_case)),
+          JvmkillAgent.new(sub_configuration_context(context, 'jvmkill_agent')),
+          OpenJDKLikeSecurityProviders.new(context)
+        ]
+      end
+
+      # (see JavaBuildpack::Component::ModularComponent#supports?)
+      def supports?
+        true
+      end
+
+    end
+
+  end
+end

--- a/lib/java_buildpack/jre/open_jdk_open_j9_initializer.rb
+++ b/lib/java_buildpack/jre/open_jdk_open_j9_initializer.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Cloud Foundry Java Buildpack
+# Copyright 2018 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'fileutils'
+require 'java_buildpack/logging/logger_factory'
+require 'java_buildpack/component/versioned_dependency_component'
+require 'java_buildpack/jre'
+require 'java_buildpack/util/tokenized_version'
+
+module JavaBuildpack
+  module Jre
+
+    # Encapsulates the detect, compile, and release functionality for selecting a JRE.
+    class OpenJdkOpenJ9Initializer < JavaBuildpack::Component::VersionedDependencyComponent
+
+      # Creates an instance
+      #
+      # @param [Hash] context a collection of utilities used the component
+      def initialize(context)
+        @logger = JavaBuildpack::Logging::LoggerFactory.instance.get_logger OpenJdkOpenJ9Initializer
+
+        @application    = context[:application]
+        @component_name = context[:component_name]
+        @configuration  = context[:configuration]
+        @droplet        = context[:droplet]
+
+        @droplet.java_home.root = @droplet.sandbox + 'jre/'
+      end
+
+      # (see JavaBuildpack::Component::BaseComponent#detect)
+      def detect
+        @version, @uri = JavaBuildpack::Repository::ConfiguredItem.find_item(@component_name,
+                                                                             @configuration)
+        @droplet.java_home.version = @version
+        super
+      end
+
+      # (see JavaBuildpack::Component::BaseComponent#compile)
+      def compile
+        download_tar
+        @droplet.copy_resources
+
+        # stripping top level from tar doesn't seem to be enough
+        # need to strip one more level
+        orig_dir = Dir.entries(@droplet.sandbox).select { |f| f.start_with? 'jdk' }.first
+        File.rename(File.join(@droplet.sandbox, orig_dir), @droplet.java_home.root) unless orig_dir.nil?
+      end
+
+      # (see JavaBuildpack::Component::BaseComponent#release)
+      def release
+        @droplet
+          .java_opts
+          .add_system_property('java.io.tmpdir', '$TMPDIR')
+          .add_preformatted_options('-Xtune:virtualized')
+          .add_preformatted_options('-Xshareclasses:none')
+      end
+
+    end
+
+  end
+end

--- a/spec/java_buildpack/jre/open_jdk_open_j9_jre_initializer_spec.rb
+++ b/spec/java_buildpack/jre/open_jdk_open_j9_jre_initializer_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# Cloud Foundry Java Buildpack
+# Copyright 2017 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'component_helper'
+require 'java_buildpack/component/mutable_java_home'
+require 'java_buildpack/jre/open_jdk_open_j9_initializer'
+
+describe JavaBuildpack::Jre::OpenJdkOpenJ9Initializer do
+  include_context 'with component help'
+
+  let(:java_home) { JavaBuildpack::Component::MutableJavaHome.new }
+
+  it 'detects with id of open-jdk-open-j9-initializer-<version>' do
+    expect(component.detect).to eq("open-jdk-open-j9-initializer=#{version}")
+  end
+
+  it 'extracts Java from a GZipped TAR',
+     cache_fixture: 'stub-java.tar.gz' do
+
+    component.detect
+    component.compile
+
+    expect(sandbox + 'bin/java').to exist
+  end
+
+  it 'adds JAVA_HOME to java_home' do
+    component
+
+    expect(java_home.root).to eq(sandbox + 'jre/')
+  end
+
+  it 'adds java.io.tmpdir to java_opts' do
+    component.detect
+    component.release
+
+    expect(java_opts).to include('-Djava.io.tmpdir=$TMPDIR')
+  end
+
+  it 'adds Xtune to java_opts' do
+    component.detect
+    component.release
+
+    expect(java_opts).to include('-Xtune:virtualized')
+  end
+
+  it 'adds Xshareclasses to java_opts' do
+    component.detect
+    component.release
+
+    expect(java_opts).to include('-Xshareclasses:none')
+  end
+
+end

--- a/spec/java_buildpack/jre/open_jdk_open_j9_jre_spec.rb
+++ b/spec/java_buildpack/jre/open_jdk_open_j9_jre_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# Cloud Foundry Java Buildpack
+# Copyright 2017 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'component_helper'
+require 'fileutils'
+require 'java_buildpack/component/mutable_java_home'
+require 'java_buildpack/jre/open_jdk_open_j9_initializer'
+require 'java_buildpack/jre/open_jdk_open_j9'
+
+describe JavaBuildpack::Jre::OpenJdkOpenJ9 do
+  include_context 'with component help'
+
+  let(:component) { StubOpenJdkOpenJ9JRE.new context }
+
+  let(:java_home) { JavaBuildpack::Component::MutableJavaHome.new }
+
+  let(:configuration) do
+    { 'jre'           => jre_configuration,
+      'jvmkill_agent' => jvmkill_agent_configuration }
+  end
+
+  let(:jre_configuration) { instance_double('jre_configuration') }
+
+  let(:jvmkill_agent_configuration) { {} }
+
+  it 'supports anyway' do
+    expect(component.supports?).to be
+  end
+
+  it 'creates OpenJdkOpenJ9Initializer instance' do
+    allow_any_instance_of(StubOpenJdkOpenJ9JRE).to receive(:supports?).and_return false
+
+    allow(JavaBuildpack::Jre::OpenJdkOpenJ9Initializer)
+      .to receive(:new).with(sub_configuration_context(jre_configuration)
+      .merge(component_name: 'Stub Open Jdk Open J9 JRE'))
+    allow(JavaBuildpack::Jre::JvmkillAgent)
+      .to receive(:new).with(sub_configuration_context(jvmkill_agent_configuration))
+
+    component.sub_components context
+  end
+
+end
+
+class StubOpenJdkOpenJ9JRE < JavaBuildpack::Jre::OpenJdkOpenJ9
+
+  public :command, :sub_components
+
+  def supports?
+    super
+  end
+
+end
+
+def sub_configuration_context(configuration)
+  cntxt                 = context.clone
+  cntxt[:configuration] = configuration
+  cntxt
+end


### PR DESCRIPTION
Created JRE components that install OpenJDK with the [Eclipse foundation's OpenJ9 VM](https://www.eclipse.org/openj9/). Adding because it seems neat and reports to offer benefits for running Java apps in a "cloud" environment like fast start up & low memory footprint (who doesn't wan that?).

I basically copied the IBM JRE Ruby classes & tests, and made a few minor edits to get this to work. I'm doubting that's the best path, but it seems to work and I figured it would be a way to start the conversation.

To run with Spring Music:

1. Git clone Spring music.
2. Use this manifest:

    ```
    ---
    applications:
    - name: spring-music
      memory: 256M
      path: build/libs/spring-music-1.0.jar
      buildpack: https://github.com/dmikusa-pivotal/java-buildpack.git#open-j9-support
      routes:
      - route: spring-music-dan.cfapps.io
      env:
        JBP_CONFIG_COMPONENTS: '{ jres: [ "JavaBuildpack::Jre::OpenJdkOpenJ9" ] }'
        JBP_CONFIG_OPEN_JDK_OPEN_J9: '{ jre: { version: "0.9.+", repository_root: "https://s3.amazonaws.com/dmikusa-buildpack-tests/java-buildpack/" } }'
    ```

3. Run `cf push`.

Ex:

```
$ cf push
Pushing from manifest to org dmikusa / space development as dmikusa@gopivotal.com...
Using manifest file /Users/dmikusa/Code/Samples/spring-music/manifest.yml
Getting app info...
Creating app with these attributes...
+ name:        spring-music
  path:        /Users/dmikusa/Code/Samples/spring-music/build/libs/spring-music-1.0.jar
+ buildpack:   https://github.com/dmikusa-pivotal/java-buildpack.git#open-j9-support
+ memory:      256M
  env:
+   JBP_CONFIG_COMPONENTS
+   JBP_CONFIG_OPEN_JDK_OPEN_J9
  routes:
+   spring-music-dan.cfapps.io

Creating app spring-music...
Mapping routes...
Comparing local files to remote cache...
Packaging files to upload...
Uploading files...
 518.30 KiB / 518.30 KiB [=====================================================================================================================================] 100.00% 1s

Waiting for API to complete processing files...

Staging app and tracing logs...
   Cell e6c5e16e-1195-480a-b1ea-1d111965d95b creating container for instance 546c98be-4b41-4959-8730-092ab6a7a366
   Cell e6c5e16e-1195-480a-b1ea-1d111965d95b successfully created container for instance 546c98be-4b41-4959-8730-092ab6a7a366
   Downloading app package...
   Downloaded app package (40.8M)
   -----> Java Buildpack 962e752 | https://github.com/dmikusa-pivotal/java-buildpack.git#962e752
   -----> Downloading Open Jdk Open J9 0.9.0 from https://github.com/AdoptOpenJDK/openjdk8-openj9-releases/releases/download/jdk8u181-b13_openj9-0.9.0/OpenJDK8-OPENJ9_x64_Linux_jdk8u181-b13_openj9-0.9.0.tar.gz (2.4s)
          Expanding Open Jdk Open J9 to .java-buildpack/open_jdk_open_j9 (2.8s)
   -----> Downloading Jvmkill Agent 1.16.0_RELEASE from https://java-buildpack.cloudfoundry.org/jvmkill/trusty/x86_64/jvmkill-1.16.0_RELEASE.so (0.2s)
   -----> Downloading Client Certificate Mapper 1.8.0_RELEASE from https://java-buildpack.cloudfoundry.org/client-certificate-mapper/client-certificate-mapper-1.8.0_RELEASE.jar (0.1s)
   -----> Downloading Container Security Provider 1.16.0_RELEASE from https://java-buildpack.cloudfoundry.org/container-security-provider/container-security-provider-1.16.0_RELEASE.jar (0.1s)
   -----> Downloading Spring Auto Reconfiguration 2.4.0_RELEASE from https://java-buildpack.cloudfoundry.org/auto-reconfiguration/auto-reconfiguration-2.4.0_RELEASE.jar (0.1s)
   Exit status 0
   Uploading droplet, build artifacts cache...
   Uploading droplet...
   Uploading build artifacts cache...
   Uploaded build artifacts cache (86.5M)
   Uploaded droplet (127.6M)
   Uploading complete
   Cell e6c5e16e-1195-480a-b1ea-1d111965d95b stopping instance 546c98be-4b41-4959-8730-092ab6a7a366
   Cell e6c5e16e-1195-480a-b1ea-1d111965d95b destroying container for instance 546c98be-4b41-4959-8730-092ab6a7a366
   Cell e6c5e16e-1195-480a-b1ea-1d111965d95b successfully destroyed container for instance 546c98be-4b41-4959-8730-092ab6a7a366

Waiting for app to start...

name:              spring-music
requested state:   started
instances:         1/1
usage:             256M x 1 instances
routes:            spring-music-dan.cfapps.io
last uploaded:     Sat 08 Sep 12:14:09 EDT 2018
stack:             cflinuxfs2
buildpack:         https://github.com/dmikusa-pivotal/java-buildpack.git#open-j9-support
start command:     JAVA_OPTS="-Djava.io.tmpdir=$TMPDIR -Xtune:virtualized -Xshareclasses:none
                   -agentpath:$PWD/.java-buildpack/open_jdk_open_j9/bin/jvmkill-1.16.0_RELEASE=printHeapHistogram=1
                   -Djava.ext.dirs=$PWD/.java-buildpack/container_security_provider:$PWD/.java-buildpack/open_jdk_open_j9/jre/jre/lib/ext
                   -Djava.security.properties=$PWD/.java-buildpack/java_security/java.security $JAVA_OPTS" && SERVER_PORT=$PORT eval exec
                   $PWD/.java-buildpack/open_jdk_open_j9/jre/bin/java $JAVA_OPTS -cp $PWD/. org.springframework.boot.loader.JarLauncher

     state     since                  cpu      memory           disk           details
#0   running   2018-09-08T16:16:14Z   120.6%   162.9M of 256M   241.1M of 1G
```
