### PR TITLE
Set maxHttpHeaderSize in tomcat server as a parameter

### DIFF
--- a/config/tomcat.yml
+++ b/config/tomcat.yml
@@ -20,6 +20,8 @@ tomcat:
   repository_root: "{default.repository.root}/tomcat"
   context_path: 
   external_configuration_enabled: false
+  maxHttpHeaderSize_enabled: false
+  maxHttpHeaderSize: 24576
 external_configuration:
   version: 1.+
   repository_root: 

--- a/lib/java_buildpack/container/tomcat/tomcat_instance.rb
+++ b/lib/java_buildpack/container/tomcat/tomcat_instance.rb
@@ -54,8 +54,10 @@ module JavaBuildpack
       end
 
       TOMCAT_8 = JavaBuildpack::Util::TokenizedVersion.new('8.0.0').freeze
+      MAX_HTTP_HEADER_SIZE = 'maxHttpHeaderSize'
+      MAX_HTTP_HEADER_SIZE_ENABLED = 'maxHttpHeaderSize_enabled'
 
-      private_constant :TOMCAT_8
+      private_constant :TOMCAT_8, :MAX_HTTP_HEADER_SIZE, :MAX_HTTP_HEADER_SIZE_ENABLED
 
       # Checks whether Tomcat instance is Tomcat 7 compatible
       def tomcat_7_compatible
@@ -75,6 +77,14 @@ module JavaBuildpack
 
         server.insert_before '//Service', listener
 
+        write_xml server_xml, document
+      end
+
+       # http-max-header-size for tomcat
+      def configure_http_header http_header_size
+        document = read_xml server_xml
+        connector = REXML::XPath.match(document, '/Server/Service/Connector').first
+        connector.add_attribute 'maxHttpHeaderSize', http_header_size
         write_xml server_xml, document
       end
 
@@ -99,6 +109,10 @@ module JavaBuildpack
           @droplet.copy_resources
           configure_linking
           configure_jasper
+          if @configuration[MAX_HTTP_HEADER_SIZE_ENABLED]
+            configure_http_header @configuration[MAX_HTTP_HEADER_SIZE]
+          end
+
         end
       end
 

--- a/spec/java_buildpack/container/tomcat/tomcat_instance_spec.rb
+++ b/spec/java_buildpack/container/tomcat/tomcat_instance_spec.rb
@@ -165,4 +165,19 @@ describe JavaBuildpack::Container::TomcatInstance do
     expect(test_jar2.readlink).to eq((additional_libs_directory + 'test-jar-2.jar').relative_path_from(web_inf_lib))
   end
 
+  context do
+    let(:configuration) { { 'maxHttpHeaderSize_enabled' => true , 'maxHttpHeaderSize' => '24576' } }
+
+    it 'Modify tomcat maxHttpHeaderSize',
+       app_fixture:   'container_tomcat_with_index',
+       cache_fixture: 'stub-tomcat.tar.gz' do
+
+      FileUtils.touch(app_dir + '.test-file')
+
+      component.compile
+      expect((sandbox + 'conf/server.xml').read)
+        .to match(/maxHttpHeaderSize='24576'/)
+    end
+  end
+
 end


### PR DESCRIPTION
Hello Team, 

Recently JWT token usage trend increased by different microservices and client entities. JWT defines no upper limit in the spec (http://www.rfc-editor.org/rfc/rfc7519.txt) we do have some operational limits. As a JWT is included in an HTTP header, we have an upper limit (SO: Maximum on HTTP header values) of 8K on the majority of current servers. Due to avoid this conflict would like to add maxHttpHeaderSize is part of buildpack, so that the entity owner can decide how much max size is allowed for their clients. 

Even though buildpack having an alternate option to modify tomcat configuration via https://github.com/cloudfoundry/java-buildpack/blob/master/docs/container-tomcat.md#external-tomcat-configuration will be good this specific parameter is part of buildpack.

Considering this necessary I would like to send this pull request.

Regards
Lingesh M