### PR TITLE
Allow specifying the jacoco agent's output mode to choose between tcp…

### DIFF
--- a/docs/framework-jacoco_agent.md
+++ b/docs/framework-jacoco_agent.md
@@ -27,6 +27,7 @@ The credential payload of the service may contain the following entries:
 | `excludes` | (Optional) A list of class names that should be excluded from execution analysis. The list entries are separated by a colon (:) and may use wildcard characters (* and ?).
 | `includes` | (Optional) A list of class names that should be included in execution analysis. The list entries are separated by a colon (:) and may use wildcard characters (* and ?).
 | `port` | (Optional) The port for the agent to connect to
+| `output` | (Optional) The mode for the agent. Possible values are either tcpclient (the default) or tcpserver. 
 
 ## Configuration
 For general information on configuring the buildpack, including how to specify configuration values through environment variables, refer to [Configuration and Extension][].

--- a/lib/java_buildpack/framework/jacoco_agent.rb
+++ b/lib/java_buildpack/framework/jacoco_agent.rb
@@ -41,6 +41,7 @@ module JavaBuildpack
         properties['excludes'] = credentials['excludes'] if credentials.key? 'excludes'
         properties['includes'] = credentials['includes'] if credentials.key? 'includes'
         properties['port']     = credentials['port'] if credentials.key? 'port'
+        properties['output']   = credentials['output'] if credentials.key? 'output'
 
         @droplet.java_opts.add_javaagent_with_props(@droplet.sandbox + 'jacocoagent.jar', properties)
       end

--- a/spec/java_buildpack/framework/jacoco_agent_spec.rb
+++ b/spec/java_buildpack/framework/jacoco_agent_spec.rb
@@ -56,6 +56,7 @@ describe JavaBuildpack::Framework::JacocoAgent do
 
     it 'updates JAVA_OPTS with additional options' do
       allow(services).to receive(:find_service).and_return('credentials' => { 'address'  => 'test-address',
+                                                                              'output'   => 'test-output',
                                                                               'excludes' => 'test-excludes',
                                                                               'includes' => 'test-includes',
                                                                               'port'     => 6300 })
@@ -63,7 +64,7 @@ describe JavaBuildpack::Framework::JacocoAgent do
       component.release
 
       expect(java_opts).to include('-javaagent:$PWD/.java-buildpack/jacoco_agent/jacocoagent.jar=' \
-                                   'address=test-address,output=tcpclient,sessionid=$CF_INSTANCE_GUID,' \
+                                   'address=test-address,output=test-output,sessionid=$CF_INSTANCE_GUID,' \
                                    'excludes=test-excludes,includes=test-includes,port=6300')
     end
 


### PR DESCRIPTION
…client or tcpserver.

Use case:

Generating coverage reports using JaCoCo for a spring boot app.
```
cf cups jacoco-service -p '{"output":"tcpserver",address":"localhost"}'
cf bind-service APP_NAME jacoco-service
cf restage APP_NAME
cf ssh -N -L localhost:6300:localhost:6300 APP_NAME &
... run tests ...
java -jar jacococli.jar dump --address localhost --destfile jacoco.exec
... run sonar scanner ...
```

Reason:

I cannot use the tcpclient mode because the organisation disabled the `cf add-network-policy` command (no container to container networking), hence I cannot setup/use a jacoco tcp server/service in Cloud Foundry that's supposed to receive the coverage data.