### PR TITLE
Switch to SapMachine 11 LTS

### DIFF
--- a/config/sap_machine_jre.yml
+++ b/config/sap_machine_jre.yml
@@ -17,14 +17,14 @@
 # Configuration for JRE repository
 ---
 jre:
-  version: 10.+
-  repository_root: "https://sap.github.io/SapMachine/assets/cf/jre/10/linux/x86_64"
+  version: 11.+
+  repository_root: "https://sap.github.io/SapMachine/assets/cf/jre/11/linux/x86_64"
 jvmkill_agent:
   version: 1.+
   repository_root: "{default.repository.root}/jvmkill/{platform}/{architecture}"
 memory_calculator:
   version: 3.+
   repository_root: "{default.repository.root}/memory-calculator/{platform}/{architecture}"
-  class_count: 
-  headroom: 
+  class_count:
+  headroom:
   stack_threads: 250


### PR DESCRIPTION
SapMachine JRE version 11 (Long Term Support) is now available.
Switch from version 10 to 11 in the Java Buildpack.