### PR TITLE
Use a repository which is independent of the SapMachine major version.

### DIFF
--- a/config/sap_machine_jre.yml
+++ b/config/sap_machine_jre.yml
@@ -18,13 +18,13 @@
 ---
 jre:
   version: 11.+
-  repository_root: "https://sap.github.io/SapMachine/assets/cf/jre/11/linux/x86_64"
+  repository_root: "https://sap.github.io/SapMachine/assets/cf/jre/linux/{architecture}"
 jvmkill_agent:
   version: 1.+
   repository_root: "{default.repository.root}/jvmkill/{platform}/{architecture}"
 memory_calculator:
   version: 3.+
   repository_root: "{default.repository.root}/memory-calculator/{platform}/{architecture}"
-  class_count: 
-  headroom: 
+  class_count:
+  headroom:
   stack_threads: 250


### PR DESCRIPTION
Currently the repository root contains the SapMachine major version.
This PR removes the major version from the repository root and the user can select the major version with the _JBP_CONFIG_SAP_MACHINE_JRE_ environment variable.