### PR TITLE
Disabled CDS via Command Line Option for Dynatrace Injection

### DIFF
--- a/lib/java_buildpack/framework/dynatrace_appmon_agent.rb
+++ b/lib/java_buildpack/framework/dynatrace_appmon_agent.rb
@@ -36,6 +36,7 @@ module JavaBuildpack
       # (see JavaBuildpack::Component::BaseComponent#release)
       def release
         @droplet.java_opts.add_agentpath_with_props(agent_path, name: agent_name, server: server)
+        @droplet.java_opts.add_preformatted_options('-Xshare:off')
       end
 
       protected

--- a/lib/java_buildpack/framework/dynatrace_one_agent.rb
+++ b/lib/java_buildpack/framework/dynatrace_one_agent.rb
@@ -65,6 +65,7 @@ module JavaBuildpack
         manifest = agent_manifest
 
         @droplet.java_opts.add_agentpath(agent_path(manifest))
+        @droplet.java_opts.add_preformatted_options('-Xshare:off')
 
         dynatrace_environment_variables(manifest)
       end

--- a/spec/java_buildpack/framework/dynatrace_appmon_agent_spec.rb
+++ b/spec/java_buildpack/framework/dynatrace_appmon_agent_spec.rb
@@ -50,10 +50,11 @@ describe JavaBuildpack::Framework::DynatraceAppmonAgent do
       expect(sandbox + 'agent/lib64/libdtagent.so').to exist
     end
 
-    it 'updates JAVA_OPTS' do
+    it 'updates JAVA_OPTS and share set to off' do
       component.release
       expect(java_opts).to include('-agentpath:$PWD/.java-buildpack/dynatrace_appmon_agent/agent/lib64/'\
         'libdtagent.so=name=test-application-name_Monitoring,server=test-host-name')
+      expect(java_opts).to include('-Xshare:off')
     end
 
     context do

--- a/spec/java_buildpack/framework/dynatrace_one_agent_spec.rb
+++ b/spec/java_buildpack/framework/dynatrace_one_agent_spec.rb
@@ -54,13 +54,14 @@ describe JavaBuildpack::Framework::DynatraceOneAgent do
       expect(sandbox + 'manifest.json').to exist
     end
 
-    it 'updates JAVA_OPTS with agent loader',
+    it 'updates JAVA_OPTS with agent loader and share set to off',
        app_fixture: 'framework_dynatrace_one_agent' do
 
       component.release
 
       expect(java_opts).to include('-agentpath:$PWD/.java-buildpack/dynatrace_one_agent/agent/lib64/' \
         'liboneagentloader.so')
+      expect(java_opts).to include('-Xshare:off')
     end
 
     it 'updates environment variables',


### PR DESCRIPTION
Making the Agent injection future proof for upcoming Java Version Changes