### PR TITLE
change cache/offline behavior to check cache before internet

### DIFF
--- a/lib/java_buildpack/util/cache/download_cache.rb
+++ b/lib/java_buildpack/util/cache/download_cache.rb
@@ -66,14 +66,11 @@ module JavaBuildpack
         #                           already in the cache
         # @return [Void]
         def get(uri, &block)
-          cached_file             = nil
-          downloaded              = nil
-
-          cached_file, downloaded = from_mutable_cache uri if InternetAvailability.instance.available?
+          cached_file = from_immutable_caches(uri)
+          downloaded  = false
 
           unless cached_file
-            cached_file = from_immutable_caches(uri)
-            downloaded  = false
+            cached_file, downloaded = from_mutable_cache uri if InternetAvailability.instance.available?
           end
 
           raise "Unable to find cached file for #{uri.sanitize_uri}" unless cached_file


### PR DESCRIPTION
This change alters the behavior of `download_cache.rb` to look for a requested URI in the local cache before attempting to download. This allows applications (such as ours) to use the "offline" buildpack with pre-cached artifacts, while still pulling from an external configuration repository (using `remote_downloads: enabled`).

This should ideally be backward compatible, since the URI still needs to match what's in the cache. This should also make the staging operations more network friendly, since the cached version of artifacts will be preferred.

Let me know if there's a case I haven't considered!
