### PR TITLE
Tomcat external configuration repository fix for offline buildpack

### DIFF
--- a/lib/java_buildpack/container/tomcat/tomcat_external_configuration.rb
+++ b/lib/java_buildpack/container/tomcat/tomcat_external_configuration.rb
@@ -25,6 +25,15 @@ module JavaBuildpack
     class TomcatExternalConfiguration < JavaBuildpack::Component::VersionedDependencyComponent
       include JavaBuildpack::Container
 
+      # (see JavaBuildpack::Component::VersionedDependencyComponent#initialize)
+      def initialize(context, &version_validator)
+        JavaBuildpack::Util::Cache::InternetAvailability.instance.available(
+          true, 'The Tomcat External Configuration download location is always accessible'
+        ) do
+          super(context)
+        end
+      end
+
       # (see JavaBuildpack::Component::BaseComponent#compile)
       def compile
         JavaBuildpack::Util::Cache::InternetAvailability.instance.available(


### PR DESCRIPTION
(fixes 4297a526219e7adbf19378554ebde6d60c6069c7)

This change updates the handling of the Tomcat external configuration repository to make sure the internet availability flag is enabled while initializing the component. The repository's index is downloaded during the initialization, so this override is needed. I used the same block-override pattern used in the `compile` method.
