### PR TITLE
Fix typo in markdown

### DIFF
--- a/docs/jre-zulu_jre.md
+++ b/docs/jre-zulu_jre.md
@@ -123,8 +123,7 @@ The amount of memory that should be allocated to stacks is given as an amount of
 stack_threads: 500
 ```
 
-Note that the default value of 250 threads is optimized for a default Tomcat configuration.  If you are using another container, especially something non-blocking like Netty, it's more appropriate to use a significantly smaller value.  Typically 25 threads would cover the needs of both the server (Netty) and the threads started by the JVM itself.hreads: 500
-```
+Note that the default value of 250 threads is optimized for a default Tomcat configuration.  If you are using another container, especially something non-blocking like Netty, it's more appropriate to use a significantly smaller value.  Typically 25 threads would cover the needs of both the server (Netty) and the threads started by the JVM itself.
 
 #### Java Options
 


### PR DESCRIPTION
In 817d004cd58505045e72f65ce81fdd429edc3077 this got messed up.