### PR TITLE
Added default_server_name to Contrast Security Framework

### DIFF
--- a/config/contrast_security_agent.yml
+++ b/config/contrast_security_agent.yml
@@ -16,4 +16,5 @@
 # Configuration for the ContrastSecurity framework
 ---
 version: 3.+
+default_server_name: $(jq -r -n "$VCAP_APPLICATION | .space_name + \":\" + .application_name + \":$CF_INSTANCE_INDEX\"")
 repository_root: https://artifacts.contrastsecurity.com/agents/java

--- a/docs/framework-contrast_security_agent.md
+++ b/docs/framework-contrast_security_agent.md
@@ -27,6 +27,7 @@ The framework can be configured by modifying the [`config/contrast_security_agen
 | Name | Description
 | ---- | -----------
 | `repository_root` | The URL of the Contrast Security repository index ([details][repositories]).
+| `default_server_name` | The default server name for this application in the Contrast dashboard. The default value is an expression that will be evaluated based on the `space_name`, `application_name`, and `instance_index` of the application. |
 | `version` | The version of Contrast Security to use. Candidate versions can be found in [this listing][].
 
 [Contrast Security]: https://www.contrastsecurity.com

--- a/lib/java_buildpack/framework/contrast_security_agent.rb
+++ b/lib/java_buildpack/framework/contrast_security_agent.rb
@@ -42,6 +42,7 @@ module JavaBuildpack
         @droplet.java_opts.add_system_property('contrast.override.appname', application_name) unless appname_exist?
 
         @droplet.java_opts
+                .add_system_property('contrast.server', @configuration['default_server_name'])
                 .add_system_property('contrast.dir', '$TMPDIR')
                 .add_preformatted_options("-javaagent:#{qualify_path(@droplet.sandbox + jar_name, @droplet.root)}=" \
                                           "#{qualify_path(contrast_config, @droplet.root)}")


### PR DESCRIPTION
Following the de facto convention established in other frameworks (e.g. AppDynamic), this PR configures the Contrast Security framework in a way that generates a predictable hostname at runtime.