### PR TITLE
Allow specifying the jacoco agent's output mode.

### DIFF
--- a/docs/framework-jacoco_agent.md
+++ b/docs/framework-jacoco_agent.md
@@ -23,10 +23,11 @@ The credential payload of the service may contain the following entries:
 
 | Name | Description
 | ---- | -----------
-| `address` | The host for the agent to connect to
+| `address` | The host for the agent to connect to or listen on
 | `excludes` | (Optional) A list of class names that should be excluded from execution analysis. The list entries are separated by a colon (:) and may use wildcard characters (* and ?).
 | `includes` | (Optional) A list of class names that should be included in execution analysis. The list entries are separated by a colon (:) and may use wildcard characters (* and ?).
-| `port` | (Optional) The port for the agent to connect to
+| `port` | (Optional) The port for the agent to connect to or listen on
+| `output` | (Optional) The mode for the agent. Possible values are either tcpclient (default) or tcpserver. 
 
 ## Configuration
 For general information on configuring the buildpack, including how to specify configuration values through environment variables, refer to [Configuration and Extension][].

--- a/lib/java_buildpack/framework/jacoco_agent.rb
+++ b/lib/java_buildpack/framework/jacoco_agent.rb
@@ -41,6 +41,7 @@ module JavaBuildpack
         properties['excludes'] = credentials['excludes'] if credentials.key? 'excludes'
         properties['includes'] = credentials['includes'] if credentials.key? 'includes'
         properties['port'] = credentials['port'] if credentials.key? 'port'
+        properties['output'] = credentials['output'] if credentials.key? 'output'
 
         @droplet.java_opts.add_javaagent_with_props(@droplet.sandbox + 'jacocoagent.jar', properties)
       end

--- a/spec/java_buildpack/framework/jacoco_agent_spec.rb
+++ b/spec/java_buildpack/framework/jacoco_agent_spec.rb
@@ -56,6 +56,7 @@ describe JavaBuildpack::Framework::JacocoAgent do
 
     it 'updates JAVA_OPTS with additional options' do
       allow(services).to receive(:find_service).and_return('credentials' => { 'address' => 'test-address',
+                                                                              'output' => 'test-output',
                                                                               'excludes' => 'test-excludes',
                                                                               'includes' => 'test-includes',
                                                                               'port' => 6300 })
@@ -63,7 +64,7 @@ describe JavaBuildpack::Framework::JacocoAgent do
       component.release
 
       expect(java_opts).to include('-javaagent:$PWD/.java-buildpack/jacoco_agent/jacocoagent.jar=' \
-                                   'address=test-address,output=tcpclient,sessionid=$CF_INSTANCE_GUID,' \
+                                   'address=test-address,output=test-output,sessionid=$CF_INSTANCE_GUID,' \
                                    'excludes=test-excludes,includes=test-includes,port=6300')
     end
 


### PR DESCRIPTION
This allows changing the default 'tcpclient' to 'tcpserver'.

Use case:

Generating coverage reports using JaCoCo for a spring boot app.
```
cf cups jacoco-service -p '{"output":"tcpserver",address":"localhost"}'
cf bind-service APP_NAME jacoco-service
cf restage APP_NAME
// get coverage data (after running tests) ...
cf ssh -N -L localhost:6300:localhost:6300 APP_NAME &
java -jar jacococli.jar dump --address localhost --destfile jacoco.exec
```

Reason:

I cannot use the tcpclient mode because the organisation disabled the `cf add-network-policy` command (no container to container networking), hence I cannot setup/use a jacoco tcp server/service in Cloud Foundry that's supposed to receive the coverage data.
Yes outbound connections are possible by default, but I'd have to host a jacoco server receiving the coverage data somewhere meaning I'd probably need to deploy another CF app somewhere and would need container2container networking if it should be hosted in our CF instance.