### PR TITLE
Add support for exporting any java agent property from the credential…

### DIFF
--- a/docs/framework-introscope_agent.md
+++ b/docs/framework-introscope_agent.md
@@ -19,16 +19,19 @@ Tags are printed to standard output by the buildpack detect script
 ## User-Provided Service (Optional)
 Users may optionally provide their own Introscope service. A user-provided Introscope service must have a name or tag with `introscope` in it so that the Introscope Agent Framework will automatically configure the application to work with the service.
 
-The credential payload of the service may contain the following entries:
+The credential payload of the service may contain any valid CA APM Java agent property.
+
+The table below displays a subset of properties that are accepted by the buildpack.
+Please refer to CA APM docs for a full list of valid agent properties.
+
 
 | Name | Description
 | ---- | -----------
-|`agent_default_process_name`| (Optional) The name that is specified for the agent process. If not specified, default value is the application name.
-| `agent_manager_credential` | (Optional) The credential that is used to connect to the Enterprise Manager server
-| `agent_manager_url` | The url of the Enterprise Manager server
-| `agent_name` | (Optional) The name that should be given to this instance of the Introscope agent
-| `credential`| (Deprecated) The credential that is used to connect to the Enterprise Manager server
-| `url` | (Deprecated) The url of the Enterprise Manager server
+|`agent_manager_credential`| (Optional) The credential that is used to connect to the Enterprise Manager server.
+|`agentManager_url_1` | The url of the Enterprise Manager server.
+|`agent_manager_url`| (Deprecated) The url of the Enterprise Manager server.
+|`credential`| (Deprecated) The credential that is used to connect to the Enterprise Manager server
+
 
 To provide more complex values such as the `agent_name`, using the interactive mode when creating a user-provided service will manage the character escaping automatically. For example, the default `agent_name` could be set with a value of `agent-$(expr "$VCAP_APPLICATION" : '.*application_name[": ]*\([[:word:]]*\).*')` to calculate a value from the Cloud Foundry application name.
 

--- a/lib/java_buildpack/framework/introscope_agent.rb
+++ b/lib/java_buildpack/framework/introscope_agent.rb
@@ -34,7 +34,7 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::BaseComponent#release)
       def release
-        credentials = @application.services.find_service(FILTER, %w[agent_manager_url url])['credentials']
+        credentials = @application.services.find_service(FILTER)['credentials']
         java_opts = @droplet.java_opts
 
         java_opts
@@ -44,18 +44,14 @@ module JavaBuildpack
           .add_system_property('com.wily.introscope.agent.agentName', agent_name(credentials))
           .add_system_property('introscope.agent.defaultProcessName', default_process_name(credentials))
 
-        if agent_manager_credential(credentials)
-          java_opts.add_system_property('agentManager.credential', agent_manager_credential(credentials))
-        end
-
-        add_url(credentials, java_opts)
+        export_all_properties(credentials, java_opts)
       end
 
       protected
 
       # (see JavaBuildpack::Component::VersionedDependencyComponent#supports?)
       def supports?
-        @application.services.one_service? FILTER, %w[agent_manager_url url]
+        @application.services.one_service? FILTER, %w[agentManager_url_1 agent_manager_url]
       end
 
       private
@@ -121,11 +117,24 @@ module JavaBuildpack
       end
 
       def agent_manager_url(credentials)
-        credentials['agent_manager_url'] || credentials['url']
+        credentials['agentManager_url_1'] || credentials['agent_manager_url']
       end
 
       def agent_manager_credential(credentials)
         credentials['agent_manager_credential'] || credentials['credential']
+      end
+
+      def export_all_properties(credentials, java_opts)
+        credentials.keys.each do |key|
+          correct_key = key.tr('_', '.')
+          if %w[agentManager.url.1 agent.manager.url].include?(correct_key)
+            add_url(credentials, java_opts)
+          elsif %w[agent.manager.credential credential].include?(correct_key)
+            java_opts.add_system_property('agentManager.credential', agent_manager_credential(credentials))
+          else
+            java_opts.add_system_property(correct_key, credentials[key])
+          end
+        end
       end
     end
   end

--- a/spec/java_buildpack/framework/introscope_agent_spec.rb
+++ b/spec/java_buildpack/framework/introscope_agent_spec.rb
@@ -40,7 +40,8 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
     let(:credentials) { {} }
 
     before do
-      allow(services).to receive(:one_service?).with(/introscope/, %w[agent_manager_url url]).and_return(true)
+      allow(services).to receive(:one_service?).with(/introscope/,
+                                                     %w[agentManager_url_1 agent_manager_url]).and_return(true)
       allow(services).to receive(:find_service).and_return('credentials' => credentials)
     end
 
@@ -56,7 +57,7 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
     end
 
     context do
-      let(:credentials) { { 'agent_name' => 'another-test-agent-name', 'url' => 'default-host:5001' } }
+      let(:credentials) { { 'agent_name' => 'another-test-agent-name', 'agent_manager_url' => 'default-host:5001' } }
 
       it 'adds agent_name from credentials to JAVA_OPTS if specified' do
         component.release
@@ -67,7 +68,7 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
 
     context do
 
-      let(:credentials) { { 'url' => 'test-host-name:5001' } }
+      let(:credentials) { { 'agent_manager_url' => 'test-host-name:5001' } }
 
       it 'parses the url and sets host port and default socket factory' do
         component.release
@@ -114,7 +115,7 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
     end
 
     context do
-      let(:credentials) { { 'url' => 'ssl://test-host-name:5443' } }
+      let(:credentials) { { 'agent_manager_url' => 'ssl://test-host-name:5443' } }
 
       it 'parses the url and sets host, port, and ssl socket factory' do
         component.release
@@ -160,7 +161,7 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
     end
 
     context do
-      let(:credentials) { { 'url' => 'http://test-host-name:8081' } }
+      let(:credentials) { { 'agent_manager_url' => 'http://test-host-name:8081' } }
 
       it 'parses the url and sets host, port, and http socket factory' do
         component.release
@@ -206,7 +207,7 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
     end
 
     context do
-      let(:credentials) { { 'url' => 'https://test-host-name:8444' } }
+      let(:credentials) { { 'agent_manager_url' => 'https://test-host-name:8444' } }
 
       it 'parses the url and sets host, port, and https socket factory' do
         component.release
@@ -252,7 +253,10 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
     end
 
     context do
-      let(:credentials) { { 'url' => 'https://test-host-name:8444', 'credential' => 'test-credential-cccf-88-ae' } }
+      let(:credentials) do
+        { 'agent_manager_url' => 'https://test-host-name:8444',
+          'agent_manager_credential' => 'test-credential-cccf-88-ae' }
+      end
 
       it 'sets the url and also the credential' do
         component.release
@@ -304,7 +308,7 @@ describe JavaBuildpack::Framework::IntroscopeAgent do
 
     context do
       let(:credentials) do
-        { 'agent_manager_url' => 'https://test-host-name:8444',
+        { 'agentManager_url_1' => 'https://test-host-name:8444',
           'agent_manager_credential' => 'test-credential-cccf-88-ae',
           'agent_default_process_name' => 'TestProcess' }
       end


### PR DESCRIPTION
…s. Before this commit, exporting a new property meant adding a new method to read the property key from the credentials and then setting it as a java option. After this commit, all properties that are in the credentials will be set as a java option, without the need for adding code to read each individual property. The reason for this change is to keep the introscope framework concise, and it does not need to be updated in the future for new properties.