### PR TITLE
Do not report tomcat internals

### DIFF
--- a/resources/tomcat/conf/server.xml
+++ b/resources/tomcat/conf/server.xml
@@ -25,10 +25,10 @@
             <Valve className='org.cloudfoundry.tomcat.logging.access.CloudFoundryAccessLoggingValve'
                    pattern='[ACCESS] %{org.apache.catalina.AccessLog.RemoteAddr}r %l %t %D %F %B %S vcap_request_id:%{X-Vcap-Request-Id}i'
                    enabled='${access.logging.enabled}'/>
-            <Valve className='org.apache.catalina.valves.ErrorReportValve' showReport='false' showServerInfo='false'/>
             <Host name='localhost'
                   failCtxIfServletStartFails='true'>
                 <Listener className='org.cloudfoundry.tomcat.lifecycle.ApplicationStartupFailureDetectingLifecycleListener'/>
+                <Valve className='org.apache.catalina.valves.ErrorReportValve' showReport='false' showServerInfo='false'/>
             </Host>
         </Engine>
     </Service>

--- a/resources/tomcat/conf/server.xml
+++ b/resources/tomcat/conf/server.xml
@@ -25,6 +25,7 @@
             <Valve className='org.cloudfoundry.tomcat.logging.access.CloudFoundryAccessLoggingValve'
                    pattern='[ACCESS] %{org.apache.catalina.AccessLog.RemoteAddr}r %l %t %D %F %B %S vcap_request_id:%{X-Vcap-Request-Id}i'
                    enabled='${access.logging.enabled}'/>
+            <Valve className='org.apache.catalina.valves.ErrorReportValve' showReport='false' showServerInfo='false'/>
             <Host name='localhost'
                   failCtxIfServletStartFails='true'>
                 <Listener className='org.cloudfoundry.tomcat.lifecycle.ApplicationStartupFailureDetectingLifecycleListener'/>


### PR DESCRIPTION
taken from recommencations
http://tomcat.apache.org/tomcat-9.0-doc/config/valve.html#Error_Report_Valve
Requests like
https://app/rest/java?client=test|d
causes internal error page incl. tomcat version