### PR TITLE
Add support for New Relic Java Agent 5.x.x

### DIFF
--- a/config/new_relic_agent.yml
+++ b/config/new_relic_agent.yml
@@ -15,7 +15,7 @@
 
 # Configuration for the New Relic framework
 ---
-version: 4.+
+version: 5.+
 repository_root: https://download.run.pivotal.io/new-relic
 extensions:
   version: 1.+


### PR DESCRIPTION
The version 5.1.0 has an important fix for invalid errors reported on Kafka clients, introduced by version 4.12.0
https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes/java-agent-510