### PR TITLE
have jbp always talk to service broker even if it's offline

### DIFF
--- a/lib/java_buildpack/framework/riverbed_appinternals_agent.rb
+++ b/lib/java_buildpack/framework/riverbed_appinternals_agent.rb
@@ -34,8 +34,14 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::BaseComponent#compile)
       def compile
-        download_zip(false, @droplet.sandbox, @component_name)
+        JavaBuildpack::Util::Cache::InternetAvailability.instance.available(
+          true, 'The Riverbed AppInternals download location is always accessible'
+        ) do
+          download_zip(false, @droplet.sandbox, @component_name)
+        end
         @droplet.copy_resources
+      rescue StandardError => e
+        raise "Riverbed AppInternals download failed: #{e}"
       end
 
       # (see JavaBuildpack::Component::BaseComponent#release)

--- a/lib/java_buildpack/framework/riverbed_appinternals_agent.rb
+++ b/lib/java_buildpack/framework/riverbed_appinternals_agent.rb
@@ -35,7 +35,7 @@ module JavaBuildpack
       # (see JavaBuildpack::Component::BaseComponent#compile)
       def compile
         JavaBuildpack::Util::Cache::InternetAvailability.instance.available(
-          true, 'The Riverbed AppInternals download location is always accessible'
+          true, 'Downloading from Riverbed AppInternals Service Broker'
         ) do
           download_zip(false, @droplet.sandbox, @component_name)
         end


### PR DESCRIPTION
Riverbed’s SteelCentral AppInternals software is hereby expressly designated as “NOT A CONTRIBUTION”, notwithstanding the fact that Riverbed may provide a URL or other references in its Contributions that direct the user to a copy of SteelCentral AppInternals software. Riverbed’s provision of such URL or references will not constitute a Contribution of the SteelCentral AppInternals software.

Riverbed buildpack talks to service broker to retrieve extra artifacts through URL. This is broken when offline buildpack is used. It looks like the reason is that the service broker URL is not used as cache key when offline bp is built. 

To solve this issue, at runtime, internet availability needs to be temporarily set to true when downloading the artifact. This will inform the underlying bp code to always attempt to download artifact using provided url.

When setting internet availability to true, is there a way to avoid the warning message that says "Internet availability temporarily set to true: The Riverbed AppInternals download location is always accessible"?