### PR TITLE
Add support to parse newly added access key secret field and UniqueHostID

### DIFF
--- a/config/app_dynamics_agent.yml
+++ b/config/app_dynamics_agent.yml
@@ -19,4 +19,5 @@ version: 4.+
 repository_root: https://packages.appdynamics.com/java
 default_application_name: $(jq -r -n "$VCAP_APPLICATION | .space_name + \":\" + .application_name")
 default_node_name: $(jq -r -n "$VCAP_APPLICATION | .application_name + \":$CF_INSTANCE_INDEX\"")
-default_tier_name: 
+default_tier_name:
+default_unique_host_name: $(jq -r -n "$VCAP_APPLICATION | .application_id + \":$CF_INSTANCE_INDEX\"")

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -52,6 +52,7 @@ module JavaBuildpack
         host_name java_opts, credentials
         port java_opts, credentials
         ssl_enabled java_opts, credentials
+        unique_host_name java_opts
       end
 
       protected
@@ -74,7 +75,7 @@ module JavaBuildpack
       end
 
       def account_access_key(java_opts, credentials)
-        account_access_key = credentials['account-access-key']
+        account_access_key = credentials['account-access-key'] || credentials['account-access-secret']['secret'] 
         java_opts.add_system_property 'appdynamics.agent.accountAccessKey', account_access_key if account_access_key
       end
 
@@ -111,6 +112,11 @@ module JavaBuildpack
         java_opts.add_system_property('appdynamics.agent.tierName', name.to_s)
       end
 
+      def unique_host_name(java_opts)
+        name = @configuration['default_unique_host_name'] ||  @application.details['application_name']
+        java_opts.add_system_property('appdynamics.agent.uniqueHostId', name.to_s)
+      end
+      
       # Copy default configuration present in resources folder of app_dynamics_agent ver* directories present in sandbox
       #
       # @param [Pathname] default_conf_dir the 'defaults' directory present in app_dynamics_agent resources.


### PR DESCRIPTION
-  Starting 4.7 service broker tile, we are introducing secret typed form  fields for sensitive data  (account access key) to replace text typed fields. This will lead to a different VCAP_SERVICES structure and hence requires additional parsing logic. It is a one line change to honor the secret typed field

- Please note that we are going to deprecate the older text field eventually (2 months) but till then we need to support the text field as well.

this is what new credentials structure look like
```
          "credentials": {
            "account-access-key": null,
            "account-access-secret": {
              "secret": "60dbc1a8-043c-44f7-93f8-e18aeb0b8274"
            },```

- Have also added UNIQUE_HOST_ID in the config for our container correlation