### PR TITLE
Update version of agents to be consistent with the latest releases

### DIFF
--- a/config/introscope_agent.yml
+++ b/config/introscope_agent.yml
@@ -15,6 +15,6 @@
 
 # Configuration for the CA Wily framework
 ---
-version: 10.+
+version: 11.+
 repository_root: https://ca.bintray.com/apm-agents
 default_agent_name: $(jq -r -n "$VCAP_APPLICATION | .application_name")

--- a/config/introscope_agent.yml
+++ b/config/introscope_agent.yml
@@ -16,5 +16,5 @@
 # Configuration for the CA Wily framework
 ---
 version: 11.+
-repository_root: https://ca.bintray.com/apm-agents
+repository_root: https://ca.bintray.com/test-agents
 default_agent_name: $(jq -r -n "$VCAP_APPLICATION | .application_name")


### PR DESCRIPTION
Before this commit, the current version of agents to be downloaded was 10.+. After this commit, the version will be 11.+.