### PR TITLE
Revert "Added default_server_name to Contrast Security Framework"

### DIFF
--- a/config/contrast_security_agent.yml
+++ b/config/contrast_security_agent.yml
@@ -16,5 +16,4 @@
 # Configuration for the ContrastSecurity framework
 ---
 version: 3.+
-default_server_name: $(jq -r -n "$VCAP_APPLICATION | .space_name + \":\" + .application_name | @sh"):$CF_INSTANCE_INDEX
 repository_root: https://artifacts.contrastsecurity.com/agents/java

--- a/docs/framework-contrast_security_agent.md
+++ b/docs/framework-contrast_security_agent.md
@@ -27,7 +27,6 @@ The framework can be configured by modifying the [`config/contrast_security_agen
 | Name | Description
 | ---- | -----------
 | `repository_root` | The URL of the Contrast Security repository index ([details][repositories]).
-| `default_server_name` | The default server name for this application in the Contrast dashboard. The default value is an expression that will be evaluated based on the `space_name`, `application_name`, and `instance_index` of the application. |
 | `version` | The version of Contrast Security to use. Candidate versions can be found in [this listing][].
 
 [Contrast Security]: https://www.contrastsecurity.com

--- a/lib/java_buildpack/framework/contrast_security_agent.rb
+++ b/lib/java_buildpack/framework/contrast_security_agent.rb
@@ -40,7 +40,6 @@ module JavaBuildpack
       # (see JavaBuildpack::Component::BaseComponent#release)
       def release
         @droplet.java_opts.add_system_property('contrast.override.appname', application_name) unless appname_exist?
-        @droplet.java_opts.add_system_property('contrast.server', server_name) unless server_exist?
 
         @droplet.java_opts
                 .add_system_property('contrast.dir', '$TMPDIR')
@@ -117,15 +116,6 @@ module JavaBuildpack
 
       def contrast_config
         @droplet.sandbox + 'contrast.config'
-      end
-
-      def server_exist?
-        @droplet.java_opts.any? { |java_opt| java_opt =~ /contrast.server/ }
-      end
-
-      def server_name
-        @configuration['default_server_name'] ||
-          "#{@application.details['space_name']}:#{@application.details['application_name']}:$CF_INSTANCE_INDEX"
       end
 
       def short_version

--- a/spec/java_buildpack/framework/contrast_security_agent_spec.rb
+++ b/spec/java_buildpack/framework/contrast_security_agent_spec.rb
@@ -77,7 +77,6 @@ describe JavaBuildpack::Framework::ContrastSecurityAgent do
         '=$PWD/.java-buildpack/contrast_security_agent/contrast.config')
       expect(java_opts).to include('-Dcontrast.dir=$TMPDIR')
       expect(java_opts).to include('-Dcontrast.override.appname=test-application-name')
-      expect(java_opts).to include('-Dcontrast.server=test-space-name:test-application-name:$CF_INSTANCE_INDEX')
     end
 
     it 'created contrast.config',
@@ -94,15 +93,6 @@ describe JavaBuildpack::Framework::ContrastSecurityAgent do
 
       expect(java_opts).to include('-Dcontrast.override.appname=NAME_ALREADY_OVERRIDDEN')
       expect(java_opts).not_to include('-Dcontrast.override.appname=test-application-name')
-    end
-
-    it 'does not override server if there is an existing server' do
-      java_opts.add_system_property('contrast.server', 'NAME_ALREADY_OVERRIDDEN')
-
-      component.release
-
-      expect(java_opts).to include('-Dcontrast.server=NAME_ALREADY_OVERRIDDEN')
-      expect(java_opts).not_to include('-Dcontrast.server=test-space-name:test-application-name:$CF_INSTANCE_INDEX')
     end
 
   end


### PR DESCRIPTION
This reverts commit cd849e8ba7d385946f4e99233c2525188fcb6e20 from this Pull Request https://github.com/cloudfoundry/java-buildpack/pull/702

cd849e8 introduced a default server naming convention that was in conflict with the ways that others were setting server names. We would like to return to the server naming behavior as it was before cd849e8. We've discussed this change with @owenfarrell 