### PR TITLE
Added node prefix env var

### DIFF
--- a/config/app_dynamics_agent.yml
+++ b/config/app_dynamics_agent.yml
@@ -18,6 +18,6 @@
 version: 4.+
 repository_root: https://packages.appdynamics.com/java
 default_application_name: $(jq -r -n "$VCAP_APPLICATION | .space_name + \":\" + .application_name | @sh")
-default_node_name: $(jq -r -n "$VCAP_APPLICATION | .application_name + \":$CF_INSTANCE_INDEX\"")
+default_node_name: $(jq -r -n "\"$APPD_CF_NODE_PREFIX\" + ($VCAP_APPLICATION | .application_name) + \":$CF_INSTANCE_INDEX\"")
 default_tier_name: 
 default_unique_host_name: $(jq -r -n "$VCAP_APPLICATION | .application_id + \":$CF_INSTANCE_INDEX\"")


### PR DESCRIPTION
I'd like to submit this change to support customizing the AppD node name that's reported by the APM agent. It assumes an optional env var APPD_CF_NODE_PREFIX that when set to a non empty value would add the value as a prefix to the node name assigned by the buildpack. For example, setting it as follows for an app called 'cf-java-app' with default node name 'cf-java-app:index'
    APPD_CF_NODE_PREFIX: pcf-node-
would cause node name to be reported as 'pcf-node-cf-java-app:index'