### PR TITLE
Enable configuration override during compile phase if a config server is specified via manifest

### DIFF
--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -117,9 +117,9 @@ module JavaBuildpack
         java_opts.add_system_property('appdynamics.agent.uniqueHostId', name.to_s)
       end
 
-      # Copy default configuration present in resources folder of  ver* directories present in sandbox
+      # Copy default configuration present in resources folder of app_dynamics_agent ver* directories present in sandbox
       #
-      # @param [Pathname] default_conf_dir the 'defaults' directory present in  resources.
+      # @param [Pathname] default_conf_dir the 'defaults' directory present in app_dynamics_agent resources.
       # @return [Void]
       def copy_appd_default_configuration(default_conf_dir)
         return unless default_conf_dir.exist?

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -176,9 +176,8 @@ module JavaBuildpack
           # `download` uses retries with exponential backoff which is expensive and unnecessary
           # for situations like 404 File not Found. Also, `download` does not have an api exposed
           # to disable retries, which makes this check necessary to prevent long install times.
-          if not check_if_resource_exists(uri, conf_file)
-            next
-          end
+          next unless check_if_resource_exists(uri, conf_file)
+          
           download(false, uri.scheme + '://' + uri.host + uri.path)  do |file|
             Dir.glob(@droplet.sandbox + 'ver*') do |target_directory|
               FileUtils.cp_r file, target_directory + '/conf/' + conf_file

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -161,7 +161,7 @@ module JavaBuildpack
       # @return [Void]
       def override_default_config_if_applicable()
         return unless @application.environment['APPD_CONF_HTTP_URL']
-        config_files = [
+        conf_files = [
           '/logging/log4j2.xml',
           '/logging/log4j.xml',
           '/app-agent-config.xml',

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -34,7 +34,7 @@ module JavaBuildpack
         resources_dir = Pathname.new(File.expand_path('../../../resources', __dir__)).freeze
         default_conf_dir = resources_dir + @droplet.component_id + 'defaults'
         copy_appd_default_configuration(default_conf_dir)
-        override_default_configuration()
+        override_default_config_if_applicable()
         @droplet.copy_resources
       end
 
@@ -151,7 +151,7 @@ module JavaBuildpack
 
       # Check for configuration files on a remote server. If found, copy to conf dir under each ver* dir
       # @return [Void]
-      def override_default_configuration()
+      def override_default_config_if_applicable()
         return unless @application.environment['APPD_CONF_HTTP_URL']
 
         conf_files_map = {

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -173,11 +173,12 @@ module JavaBuildpack
         conf_files.each do |conf_file|
           uri = URI.join(@application.environment['APPD_CONF_HTTP_URL'], conf_file)
 
-          # `download` uses retries with exponential backoff which is expensive and unnecessary
-          # for situations like 404 File not Found. Also, `download` does not have an api exposed
-          # to disable retries, which makes this check necessary to prevent long install times.
+          # `download()` uses retries with exponential backoff which is expensive
+          # for situations like 404 File not Found. Also, `download()` doesn't expose 
+          # an api to disable retries, which makes this check necessary to prevent 
+          # long install times.
           next unless check_if_resource_exists(uri, conf_file)
-          
+
           download(false, uri.scheme + '://' + uri.host + uri.path)  do |file|
             Dir.glob(@droplet.sandbox + 'ver*') do |target_directory|
               FileUtils.cp_r file, target_directory + '/conf/' + conf_file

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -171,7 +171,7 @@ module JavaBuildpack
         ]
 
         conf_files.each do |conf_file|
-          uri = URI.join(@application.environment['APPD_CONF_HTTP_URL'], conf_file)
+          uri = URI(@application.environment['APPD_CONF_HTTP_URL'].chomp('/') + '/' + conf_file)
 
           # `download()` uses retries with exponential backoff which is expensive
           # for situations like 404 File not Found. Also, `download()` doesn't expose 

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -179,7 +179,7 @@ module JavaBuildpack
           if not check_if_resource_exists(uri, conf_file)
             next
           end
-          download(false, uri.host + uri.path)  do |file|
+          download(false, uri.scheme + uri.host + uri.path)  do |file|
             Dir.glob(@droplet.sandbox + 'ver*') do |target_directory|
               FileUtils.cp_r file, target_directory + '/conf/' + conf_file
             end

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -130,8 +130,8 @@ module JavaBuildpack
       end
 
       # Check if configuration file exists on the server before download
-      # @param [Path] path Path to the resource on the server
-      # @param [ConfigName] conf_file Name of the configuration file
+      # @param [ResourceURI] uri URI of the remote configuration server
+      # @param [ConfigFileName] conf_file Name of the configuration file
       # @return [Boolean] returns true if files exists on path specified by APPD_CONF_HTTP_URL, false otherwise
       def check_if_resource_exists(resource_uri, conf_file)
         # check if resource exists on remote server

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -179,7 +179,7 @@ module JavaBuildpack
           if not check_if_resource_exists(uri, conf_file)
             next
           end
-          download(false, uri.scheme + "://" + uri.host + uri.path)  do |file|
+          download(false, uri.scheme + '://' + uri.host + uri.path)  do |file|
             Dir.glob(@droplet.sandbox + 'ver*') do |target_directory|
               FileUtils.cp_r file, target_directory + '/conf/' + conf_file
             end

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -137,8 +137,13 @@ module JavaBuildpack
       def check_if_resource_exists(path, conf_type, conf_file)
           resource_uri = URI(path)
           # check if resource exists on remote server
-          response = Net::HTTP.start(resource_uri.host, resource_uri.port) do |http|
-            http.request_head(resource_uri)
+          begin
+            response = Net::HTTP.start(resource_uri.host, resource_uri.port) do |http|
+              http.request_head(resource_uri)
+            end
+          rescue Exception => e
+            puts e.inspect
+            return false
           end
 
           if response.code == '404'
@@ -146,7 +151,6 @@ module JavaBuildpack
             return false
           end
         return true
-
       end
 
       # Check for configuration files on a remote server. If found, copy to conf dir under each ver* dir

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -179,7 +179,7 @@ module JavaBuildpack
           if not check_if_resource_exists(uri, conf_file)
             next
           end
-          download(false, uri.scheme + uri.host + uri.path)  do |file|
+          download(false, uri.scheme + "://" + uri.host + uri.path)  do |file|
             Dir.glob(@droplet.sandbox + 'ver*') do |target_directory|
               FileUtils.cp_r file, target_directory + '/conf/' + conf_file
             end

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -171,7 +171,7 @@ module JavaBuildpack
         ]
 
         conf_files.each do |conf_file|
-          uri = URI(@application.environment['APPD_CONF_HTTP_URL'].chomp!('/') + '/' + conf_file)
+          uri = URI(@application.environment['APPD_CONF_HTTP_URL'].chomp('/') + '/' + conf_file)
 
           # `download()` uses retries with exponential backoff which is expensive
           # for situations like 404 File not Found. Also, `download()` doesn't expose 

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -152,7 +152,7 @@ module JavaBuildpack
             puts "redirected to #{location}"
             return check_if_resource_exists(location, conf_file)
           else
-            puts "Could not retrieve #{conf_file}. Status code: #{response.code}"
+            puts "Could not retrieve #{conf_file}.  Code: #{response.code} Message: #{response.message}"
             return false
         end
       end

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -179,7 +179,7 @@ module JavaBuildpack
           # long install times.
           next unless check_if_resource_exists(uri, conf_file)
 
-          download(false, uri.scheme + '://' + uri.host + uri.path)  do |file|
+          download(false, "#{uri}")  do |file|
             Dir.glob(@droplet.sandbox + 'ver*') do |target_directory|
               FileUtils.cp_r file, target_directory + '/conf/' + conf_file
             end

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -129,10 +129,10 @@ module JavaBuildpack
         end
       end
 
-      # Check if configuration file exists on the server before downloading
+      # Check if configuration file exists on the server before download
       # @param [Path] path Path to the resource on the server
-      # @paran [ConfigType] conf_type Type of Configuration file
-      # @paran [ConfigName] conf_file Name of the configuration file
+      # @param [ConfigType] conf_type Type of Configuration file
+      # @param [ConfigName] conf_file Name of the configuration file
       # @return [Boolean] returns true if files exists on path specified by APPD_CONF_HTTP_URL, false otherwise
       def check_if_resource_exists(path, conf_type, conf_file)
           resource_uri = URI(path)

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -171,7 +171,7 @@ module JavaBuildpack
         ]
 
         conf_files.each do |conf_file|
-          uri = URI(@application.environment['APPD_CONF_HTTP_URL'].chomp('/') + '/' + conf_file)
+          uri = URI(@application.environment['APPD_CONF_HTTP_URL'].chomp!('/') + '/' + conf_file)
 
           # `download()` uses retries with exponential backoff which is expensive
           # for situations like 404 File not Found. Also, `download()` doesn't expose 

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -133,7 +133,7 @@ module JavaBuildpack
       # @param [Path] path Path to the resource on the server
       # @paran [ConfigType] conf_type Type of Configuration file
       # @paran [ConfigName] conf_file Name of the configuration file
-      # @return [Boolean]
+      # @return [Boolean] returns true if files exists on path specified by APPD_CONF_HTTP_URL, false otherwise
       def check_if_resource_exists(path, conf_type, conf_file)
           resource_uri = URI(path)
           # check if resource exists on remote server

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -162,12 +162,12 @@ module JavaBuildpack
       def override_default_config_if_applicable()
         return unless @application.environment['APPD_CONF_HTTP_URL']
         config_files = [
-          'logging/log4j2.xml',
-          'logging/log4j.xml',
-          'app-agent-config.xml',
-          'controller-info.xml',
-          'service-endpoint.xml',
-          'transactions.xml'
+          '/logging/log4j2.xml',
+          '/logging/log4j.xml',
+          '/app-agent-config.xml',
+          '/controller-info.xml',
+          '/service-endpoint.xml',
+          '/transactions.xml'
         ]
 
         conf_files.each do |conf_file|

--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -162,12 +162,12 @@ module JavaBuildpack
       def override_default_config_if_applicable()
         return unless @application.environment['APPD_CONF_HTTP_URL']
         conf_files = [
-          '/logging/log4j2.xml',
-          '/logging/log4j.xml',
-          '/app-agent-config.xml',
-          '/controller-info.xml',
-          '/service-endpoint.xml',
-          '/transactions.xml'
+          'logging/log4j2.xml',
+          'logging/log4j.xml',
+          'app-agent-config.xml',
+          'controller-info.xml',
+          'service-endpoint.xml',
+          'transactions.xml'
         ]
 
         conf_files.each do |conf_file|


### PR DESCRIPTION
Enables agent log messages to be routed to stdout by overriding agent and log config during compile phase