### PR TITLE
Enable config override if APPD_CONF_HTTP_URL is specified. 

### DIFF
--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -24,6 +24,19 @@ module JavaBuildpack
 
     # Encapsulates the functionality for enabling zero-touch AppDynamics support.
     class AppDynamicsAgent < JavaBuildpack::Component::VersionedDependencyComponent
+      @conf_files = [
+        'logging/log4j2.xml',
+        'logging/log4j.xml',
+        'app-agent-config.xml',
+        'controller-info.xml',
+        'service-endpoint.xml',
+        'transactions.xml'
+      ]
+
+      def initialize(context)
+        super(context)
+        @logger = JavaBuildpack::Logging::LoggerFactory.instance.get_logger AppDynamicsAgent
+      end
 
       # (see JavaBuildpack::Component::BaseComponent#compile)
       def compile
@@ -34,7 +47,7 @@ module JavaBuildpack
         default_conf_dir = resources_dir + @droplet.component_id + 'defaults'
 
         copy_appd_default_configuration(default_conf_dir)
-
+        override_default_config_if_applicable
         @droplet.copy_resources
       end
 
@@ -129,7 +142,57 @@ module JavaBuildpack
         end
       end
 
-    end
+      # Check if configuration file exists on the server before download
+      # @param [ResourceURI] uri URI of the remote configuration server
+      # @param [ConfigFileName] conf_file Name of the configuration file
+      # @return [Boolean] returns true if files exists on path specified by APPD_CONF_HTTP_URL, false otherwise
+      def check_if_resource_exists(resource_uri, conf_file)
+        # check if resource exists on remote server
+        begin
+          response = Net::HTTP.start(resource_uri.host, resource_uri.port) do |http|
+            http.request_head(resource_uri)
+          end
+        rescue StandardError => e
+          @logger.error { "Request failure: #{e.message}" }
+          return false
+        end
 
+        case response
+        when Net::HTTPSuccess
+          return true
+        when Net::HTTPRedirection
+          location = response['location']
+          @logger.info { "redirected to #{location}" }
+          return check_if_resource_exists(location, conf_file)
+        else
+          @logger.info { "Could not retrieve #{resource_uri}.  Code: #{response.code} Message: #{response.message}" }
+          return false
+        end
+      end
+
+      # Check for configuration files on a remote server. If found, copy to conf dir under each ver* dir
+      # @return [Void]
+      def override_default_config_if_applicable
+        return unless @application.environment['APPD_CONF_HTTP_URL']
+
+        agent_root = @application.environment['APPD_CONF_HTTP_URL'].chomp('/') + '/java/'
+        @logger.info { "Downloading override configuration files from #{agent_root}" }
+        JavaBuildpack::Framework::AppDynamicsAgent.instance_variable_get(:@conf_files).each do |conf_file|
+          uri = URI(agent_root + conf_file)
+
+          # `download()` uses retries with exponential backoff which is expensive
+          # for situations like 404 File not Found. Also, `download()` doesn't expose
+          # an api to disable retries, which makes this check necessary to prevent
+          # long install times.
+          next unless check_if_resource_exists(uri, conf_file)
+
+          download(false, uri.to_s) do |file|
+            Dir.glob(@droplet.sandbox + 'ver*') do |target_directory|
+              FileUtils.cp_r file, target_directory + '/conf/' + conf_file
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/java_buildpack/framework/app_dynamics_agent_spec.rb
+++ b/spec/java_buildpack/framework/app_dynamics_agent_spec.rb
@@ -141,8 +141,25 @@ describe JavaBuildpack::Framework::AppDynamicsAgent do
           expect(java_opts).to include('-Dappdynamics.agent.accountAccessKey=test-account-access-key')
         end
       end
+
+      context do
+
+        let(:environment) { { 'APPD_CONF_HTTP_URL' => 'http://foo.com' } }
+        let(:conf_files) { described_class.instance_variable_get(:@conf_files) }
+
+        it 'sets APPD_CONF_HTTP_URL env var to download config files from',
+           cache_fixture: 'stub-app-dynamics-agent.zip' do
+          conf_files.each do |file|
+            uri = "http://foo.com/java/#{file}"
+            allow(application_cache).to receive(:get)
+              .with(uri)
+            stub_request(:head, uri)
+              .with(headers: { 'Accept' => '*/*', 'Host' => 'foo.com', 'User-Agent' => 'Ruby' })
+              .to_return(status: 200, body: '', headers: {})
+          end
+          component.compile
+        end
+      end
     end
-
   end
-
 end


### PR DESCRIPTION
These changes implements feature described in "Extending agent configuration" section of https://docs.pivotal.io/partners/appdynamics/multibuildpack.html

If APPD_CONF_HTTP_URL is specified, any configuration files found on the configuration server will be mapped to corresponding directory of the java agent to override the default configuration.