### PR TITLE
Buildpack test fails. Issue #770

### DIFF
--- a/spec/java_buildpack/util/configuration_utils_spec.rb
+++ b/spec/java_buildpack/util/configuration_utils_spec.rb
@@ -115,7 +115,7 @@ describe JavaBuildpack::Util::ConfigurationUtils do
     context do
 
       let(:environment) do
-        { 'JBP_CONFIG_TEST' => '{version:1.8.+}' }
+        { 'JBP_CONFIG_TEST' => '{version:1.8.+' }
       end
 
       it 'diagnoses invalid YAML syntax' do


### PR DESCRIPTION
The test to diagnose invalid YAML fails. This commit fixes the test case by correcting JBP_CONFIG_TEST.

Resolves: #770