### PR TITLE
Update documentation to include samples to add custom configuration for introscope agent

### DIFF
--- a/docs/framework-introscope_agent.md
+++ b/docs/framework-introscope_agent.md
@@ -48,6 +48,30 @@ The framework can be configured by modifying the [`config/introscope_agent.yml`]
 ### Additional Resources
 The framework can also be configured by overlaying a set of resources on the default distribution.  To do this, add files to the `resources/ca_wily_agent` directory in the buildpack fork.  For example, to override the default profile add your custom profile to `resources/introscope_agent/`.
 
+##### Example for 10.x
+```
+resources/
+    |-introscope_agent/
+          |-core/
+              |-config/
+                   |-IntroscopeAgent.profile                 # place custom Introscope Profile under the config folder
+                   |-hotdeploy/                              # place custom pbd files under the hotdeploy folder
+                         |-example.pbd
+```
+
+##### Example for 11.1.x
+```
+resources/
+    |-introscope_agent/
+            |-releases/
+                 |-11.1/
+                     |-core/
+                         |-config/
+                              |-IntroscopeAgent.profile     # place custom Introscope Profile under the config folder
+                              |-hotdeploy/                  # place custom pbd files under the hotdeploy folder
+                                     |-example.pbd
+```
+
 [Configuration and Extension]: ../README.md#configuration-and-extension
 [`config/intoscope_agent.yml`]: ../config/intoscope_agent.yml
 [Introscope service]: http://www.ca.com/us/opscenter/ca-application-performance-management.aspx

--- a/docs/framework-introscope_agent.md
+++ b/docs/framework-introscope_agent.md
@@ -46,7 +46,7 @@ The framework can be configured by modifying the [`config/introscope_agent.yml`]
 | `version` | The version of Introscope Agent to use.
 
 ### Additional Resources
-The framework can also be configured by overlaying a set of resources on the default distribution.  To do this, add files to the `resources/ca_wily_agent` directory in the buildpack fork.  For example, to override the default profile add your custom profile to `resources/introscope_agent/`.
+The framework can also be configured by overlaying a set of resources on the default distribution.  To do this, add files to the `resources/introscope_agent` directory in the buildpack fork. 
 
 ##### Example for 10.x
 ```


### PR DESCRIPTION
Added examples to add custom configuration files for 10.x and 11.x Introscope Agent, because 11.x uses different file structure.  