### PR TITLE
Switch back to normal downloading of our profiler

### DIFF
--- a/docs/framework-riverbed_appinternals_agent.md
+++ b/docs/framework-riverbed_appinternals_agent.md
@@ -52,3 +52,7 @@ The framework can be configured by modifying the [`config/riverbed_appinternals_
 **NOTE**
 
 If the Riverbed Service Broker's version is greater than or equal to 10.20, the buildpack will instead download Riverbed AppInternals agent from Riverbed Service Broker and will fall back to using `repository_root` in [`config/riverbed_appinternals_agent.yml`][] only if Service Broker failed to serve the Agent artifact.
+
+**NOTE**
+
+If the Rivered verstion is 10.21.9 or later, the buildpack will load the profiler normally, instead of from the Service Broker. This allows for creating multiple offline buildpacks containing different versions.

--- a/lib/java_buildpack/framework/riverbed_appinternals_agent.rb
+++ b/lib/java_buildpack/framework/riverbed_appinternals_agent.rb
@@ -29,19 +29,19 @@ module JavaBuildpack
       # @param [Hash] context a collection of utilities used the component
       def initialize(context)
         super(context)
-        @uri = download_url(credentials, @uri)
+###        @uri = download_url(credentials, @uri)
       end
 
       # (see JavaBuildpack::Component::BaseComponent#compile)
       def compile
-        JavaBuildpack::Util::Cache::InternetAvailability.instance.available(
-          true, 'Downloading from Riverbed AppInternals Service Broker'
-        ) do
+###        JavaBuildpack::Util::Cache::InternetAvailability.instance.available(
+###          true, 'Downloading from Riverbed AppInternals Service Broker'
+###        ) do
           download_zip(false, @droplet.sandbox, @component_name)
-        end
+###        end
         @droplet.copy_resources
-      rescue StandardError => e
-        raise "Riverbed AppInternals download failed: #{e}"
+###      rescue StandardError => e
+###        raise "Riverbed AppInternals download failed: #{e}"
       end
 
       # (see JavaBuildpack::Component::BaseComponent#release)
@@ -107,9 +107,9 @@ module JavaBuildpack
         credentials['rvbd_moniker'] || @configuration['rvbd_moniker']
       end
 
-      def download_url(credentials, default_url)
-        (credentials[PROFILERURL] unless credentials.nil?) || default_url
-      end
+###      def download_url(credentials, default_url)
+###        (credentials[PROFILERURL] unless credentials.nil?) || default_url
+###      end
 
     end
   end

--- a/spec/java_buildpack/framework/riverbed_appinternals_agent_spec.rb
+++ b/spec/java_buildpack/framework/riverbed_appinternals_agent_spec.rb
@@ -31,8 +31,8 @@ describe JavaBuildpack::Framework::RiverbedAppinternalsAgent do
     before do
       allow(services).to receive(:one_service?).with(/appinternals/).and_return(true)
 
-      allow(services).to receive(:find_service).and_return('credentials' => { 'profilerUrlLinux' =>
-                                                                                'http://testfoobar/profiler.zip' })
+###      allow(services).to receive(:find_service).and_return('credentials' => { 'profilerUrlLinux' =>
+###                                                                                'http://testfoobar/profiler.zip' })
 
       allow(application_cache).to receive(:get).with('http://testfoobar/profiler.zip')
                                                .and_yield(Pathname.new('spec/fixtures/'\


### PR DESCRIPTION
No longer downloaded from the Service Broker. This is necessary for customers to be able to create offline buildpacks for various versions.  They want to do that so that they can upgrade applications one by one to the new version of our software, after their internal testing.