### PR TITLE
Update Java Memory Assistant

### DIFF
--- a/config/java_memory_assistant.yml
+++ b/config/java_memory_assistant.yml
@@ -30,6 +30,11 @@ agent:
     eden: 
     survivor: 
     old_gen: ">600MB"
+    tenured_gen:
+    code_heap.non_nmethods:
+    code_heap.non_profiled_nmethods:
+    code_heap.profiled_nmethods:
+
 clean_up:
   version: 0.+
   repository_root: https://raw.githubusercontent.com/SAP/java-memory-assistant-tools/repository-cu

--- a/docs/framework-java_memory_assistant.md
+++ b/docs/framework-java_memory_assistant.md
@@ -46,6 +46,13 @@ The timestamp pattern `%ts:yyyyMMdd'T'mmssSSSZ%` is equivalent to the `%FT%T%z` 
 | Eden                   | `eden`             |
 | Survivor               | `survivor`         |
 | Old Generation         | `old_gen`          |
+| Tenured Gen            | `tenured_gen`      |
+| CodeHeap 'non-nmethods' | `code_heap.non_nmethods` |
+| CodeHeap 'profiled nmethods' | `code_heap.profiled_nmethods` |
+| CodeHeap 'non-profiled nmethods' | `code_heap.non_profiled_nmethods` |
+
+Different builds and versions of Java Virtual Machines offer different memory areas.
+The list of supported Java Virtual Machines and the respective memory areas can be found in the [Java Memory Assistant documentation](https://github.com/SAP/java-memory-assistant#supported-jvms).
 
 The default values can be found in the [`config/java_memory_assistant.yml`][] file.
 

--- a/lib/java_buildpack/framework/java_memory_assistant/agent.rb
+++ b/lib/java_buildpack/framework/java_memory_assistant/agent.rb
@@ -51,12 +51,15 @@ module JavaBuildpack
         end
 
         add_system_prop_if_config_present 'check_interval', 'jma.check_interval'
-        add_system_prop_if_config_present 'max_frequency', 'jma.max_frequency'
+
+        if @configuration.key?('max_frequency')
+          @droplet.java_opts.add_preformatted_options "'-Djma.max_frequency=#{@configuration['max_frequency']}'"
+        end
 
         return unless @configuration.key?('thresholds')
 
         @configuration['thresholds'].each do |key, value|
-          @droplet.java_opts.add_system_property "jma.thresholds.#{key}", value.to_s
+          @droplet.java_opts.add_preformatted_options "'-Djma.thresholds.#{key}=#{value.to_s}'"
         end
       end
 

--- a/lib/java_buildpack/framework/java_memory_assistant/agent.rb
+++ b/lib/java_buildpack/framework/java_memory_assistant/agent.rb
@@ -42,6 +42,14 @@ module JavaBuildpack
                 .add_system_property('jma.heap_dump_name', %("#{name_pattern}"))
                 .add_system_property 'jma.log_level', normalized_log_level
 
+        if @droplet.java_home.java_9_or_later?
+          # Enable access to com.sun.management.HotSpotDiagnosticMXBean to circumvent
+          # Java modules limitations in Java 9+
+          # See https://github.com/SAP/java-memory-assistant#running-the-java-memory-assistant-on-java-11
+          @droplet.java_opts
+                .add_preformatted_options('--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED')
+        end
+
         add_system_prop_if_config_present 'check_interval', 'jma.check_interval'
         add_system_prop_if_config_present 'max_frequency', 'jma.max_frequency'
 

--- a/spec/java_buildpack/framework/java_memory_assistant/agent_spec.rb
+++ b/spec/java_buildpack/framework/java_memory_assistant/agent_spec.rb
@@ -59,10 +59,10 @@ describe JavaBuildpack::Framework::JavaMemoryAssistantAgent do
       expect(java_opts).to include('-Djma.enabled=true')
 
       expect(java_opts).to include('-Djma.check_interval=5s')
-      expect(java_opts).to include('-Djma.max_frequency=1/1m')
+      expect(java_opts).to include('\'-Djma.max_frequency=1/1m\'')
 
-      expect(java_opts).to include('-Djma.thresholds.heap=90')
-      expect(java_opts).to include('-Djma.thresholds.old_gen=90')
+      expect(java_opts).to include('\'-Djma.thresholds.heap=90\'')
+      expect(java_opts).to include('\'-Djma.thresholds.old_gen=90\'')
 
     end
 
@@ -132,15 +132,15 @@ describe JavaBuildpack::Framework::JavaMemoryAssistantAgent do
         'java-memory-assistant-0.1.0.jar')
       expect(java_opts).to include('-Djma.enabled=true')
       expect(java_opts).to include('-Djma.check_interval=10m')
-      expect(java_opts).to include('-Djma.max_frequency=4/10h')
+      expect(java_opts).to include('\'-Djma.max_frequency=4/10h\'')
       expect(java_opts).to include('-Djma.log_level=DEBUG')
-      expect(java_opts).to include('-Djma.thresholds.heap=60')
-      expect(java_opts).to include('-Djma.thresholds.code_cache=30')
-      expect(java_opts).to include('-Djma.thresholds.metaspace=5')
-      expect(java_opts).to include('-Djma.thresholds.perm_gen=45.5')
-      expect(java_opts).to include('-Djma.thresholds.eden=90')
-      expect(java_opts).to include('-Djma.thresholds.survivor=95.5')
-      expect(java_opts).to include('-Djma.thresholds.old_gen=30')
+      expect(java_opts).to include('\'-Djma.thresholds.heap=60\'')
+      expect(java_opts).to include('\'-Djma.thresholds.code_cache=30\'')
+      expect(java_opts).to include('\'-Djma.thresholds.metaspace=5\'')
+      expect(java_opts).to include('\'-Djma.thresholds.perm_gen=45.5\'')
+      expect(java_opts).to include('\'-Djma.thresholds.eden=90\'')
+      expect(java_opts).to include('\'-Djma.thresholds.survivor=95.5\'')
+      expect(java_opts).to include('\'-Djma.thresholds.old_gen=30\'')
     end
 
   end
@@ -157,6 +157,30 @@ describe JavaBuildpack::Framework::JavaMemoryAssistantAgent do
 
       expect(java_opts).to include('-Djma.log_level=DEBUG')
     end
+
+  end
+
+  context do
+    let(:configuration) do
+      {
+        'thresholds' => {
+          'heap' => '>600MB',
+          'eden' => '< 30MB'
+        }
+      }
+    end
+
+    let(:version) { '0.1.0' }
+
+    it 'escapses redirection characters' do
+      component.release
+
+      expect(java_opts).to include('-javaagent:$PWD/.java-buildpack/java_memory_assistant_agent/' \
+        'java-memory-assistant-0.1.0.jar')
+
+        expect(java_opts).to include('\'-Djma.thresholds.heap=>600MB\'')
+        expect(java_opts).to include('\'-Djma.thresholds.eden=< 30MB\'')
+      end
 
   end
 


### PR DESCRIPTION
Adjust the integration of the Java Memory Assistant so that version 0.4.0 works with Java 9+. On Java 9+, the JMA needs an exception to the Java Module system must be added
(specifically, `--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED`)
to allow access to `com.sun.management.HotSpotDiagnosticMXBean`, which is
needed to created heap dumps in live mode.

This PR enables to use the JMA with the following JVMs (and more, these are the one tested):

- AdoptOpenJDK HotSpot 8.x
- AdoptOpenJDK HotSpot 11.x
- OpenJDK 11.x
- Oracle JVM 11.x
- Pivotal JDK 8.x
- SAP Machine 11.x

