### PR TITLE
#795 Handle url-encoded proxy user and password

### DIFF
--- a/lib/java_buildpack/util/cache/download_cache.rb
+++ b/lib/java_buildpack/util/cache/download_cache.rb
@@ -314,8 +314,11 @@ module JavaBuildpack
                         URI.parse(ENV['http_proxy'] || ENV['HTTP_PROXY'] || '')
                       end
 
-          @logger.debug { "Proxy: #{proxy_uri.host}, #{proxy_uri.port}, #{proxy_uri.user}, #{proxy_uri.password}" }
-          Net::HTTP::Proxy(proxy_uri.host, proxy_uri.port, proxy_uri.user, proxy_uri.password)
+          proxy_user = proxy_uri.user ? URI.decode_www_form_component(proxy_uri.user) : nil
+          proxy_pass = proxy_uri.password ? URI.decode_www_form_component(proxy_uri.password) : nil
+
+          @logger.debug { "Proxy: #{proxy_uri.host}, #{proxy_uri.port}, #{proxy_user}, #{proxy_pass}" }
+          Net::HTTP::Proxy(proxy_uri.host, proxy_uri.port, proxy_user, proxy_pass)
         end
 
         def redirect?(response)

--- a/spec/java_buildpack/util/cache/download_cache_spec.rb
+++ b/spec/java_buildpack/util/cache/download_cache_spec.rb
@@ -225,6 +225,22 @@ describe JavaBuildpack::Util::Cache::DownloadCache do
 
   context do
 
+    let(:environment) { { 'HTTP_PROXY' => 'http://user%21:pass%40@proxy:9000', 'http_proxy' => nil } }
+
+    it 'decodes user/pass from HTTP_PROXY if encoded' do
+      stub_request(:get, uri)
+        .to_return(status: 200, body: 'foo-cached', headers: { Etag: 'foo-etag',
+                                                               'Last-Modified' => 'foo-last-modified' })
+
+      allow(Net::HTTP).to receive(:Proxy).with('proxy', 9000, /user!/, /pass@/).and_call_original
+
+      download_cache.get(uri) {}
+    end
+
+  end
+
+  context do
+
     let(:environment) { { 'https_proxy' => 'http://proxy:9000', 'HTTPS_PROXY' => nil } }
 
     it 'uses https_proxy if specified and URL is secure' do
@@ -251,6 +267,22 @@ describe JavaBuildpack::Util::Cache::DownloadCache do
 
       allow(Net::HTTP).to receive(:Proxy).and_call_original
       allow(Net::HTTP).to receive(:Proxy).with('proxy', 9000, nil, nil).and_call_original
+
+      download_cache.get(uri_secure) {}
+    end
+
+  end
+
+  context do
+
+    let(:environment) { { 'HTTPS_PROXY' => 'http://user%21:pass%40@proxy:9000', 'https_proxy' => nil } }
+
+    it 'decodes user/pass from HTTPS_PROXY if encoded' do
+      stub_request(:get, uri_secure)
+        .to_return(status: 200, body: 'foo-cached', headers: { Etag: 'foo-etag',
+                                                               'Last-Modified' => 'foo-last-modified' })
+
+      allow(Net::HTTP).to receive(:Proxy).with('proxy', 9000, /user!/, /pass@/).and_call_original
 
       download_cache.get(uri_secure) {}
     end


### PR DESCRIPTION
This PR  adds support for url-encoded userinfo from a proxy url, specified either via `http_proxy` or `https_proxy` variable.

Fixes #795 
