### PR TITLE
Fix test not to assume that it is not running with BOSH DNS

### DIFF
--- a/spec/java_buildpack/jre/open_jdk_like_jre_spec.rb
+++ b/spec/java_buildpack/jre/open_jdk_like_jre_spec.rb
@@ -56,6 +56,8 @@ describe JavaBuildpack::Jre::OpenJDKLikeJre do
   it 'does not disable dns caching if no BOSH DNS',
      cache_fixture: 'stub-java.tar.gz' do
 
+    allow_any_instance_of(Resolv::DNS::Config).to receive(:nameserver_port).and_return([['8.8.8.8', 53]])
+
     component.detect
     component.compile
 


### PR DESCRIPTION
It appears that the test was written with the assumption that it would be running in an environment that does not have BOSH DNS. However, we recently enable BOSH DNS for Concourse which started causing this test to fail.