### PR TITLE
allow setting start command arguments for distZip containers

### DIFF
--- a/config/dist_zip.yml
+++ b/config/dist_zip.yml
@@ -1,0 +1,18 @@
+# Cloud Foundry Java Buildpack
+# Copyright 2013-2020 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration for the DistZip container
+---
+arguments:

--- a/config/dist_zip_like.yml
+++ b/config/dist_zip_like.yml
@@ -1,0 +1,18 @@
+# Cloud Foundry Java Buildpack
+# Copyright 2013-2020 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration for the DistZip container
+---
+arguments:

--- a/docs/container-dist_zip.md
+++ b/docs/container-dist_zip.md
@@ -16,11 +16,18 @@ The Dist Zip Container allows applications packaged in [`distZip`-style][] to be
 </table>
 Tags are printed to standard output by the buildpack detect script
 
-If the application uses Spring, [Spring profiles][] can be specified by setting the [`SPRING_PROFILES_ACTIVE`][] environment variable. This is automatically detected and used by Spring. The Spring Auto-reconfiguration Framework will specify the `cloud` profile in addition to any others. 
+If the application uses Spring, [Spring profiles][] can be specified by setting the [`SPRING_PROFILES_ACTIVE`][] environment variable. This is automatically detected and used by Spring. The Spring Auto-reconfiguration Framework will specify the `cloud` profile in addition to any others.
 
 ## Configuration
-The Dist Zip Container cannot be configured.
+For general information on configuring the buildpack, including how to specify configuration values through environment variables, refer to [Configuration and Extension][].
 
+The container can be configured by modifying the `config/dist_zip.yml` file in the buildpack fork.
+
+| Name | Description
+| ---- | -----------
+| `arguments` | Optional command line arguments to be passed to the start script. The arguments are specified as a single YAML scalar in plain style or enclosed in single or double quotes.
+
+[Configuration and Extension]: ../README.md#configuration-and-extension
 [`distZip`-style]: http://www.gradle.org/docs/current/userguide/application_plugin.html
 [Spring profiles]:http://blog.springsource.com/2011/02/14/spring-3-1-m1-introducing-profile/
 [`SPRING_PROFILES_ACTIVE`]: http://static.springsource.org/spring/docs/3.1.x/javadoc-api/org/springframework/core/env/AbstractEnvironment.html#ACTIVE_PROFILES_PROPERTY_NAME

--- a/lib/java_buildpack/container/dist_zip_like.rb
+++ b/lib/java_buildpack/container/dist_zip_like.rb
@@ -47,7 +47,8 @@ module JavaBuildpack
           @droplet.environment_variables.as_env_vars,
           @droplet.java_home.as_env_var,
           'exec',
-          qualify_path(start_script(root), @droplet.root)
+          qualify_path(start_script(root), @droplet.root),
+          arguments
         ].flatten.compact.join(' ')
       end
 
@@ -76,11 +77,17 @@ module JavaBuildpack
 
       private
 
+      ARGUMENTS_PROPERTY = 'arguments'
+
       PATTERN_APP_CLASSPATH = /^declare -r app_classpath=\"(.*)\"$/.freeze
 
       PATTERN_CLASSPATH = /^CLASSPATH=(.*)$/.freeze
 
-      private_constant :PATTERN_APP_CLASSPATH, :PATTERN_CLASSPATH
+      private_constant :ARGUMENTS_PROPERTY, :PATTERN_APP_CLASSPATH, :PATTERN_CLASSPATH
+
+      def arguments
+        @configuration[ARGUMENTS_PROPERTY]
+      end
 
       def augment_app_classpath(content)
         additional_classpath = (@droplet.additional_libraries + @droplet.root_libraries).sort.map do |library|

--- a/spec/java_buildpack/container/dist_zip_like_spec.rb
+++ b/spec/java_buildpack/container/dist_zip_like_spec.rb
@@ -58,4 +58,14 @@ describe JavaBuildpack::Container::DistZipLike do
                                     '$PWD/bin/application')
   end
 
+  context do
+    let(:configuration) { { 'arguments' => 'some arguments' } }
+
+    it 'returns command line arguments when they are specified',
+       app_fixture: 'container_dist_zip' do
+
+      expect(component.release).to end_with('some arguments')
+    end
+  end
+
 end

--- a/spec/java_buildpack/container/dist_zip_spec.rb
+++ b/spec/java_buildpack/container/dist_zip_spec.rb
@@ -52,4 +52,14 @@ describe JavaBuildpack::Container::DistZip do
     expect(component.detect).to be_nil
   end
 
+  context do
+    let(:configuration) { { 'arguments' => 'some arguments' } }
+
+    it 'returns command line arguments when they are specified',
+       app_fixture: 'container_dist_zip' do
+
+      expect(component.release).to end_with('some arguments')
+    end
+  end
+
 end


### PR DESCRIPTION
## What

Adds the ability to configure the args passed to the start script when
using the distZip container format.

This lets you, for example, set:

    JBP_CONFIG_DIST_ZIP : '{ arguments: "server config.yml" }'

to add "server config.yml" as arguments to the start script. It is
analogous to JBP_CONFIG_JAVA_MAIN.

## Why

So that distZip packaged applications can easily configure their command arguments.

## Related

fixes: #721