### PR TITLE
Add configuration option to overwrite communication endpoints for Dynatrace OneAgent

### DIFF
--- a/config/dynatrace_one_agent.yml
+++ b/config/dynatrace_one_agent.yml
@@ -1,0 +1,18 @@
+# Cloud Foundry Java Buildpack
+# Copyright 2013-2020 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration for the Dynatrace OneAgent framework
+---
+communication_endpoints:

--- a/docs/framework-dynatrace_one_agent.md
+++ b/docs/framework-dynatrace_one_agent.md
@@ -33,6 +33,14 @@ The credential payload of the service may contain the following entries:
 ## Configuration
 For general information on configuring the buildpack, including how to specify configuration values through environment variables, refer to [Configuration and Extension][].
 
+
+The framework can be configured by modifying the [`config/dynatrace_one_agent.yml`][] file in the buildpack fork.  The framework uses the [`Repository` utility support][repositories] and so it supports the [version syntax][] defined there.
+
+| Name | Description
+| ---- | -----------
+| `communication_endpoints` | (Optional) This option allows to overwrite the list of communication endpoints for the Dynatrace OneAgent. Multiple URLs can be specified in a single string, separated by a semicolon, e.g. `"https://endpoint1:9999/communication;https://endpoint2:9999/communication"`
+
+
 ## Support
 This buildpack extension is currently Beta. If you have any questions or problems regarding the build pack itself please don't hesitate to contact Dynatrace on https://answers.ruxit.com/, be sure to use "cloudfoundry" as a topic.
 

--- a/lib/java_buildpack/framework/dynatrace_one_agent.rb
+++ b/lib/java_buildpack/framework/dynatrace_one_agent.rb
@@ -107,8 +107,11 @@ module JavaBuildpack
 
       SKIP_ERRORS = 'skiperrors'
 
+      COMMUNICATION_ENDPOINTS = 'communication_endpoints'
+
       private_constant :APIURL, :APITOKEN, :DT_APPLICATION_ID, :DT_CONNECTION_POINT, :DT_NETWORK_ZONE, :DT_LOGSTREAM,
-                       :DT_TENANT, :DT_TENANTTOKEN, :ENVIRONMENTID, :FILTER, :NETWORKZONE, :SKIP_ERRORS
+                       :DT_TENANT, :DT_TENANTTOKEN, :ENVIRONMENTID, :FILTER, :NETWORKZONE, :SKIP_ERRORS,
+                       :COMMUNICATION_ENDPOINTS
 
       def agent_download_url
         download_uri = "#{api_base_url(credentials)}/v1/deployment/installer/agent/unix/paas/latest?include=java" \
@@ -156,8 +159,12 @@ module JavaBuildpack
         environment_variables.add_environment_variable(DT_LOGSTREAM, 'stdout') unless logstream?
       end
 
+      def endpoints_from_config_or_manifest(manifest)
+        @configuration[COMMUNICATION_ENDPOINTS] || manifest['communicationEndpoints'].join(';')
+      end
+
       def endpoints(manifest)
-        "\"#{manifest['communicationEndpoints'].join(';')}\""
+        "\"#{endpoints_from_config_or_manifest(manifest)}\""
       end
 
       def error_file

--- a/spec/java_buildpack/framework/dynatrace_one_agent_spec.rb
+++ b/spec/java_buildpack/framework/dynatrace_one_agent_spec.rb
@@ -23,6 +23,10 @@ require 'java_buildpack/util/tokenized_version'
 describe JavaBuildpack::Framework::DynatraceOneAgent do
   include_context 'with component help'
 
+  let(:configuration) do
+    { 'communication_endpoints' => nil }
+  end
+
   it 'does not detect without dynatrace-n/a service' do
     expect(component.detect).to be_nil
   end
@@ -136,6 +140,21 @@ describe JavaBuildpack::Framework::DynatraceOneAgent do
 
         expect(java_opts).not_to include('-agentpath:$PWD/.java-buildpack/dynatrace_one_agent/agent/lib64/' \
           'liboneagentloader.so')
+      end
+
+    end
+
+    context do
+
+      let(:configuration) { { 'communication_endpoints' => "config-overwrite1;config-overwrite2" } }
+
+      it 'does overwrite connection points from configuration if it exists',
+         app_fixture: 'framework_dynatrace_one_agent' do
+
+        component.release
+
+        expect(environment_variables).to include('DT_CONNECTION_POINT=' \
+        '"config-overwrite1;config-overwrite2"')
       end
 
     end


### PR DESCRIPTION
This is another solution to #828 where a user can specify the communication endpoints for the Dynatrace OneAgent via an env variable or in the application manifest.yaml, e..g:
```yaml
---
applications:
- name: <application>
   ...
services:
- dynatrace-service
env:
    JBP_CONFIG_DYNATRACE_ONE_AGENT: '{ communication_endpoints: "https://test1;https://test1" }'
```
or use 
```
cf set-env <application> JBP_CONFIG_DYNATRACE_ONE_AGENT '{ communication_endpoints: "https://test1;https://test1" }'
```