### PR TITLE
Java 15

### DIFF
--- a/rakelib/versions_task.rb
+++ b/rakelib/versions_task.rb
@@ -72,7 +72,7 @@ module Package
       'jprofiler_profiler' => 'JProfiler Profiler',
       'jre' => 'OpenJDK JRE',
       'jre-11' => 'OpenJDK JRE 11',
-      'jre-14' => 'OpenJDK JRE 14',
+      'jre-15' => 'OpenJDK JRE 15',
       'jrebel_agent' => 'JRebel Agent',
       'jvmkill_agent' => 'jvmkill Agent',
       'lifecycle_support' => 'Tomcat Lifecycle Support',
@@ -167,8 +167,8 @@ module Package
 
         if component_id == 'open_jdk_jre' && sub_component_id == 'jre'
           c1 = configuration.clone
-          c1['sub_component_id'] = 'jre-14'
-          c1['version'] = '14.+'
+          c1['sub_component_id'] = 'jre-15'
+          c1['version'] = '15.+'
 
           configurations << c1
         end


### PR DESCRIPTION
This change replaces the non-LTS Java 14 which is now EOL with the non-LTS Java 15 which is now active.
