### PR TITLE
New Relic Agent Version

### DIFF
--- a/config/new_relic_agent.yml
+++ b/config/new_relic_agent.yml
@@ -15,8 +15,8 @@
 
 # Configuration for the New Relic framework
 ---
-version: 5.+
+version: +
 repository_root: https://download.run.pivotal.io/new-relic
 extensions:
   version: 1.+
-  repository_root: 
+  repository_root:


### PR DESCRIPTION
This change loosens the New Relic Agent version wildcard to "latest" for even major releases.

[resolves #827]
