### PR TITLE
Relax YourKit Version

### DIFF
--- a/config/your_kit_profiler.yml
+++ b/config/your_kit_profiler.yml
@@ -15,7 +15,7 @@
 
 # JMX configuration
 ---
-version: 2019.+
+version: +
 repository_root: https://download.run.pivotal.io/your-kit/{platform}/{architecture}
 enabled: false
 port: 10001


### PR DESCRIPTION
This change relaxes the YourKit version to select the latest available at all times rather than being tied to a given year.
