### PR TITLE
APMDEV-4870: Update to use the latest version of the profiler.

### DIFF
--- a/config/riverbed_appinternals_agent.yml
+++ b/config/riverbed_appinternals_agent.yml
@@ -15,6 +15,6 @@
 
 # Configuration for the riverbed appinternals agent framework
 ---
-version: 10.+
+version: 11.+
 repository_root: https://pcf-instrumentation-download.steelcentral.net/
 rvbd_moniker: $(jq -r -n "$VCAP_APPLICATION | .application_name")


### PR DESCRIPTION
The buildpack should use 11.7.1 by default now. -Scott