### PR TITLE
Support appdynamics application names with spaces

### DIFF
--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -80,7 +80,7 @@ module JavaBuildpack
       def application_name(java_opts, credentials)
         name = credentials['application-name'] || @configuration['default_application_name'] ||
           @application.details['application_name']
-        java_opts.add_system_property('appdynamics.agent.applicationName', name.to_s)
+        java_opts.add_system_property('appdynamics.agent.applicationName', "\\\"#{name}\\\"")
       end
 
       def account_access_key(java_opts, credentials)

--- a/spec/java_buildpack/framework/app_dynamics_agent_spec.rb
+++ b/spec/java_buildpack/framework/app_dynamics_agent_spec.rb
@@ -66,7 +66,7 @@ describe JavaBuildpack::Framework::AppDynamicsAgent do
 
         expect(java_opts).to include('-javaagent:$PWD/.java-buildpack/app_dynamics_agent/javaagent.jar')
         expect(java_opts).to include('-Dappdynamics.controller.hostName=test-host-name')
-        expect(java_opts).to include('-Dappdynamics.agent.applicationName=test-application-name')
+        expect(java_opts).to include('-Dappdynamics.agent.applicationName=\"test-application-name\"')
         expect(java_opts).to include('-Dappdynamics.agent.tierName=test-application-name')
         expect(java_opts).to include('-Dappdynamics.agent.nodeName=$(expr "$VCAP_APPLICATION" : ' \
                                      '\'.*instance_index[": ]*\\([[:digit:]]*\\).*\')')
@@ -88,7 +88,7 @@ describe JavaBuildpack::Framework::AppDynamicsAgent do
         it 'adds application_name from credentials to JAVA_OPTS if specified' do
           component.release
 
-          expect(java_opts).to include('-Dappdynamics.agent.applicationName=another-test-application-name')
+          expect(java_opts).to include('-Dappdynamics.agent.applicationName=\"another-test-application-name\"')
         end
       end
 


### PR DESCRIPTION
Otherwise the following service instance:

```shell
cf cups appdynamics -p '{"account-name":"XXXX",...,"application-name":"app: foo"}'
```

will result in the application failing to start with the following error:

> 2020-11-11T15:30:25.99+0000 [APP/PROC/WEB/0] ERR Error: Could not find or load main class foo