### PR TITLE
Allow custom configuration to be fetched over HTTPS

### DIFF
--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -145,7 +145,8 @@ module JavaBuildpack
       def check_if_resource_exists(resource_uri, conf_file)
         # check if resource exists on remote server
         begin
-          response = Net::HTTP.start(resource_uri.host, resource_uri.port) do |http|
+          opts = { use_ssl: true } if resource_uri.scheme == 'https'
+          response = Net::HTTP.start(resource_uri.host, resource_uri.port, opts) do |http|
             http.request_head(resource_uri)
           end
         rescue StandardError => e


### PR DESCRIPTION
Without the change in this PR, setting `APPD_CONF_HTTP_URL` to an HTTPS URI results in the following error in the logs:

> 2020-11-11T17:10:19.47+0000 [STG/0] ERR [AppDynamicsAgent] INFO  Could not retrieve https://appdynamics-configuration.cfapps.pcfeagledev.cf-app.com/java/app-agent-config.xml. Code: 400 Message: Bad Request