### PR TITLE
Update geode store version

### DIFF
--- a/config/tomcat.yml
+++ b/config/tomcat.yml
@@ -40,5 +40,5 @@ redis_store:
   timeout: 2000
   connection_pool_size: 2
 geode_store:
-  version: 1.13.+
+  version: 1.11.+
   repository_root: https://java-buildpack-tomcat-gemfire-store.s3-us-west-2.amazonaws.com


### PR DESCRIPTION
We would like to update the Geode store version that the Java buildpack pulls in to an earlier version so that it is compatible with more versions of TGF4VMs.