### PR TITLE
Add basic auth support when using APPD_CONF_HTTP_URL to fetch configuration from a remote server.

### DIFF
--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -148,7 +148,11 @@ module JavaBuildpack
         begin
           opts = { use_ssl: true } if resource_uri.scheme == 'https'
           response = Net::HTTP.start(resource_uri.host, resource_uri.port, opts) do |http|
-            http.request_head(resource_uri)
+            req = Net::HTTP::Head.new(resource_uri)
+            if resource_uri.user != '' || resource_uri.password != ''
+              req.basic_auth(resource_uri.user, resource_uri.password)
+            end
+            http.request(req)
           end
         rescue StandardError => e
           @logger.error { "Request failure: #{e.message}" }


### PR DESCRIPTION
Currently, if you attempt to fetch App Dynamics configuration from a remote server using `APPD_CONF_HTTP_URL`, it will work so long as the server is not protected with basic auth.

Downloads from the remote server are OK, but this [call to check_if_resource_exists](https://github.com/cloudfoundry/java-buildpack/blob/main/lib/java_buildpack/framework/app_dynamics_agent.rb#L146) doesn't use the standard download code and makes a direct HEAD request which doesn't currently support basic auth.

This patch uses basic auth for the HEAD request, which should allow it to support App Dynamics config from a remote server protected with basic auth.