### PR TITLE
Allow for additional components (JREs) in the cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,11 @@ The offline package is a version of the buildpack designed to run without access
 
 To pin the version of dependencies used by the buildpack to the ones currently resolvable use the `PINNED=true` argument. This will update the [`config/` directory][] to contain exact version of each dependency instead of version ranges.
 
+Only packages referenced in the [`config/components.yml` file][] will be cached. Additional packages may be added using the `ADD_TO_CACHE` argument. It has to be set to the name of a `.yml` file in the [`config/` directory][]). Multiple file names may be separated by colons. This is useful to add additional JREs.
+
 ```bash
 $ bundle install
-$ bundle exec rake clean package OFFLINE=true PINNED=true
+$ bundle exec rake clean package OFFLINE=true PINNED=true ADD_TO_CACHE=sap_machine_jre
 ...
 Creating build/java-buildpack-offline-cfd6b17.zip
 ```

--- a/rakelib/dependency_cache_task.rb
+++ b/rakelib/dependency_cache_task.rb
@@ -109,7 +109,10 @@ module Package
     end
 
     def component_ids
-      configuration('components').values.flatten.map { |component| component.split('::').last.snake_case }
+      conf = configuration('components').values.flatten.map { |component| component.split('::').last.snake_case }
+      offline_cache = ENV['ADD_TO_CACHE'].split(':')
+      (conf << offline_cache).flatten!.uniq!
+      conf
     end
 
     def configuration(id)

--- a/rakelib/dependency_cache_task.rb
+++ b/rakelib/dependency_cache_task.rb
@@ -110,8 +110,11 @@ module Package
 
     def component_ids
       conf = configuration('components').values.flatten.map { |component| component.split('::').last.snake_case }
-      offline_cache = ENV['ADD_TO_CACHE'].split(':')
-      (conf << offline_cache).flatten!.uniq!
+      offline_cache = ENV['ADD_TO_CACHE']
+      if !offline_cache.nil?
+        offline_cache = offline_cache.split(':')
+        (conf << offline_cache).flatten!.uniq!
+      end
       conf
     end
 


### PR DESCRIPTION
As described in this [issue](https://github.com/cloudfoundry/java-buildpack/issues/848) we are using the offline package of the Java Buildpack and have the problem that we need to bundle more than one JRE with it. We can't uncomment more than one JRE in the components.yml file and a download on deployment is not possible (disabled and no network anyway). We have a little hack in place that additionally bundles SapMachine JRE so our customers can select it if they wish. However, we would prefer a more elegant solution.

I've made a tiny change that reads ADD_TO_CACHE during the bundling process and adds components to the offline cache that are not specified in components.yml