### PR TITLE
Update geode store version

### DIFF
--- a/config/tomcat.yml
+++ b/config/tomcat.yml
@@ -40,5 +40,5 @@ redis_store:
   timeout: 2000
   connection_pool_size: 2
 geode_store:
-  version: 1.11.+
+  version: 1.11.0
   repository_root: https://java-buildpack-tomcat-gemfire-store.s3-us-west-2.amazonaws.com

--- a/config/tomcat.yml
+++ b/config/tomcat.yml
@@ -40,7 +40,7 @@ redis_store:
   timeout: 2000
   connection_pool_size: 2
 geode_store:
-  # The version of Geode Store must be less than or equal to the Geode server version to ensure compatibility.
-  # The Geode Store version is pinned to 1.11.0 to match the oldest supported version of Tanzu Gemfire for VMs.
+  # The version of Geode Store must be less than or equal to your Tanzu Gemfire for VMs version to ensure compatibility.
+  # The Geode Store version is pinned to 1.11.0 to be compatible with the most commonly used versions of Tanzu Gemfire for VMs.
   version: 1.11.0
   repository_root: https://java-buildpack-tomcat-gemfire-store.s3-us-west-2.amazonaws.com

--- a/config/tomcat.yml
+++ b/config/tomcat.yml
@@ -40,5 +40,7 @@ redis_store:
   timeout: 2000
   connection_pool_size: 2
 geode_store:
+  # The version of Geode Store must be less than or equal to the Geode server version to ensure compatibility.
+  # The Geode Store version is pinned to 1.11.0 to match the oldest supported version of Tanzu Gemfire for VMs.
   version: 1.11.0
   repository_root: https://java-buildpack-tomcat-gemfire-store.s3-us-west-2.amazonaws.com

--- a/lib/java_buildpack/container/tomcat/tomcat_geode_store.rb
+++ b/lib/java_buildpack/container/tomcat/tomcat_geode_store.rb
@@ -23,7 +23,7 @@ require 'java_buildpack/logging/logger_factory'
 module JavaBuildpack
   module Container
 
-    # Encapsulates the detect, compile, and release functionality for Tomcat Redis support.
+    # Encapsulates the detect, compile, and release functionality for Tomcat Tanzu GemFire for VMs support.
     class TomcatGeodeStore < JavaBuildpack::Component::VersionedDependencyComponent
       include JavaBuildpack::Container
 


### PR DESCRIPTION
Stick with pulling `1.11.0` version of geode-store to avoid conflicts with a TGF4VMs 1.11.0 tile when future (1.11.+) `.tar` files are created.