### PR TITLE
Updated Introscope Agent to use neo mode by default. 

### DIFF
--- a/lib/java_buildpack/framework/introscope_agent.rb
+++ b/lib/java_buildpack/framework/introscope_agent.rb
@@ -43,6 +43,7 @@ module JavaBuildpack
           .add_system_property('introscope.agent.hostName', agent_host_name)
           .add_system_property('com.wily.introscope.agent.agentName', agent_name(credentials))
           .add_system_property('introscope.agent.defaultProcessName', default_process_name(credentials))
+          .add_system_property('com.wily.introscope.agent.startup.mode', 'neo')
 
         export_all_properties(credentials, java_opts)
       end


### PR DESCRIPTION
Updated Introscope Agent to use neo mode by default. The neo mode helps to improve the App startup time when using with Introscope Agent.