### PR TITLE
Java 16

### DIFF
--- a/rakelib/dependency_cache_task.rb
+++ b/rakelib/dependency_cache_task.rb
@@ -132,7 +132,7 @@ module Package
 
         if component_id == 'open_jdk_jre' && sub_component_id == 'jre'
           c1 = configuration.clone
-          c1['version'] = '15.+'
+          c1['version'] = '16.+'
 
           configurations << c1
         end

--- a/rakelib/versions_task.rb
+++ b/rakelib/versions_task.rb
@@ -72,7 +72,7 @@ module Package
       'jprofiler_profiler' => 'JProfiler Profiler',
       'jre' => 'OpenJDK JRE',
       'jre-11' => 'OpenJDK JRE 11',
-      'jre-15' => 'OpenJDK JRE 15',
+      'jre-16' => 'OpenJDK JRE 16',
       'jrebel_agent' => 'JRebel Agent',
       'jvmkill_agent' => 'jvmkill Agent',
       'lifecycle_support' => 'Tomcat Lifecycle Support',
@@ -167,8 +167,8 @@ module Package
 
         if component_id == 'open_jdk_jre' && sub_component_id == 'jre'
           c1 = configuration.clone
-          c1['sub_component_id'] = 'jre-15'
-          c1['version'] = '15.+'
+          c1['sub_component_id'] = 'jre-16'
+          c1['version'] = '16.+'
 
           configurations << c1
         end


### PR DESCRIPTION
This change replaces the non-LTS Java 16 which is now EOL with the non-LTS Java 16 which is now active.

Signed-off-by: Emily Casey <ecasey@vmware.com>