### PR TITLE
Allow Dockerfile users to set the base image with a build arg

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:bionic
+ARG base_image=ubuntu:bionic
+FROM ${base_image}
 
 RUN apt-get update && apt-get install -y \
     build-essential \


### PR DESCRIPTION
Still defaults to ubuntu:bionic.