### PR TITLE
Add support for Datadog APM Javaagent

### DIFF
--- a/config/components.yml
+++ b/config/components.yml
@@ -49,6 +49,7 @@ frameworks:
   - "JavaBuildpack::Framework::ContainerCustomizer"
   - "JavaBuildpack::Framework::ContainerSecurityProvider"
   - "JavaBuildpack::Framework::ContrastSecurityAgent"
+  - "JavaBuildpack::Framework::DatadogJavaagent"
   - "JavaBuildpack::Framework::Debug"
   - "JavaBuildpack::Framework::DynatraceAppmonAgent"
   - "JavaBuildpack::Framework::DynatraceOneAgent"

--- a/config/datadog_javaagent.yml
+++ b/config/datadog_javaagent.yml
@@ -1,0 +1,19 @@
+# Cloud Foundry Java Buildpack
+# Copyright 2013-2021 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration for the Datadog APM Javaagent
+---
+version: +
+repository_root: https://raw.githubusercontent.com/datadog/dd-trace-java/cloudfoundry/

--- a/docs/framework-datadog_javaagent.md
+++ b/docs/framework-datadog_javaagent.md
@@ -1,0 +1,40 @@
+# Datadog APM Javaagent Framework
+The [Datadog APM]() Javaagent Framework allows your application to be dynamically instrumented [by][datadog-javaagent] `dd-java-agent.jar`.
+
+<table>
+  <tr>
+    <td><strong>Detection Criterion</strong></td><td>One of the following environment variables configured:
+      <ul>
+        <li><code>DD_APM_ENABLED</code> configured as <code>true</code></li>
+        <li><code>DD_API_KEY</code> defined with the assumption of a <a href='https://github.com/DataDog/datadog-cloudfoundry-buildpack'>datadog-cloudfoundry-buildpack</a> configured, and <code>DD_APM_ENABLED</code> not <code>false</code></li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Tags</strong></td>
+    <td><tt>datadog-javaagent=&lt;version&gt;</tt></td>
+  </tr>
+</table>
+
+Tags are printed to standard output by the buildpack detect script
+
+## Configuration
+For general information on configuring the buildpack, including how to specify configuration values through environment variables, refer to [Configuration and Extension][].
+The framework uses the [`Repository` utility support][repositories] and so it supports the [version syntax][] defined there.
+
+The javaagent can be configured directly via environment variables or system properties as defined in the [Configuration of Datadog Javaagent][] documentation.
+
+
+| Name | Description
+| ---- | -----------
+| `repository_root` | The URL of the Datadog Javaagent repository index ([details][repositories]).
+| `version` | The `dd-java-agent` version to use. Candidate versions can be found in [this listing][].
+
+
+[Configuration and Extension]: ../README.md#configuration-and-extension
+[Datadog APM]: https://www.datadoghq.com/product/apm/
+[datadog-javaagent]: https://github.com/datadog/dd-trace-java
+[Configuration of Datadog Javaagent]: https://docs.datadoghq.com/tracing/setup_overview/setup/java/#configuration
+[this listing]: https://raw.githubusercontent.com/datadog/dd-trace-java/cloudfoundry/index.yml
+[repositories]: extending-repositories.md
+[version syntax]: extending-repositories.md#version-syntax-and-ordering

--- a/lib/java_buildpack/framework/datadog_javaagent.rb
+++ b/lib/java_buildpack/framework/datadog_javaagent.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Cloud Foundry Java Buildpack
+# Copyright 2013-2021 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'java_buildpack/component/versioned_dependency_component'
+require 'java_buildpack/framework'
+
+module JavaBuildpack
+  module Framework
+
+    # Encapsulates the functionality for enabling zero-touch Elastic APM support.
+    class DatadogJavaagent < JavaBuildpack::Component::VersionedDependencyComponent
+      include JavaBuildpack::Util
+
+      # (see JavaBuildpack::Component::BaseComponent#compile)
+      def compile
+        download_jar
+      end
+
+      # (see JavaBuildpack::Component::BaseComponent#release)
+      def release
+        java_opts   = @droplet.java_opts
+        java_opts.add_javaagent(@droplet.sandbox + jar_name)
+
+        if !@application.environment.key?('DD_SERVICE')
+          java_opts.add_system_property('dd.service', @application.details['application_name'])
+        end
+
+        if @application.details['application_version']
+          java_opts.add_system_property('dd.version', @application.details['application_version'])
+        end
+      end
+
+      protected
+
+      # (see JavaBuildpack::Component::VersionedDependencyComponent#supports?)
+      def supports?
+        api_key_defined = @application.environment.key?('DD_API_KEY') && !@application.environment['DD_API_KEY'].empty?
+        apm_disabled = @application.environment['DD_APM_ENABLED'] == 'false'
+        apm_enabled = @application.environment['DD_APM_ENABLED'] == 'true'
+        (api_key_defined && !apm_disabled) || apm_enabled
+      end
+    end
+  end
+end

--- a/rakelib/versions_task.rb
+++ b/rakelib/versions_task.rb
@@ -60,6 +60,7 @@ module Package
       'container_customizer' => 'Spring Boot Container Customizer',
       'container_security_provider' => 'Container Security Provider',
       'contrast_security_agent' => 'Contrast Security Agent',
+      'datadog_javaagent' => 'Datadog APM Javaagent',
       'dynatrace_appmon_agent' => 'Dynatrace Appmon Agent',
       'dynatrace_one_agent' => 'Dynatrace OneAgent',
       'elastic_apm_agent' => 'Elastic APM Agent',

--- a/spec/java_buildpack/framework/datadog_javaagent_spec.rb
+++ b/spec/java_buildpack/framework/datadog_javaagent_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# Cloud Foundry Java Buildpack
+# Copyright 2013-2021 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'component_helper'
+require 'java_buildpack/framework/datadog_javaagent'
+require 'java_buildpack/util/tokenized_version'
+
+describe JavaBuildpack::Framework::DatadogJavaagent do
+  include_context 'with component help'
+
+  describe '#detect' do
+    subject(:detect) { component.detect }
+
+    it 'does not detect without an api key' do
+      expect(detect).to be nil
+    end
+
+    context 'when api key is empty' do
+      let(:environment) { { 'DD_API_KEY' => '' } }
+
+      it { is_expected.to be nil }
+    end
+
+    context 'when apm is disabled' do
+      let(:environment) { { 'DD_API_KEY' => 'foo', 'DD_APM_ENABLED' => 'false' } }
+
+      it { is_expected.to be nil }
+    end
+
+    context 'when apm is enabled with no api key' do
+      let(:environment) { { 'DD_APM_ENABLED' => 'true' } }
+
+      it { is_expected.to eq("datadog-javaagent=#{version}") }
+    end
+
+    context 'when apm key is provided' do
+      let(:environment) { { 'DD_API_KEY' => 'foo' } }
+
+      it { is_expected.to eq("datadog-javaagent=#{version}") }
+    end
+  end
+
+  context 'when apm key is provided' do
+    let(:environment) { { 'DD_API_KEY' => 'foo' } }
+
+    it 'compile downloads datadog-javaagent JAR', cache_fixture: 'stub-datadog-javaagent.jar' do
+      component.compile
+      expect(sandbox + "datadog-javaagent-#{version}.jar").to exist
+    end
+
+    it 'release updates JAVA_OPTS' do
+      component.release
+      expect(java_opts).to include("-javaagent:$PWD/.java-buildpack/datadog_javaagent/datadog_javaagent-#{version}.jar")
+    end
+  end
+end


### PR DESCRIPTION
Support for activating Datadog APM auto instrumentation.

The [Datadog Trace Agent](https://github.com/DataDog/datadog-cloudfoundry-buildpack) is not configured as a service binding, so we rely on detecting environment variable config for activation.

Closes #826