### PR TITLE
Restore unique_host_name logic for AppDynamics

### DIFF
--- a/lib/java_buildpack/framework/app_dynamics_agent.rb
+++ b/lib/java_buildpack/framework/app_dynamics_agent.rb
@@ -138,8 +138,8 @@ module JavaBuildpack
       end
 
       def unique_host_name(java_opts)
-        name = @configuration['default_unique_host_name']
-        name = Shellwords.escape(@application.details['application_name']) if @application.details['application_name']
+        name = Shellwords.escape(@application.details['application_name'])
+        name = @configuration['default_unique_host_name'] if @configuration['default_unique_host_name']
 
         java_opts.add_system_property('appdynamics.agent.uniqueHostId', name.to_s)
       end


### PR DESCRIPTION
PR #870 reversed the logic overriding the default_unique_host_name with
the application_name.  This results in problems with AppDynamics where
applications running on multiple foundations are unable to add metrics
when using the same application name in Cloud Foundry.

Really, application_name should never be used. unique_host_name is
by definition a unique identifier vs an application_name, which is not
guaranteed to be unique.

But this restores the previous logic, which was functional and may have
handled cases I am not aware of.