### PR TITLE
Ensures compatibility with older and newer DataDog buildpacks.

### DIFF
--- a/lib/java_buildpack/framework/datadog_javaagent.rb
+++ b/lib/java_buildpack/framework/datadog_javaagent.rb
@@ -27,15 +27,14 @@ module JavaBuildpack
 
       def initialize(context)
         super(context)
-        @datadog_buildpack = File.exist? File.join(@droplet.root, '.datadog')
         @logger = JavaBuildpack::Logging::LoggerFactory.instance.get_logger DatadogJavaagent
       end
 
       # (see JavaBuildpack::Component::BaseComponent#compile)
       def compile
-        @logger.error 'Datadog Buildpack is required, but not found' unless @datadog_buildpack
+        @logger.error 'Datadog Buildpack is required, but not found' unless datadog_buildpack?
 
-        return unless @datadog_buildpack
+        return unless datadog_buildpack?
 
         download_jar
         fix_class_count
@@ -43,7 +42,7 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::BaseComponent#release)
       def release
-        return unless @datadog_buildpack
+        return unless datadog_buildpack?
 
         java_opts = @droplet.java_opts
         java_opts.add_javaagent(@droplet.sandbox + jar_name)
@@ -65,6 +64,11 @@ module JavaBuildpack
         api_key_defined = @application.environment.key?('DD_API_KEY') && !@application.environment['DD_API_KEY'].empty?
         apm_disabled = @application.environment['DD_APM_ENABLED'] == 'false'
         (api_key_defined && !apm_disabled)
+      end
+
+      # determins if the datadog buildpack is present
+      def datadog_buildpack?
+        File.exist?(File.join(@droplet.root, '.datadog')) || File.exist?(File.join(@droplet.root, 'datadog'))
       end
 
       # fixes issue where some classes are not counted by adding shadow class files

--- a/spec/java_buildpack/framework/datadog_javaagent_spec.rb
+++ b/spec/java_buildpack/framework/datadog_javaagent_spec.rb
@@ -100,6 +100,41 @@ describe JavaBuildpack::Framework::DatadogJavaagent do
       end
     end
 
+    context 'when datadog buildpack 4.22.0 (or older) is present' do
+      before do
+        FileUtils.mkdir_p File.join(context[:droplet].root, 'datadog')
+      end
+
+      after do
+        FileUtils.rmdir File.join(context[:droplet].root, 'datadog')
+      end
+
+      it 'compile downloads datadog-javaagent JAR', cache_fixture: 'stub-datadog-javaagent.jar' do
+        component.compile
+        expect(sandbox + "datadog_javaagent-#{version}.jar").to exist
+      end
+
+      it 'makes a jar with fake class files', cache_fixture: 'stub-datadog-javaagent.jar' do
+        component.compile
+        expect(sandbox + "datadog_javaagent-#{version}.jar").to exist
+        expect(sandbox + 'datadog_fakeclasses.jar').to exist
+        expect(sandbox + 'datadog_fakeclasses').not_to exist
+
+        cnt = `unzip -l #{sandbox}/datadog_fakeclasses.jar | grep '\\(\\.class\\)$' | wc -l`.to_i
+        expect(cnt).to equal(34)
+      end
+
+      it 'release updates JAVA_OPTS' do
+        component.release
+
+        expect(java_opts).to include(
+          "-javaagent:$PWD/.java-buildpack/datadog_javaagent/datadog_javaagent-#{version}.jar"
+        )
+        expect(java_opts).to include('-Ddd.service=\"test-application-name\"')
+        expect(java_opts).to include('-Ddd.version=test-application-version')
+      end
+    end
+
     context 'when datadog buildpack is not present' do
       it 'compile downloads datadog-javaagent JAR', cache_fixture: 'stub-datadog-javaagent.jar' do
         component.compile


### PR DESCRIPTION
Checks for the DataDog to be installed into either `$HOME/.datadog` (new) or `$HOME/datadog` (old) locations.

Resolves #897 