### PR TITLE
Modify default Tomcat configuration to include HTTP/2 support

### DIFF
--- a/resources/tomcat/conf/server.xml
+++ b/resources/tomcat/conf/server.xml
@@ -19,7 +19,9 @@
 <Server port='-1'>
 
     <Service name='Catalina'>
-        <Connector port='${http.port}' bindOnInit='false' connectionTimeout='20000'/>
+        <Connector port='${http.port}' bindOnInit='false' connectionTimeout='20000'>
+            <UpgradeProtocol className='org.apache.coyote.http2.Http2Protocol' />
+        </Connector>
 
         <Engine defaultHost='localhost' name='Catalina'>
             <Valve className='org.apache.catalina.valves.RemoteIpValve' protocolHeader='x-forwarded-proto'/>


### PR DESCRIPTION
This commit will enable HTTP/2 upgrade support, specifically H2C, in the Tomcat configuration that is generated by the buildpack. This will enable HTTP/2 by default. It cannot be disabled, unless you use the Java buildpack's feature to use external Tomcat configuration.

The impact should be minimal as you will still retain full HTTP/1.1 support, HTTP/2 will not be forced on clients, and a client would need to request HTTP/2. This commit should also support Java 8+ because we are using H2C, so the additional TLS requirements that precipitate using Java 9+ do not apply.

Full HTTP/2 support requires running a version of Cloud Foundry that also includes support for HTTP/2, or use via the container to container network.
