### PR TITLE
Version matcher now prefers a specific match over a partial match

### DIFF
--- a/lib/java_buildpack/repository/version_resolver.rb
+++ b/lib/java_buildpack/repository/version_resolver.rb
@@ -76,18 +76,25 @@ module JavaBuildpack
         end
 
         def matches?(tokenized_candidate_version, tokenized_version)
+          wildcard_matched = false
           (0..3).all? do |i|
-            tokenized_candidate_version[i].nil? || as_regex(tokenized_candidate_version[i]) =~ tokenized_version[i]
+            next true if wildcard_matched || tokenized_candidate_version[i].nil? && tokenized_version[i].nil?
+
+            next false if tokenized_candidate_version[i].nil? && !tokenized_version[i].nil?
+
+            if tokenized_candidate_version[i] == JavaBuildpack::Util::TokenizedVersion::WILDCARD
+              wildcard_matched = true
+              next true
+            end
+
+            if tokenized_candidate_version[i].end_with?(JavaBuildpack::Util::TokenizedVersion::WILDCARD)
+              next !tokenized_version[i].nil? && tokenized_version[i].start_with?(tokenized_candidate_version[i][0..-2])
+            end
+
+            tokenized_candidate_version[i] == tokenized_version[i]
           end
         end
-
-        def as_regex(version)
-          /^#{version.gsub(JavaBuildpack::Util::TokenizedVersion::WILDCARD, '.*')}/
-        end
-
       end
-
     end
-
   end
 end

--- a/spec/java_buildpack/repository/version_resolver_spec.rb
+++ b/spec/java_buildpack/repository/version_resolver_spec.rb
@@ -69,6 +69,18 @@ describe JavaBuildpack::Repository::VersionResolver do
     expect(described_class.resolve(tokenized_version('2.0.+'), versions)).to eq(tokenized_version('2.0.0'))
   end
 
+  it 'picks an exact match over a partial match' do
+    versions = %w[3.1.1 3.1.1_BETA 3.1.1_BETA.2 3.1.2 3.2.0]
+    expect(described_class.resolve(tokenized_version('3.1.1'), versions)).to eq(tokenized_version('3.1.1'))
+    expect(described_class.resolve(tokenized_version('3.1.1_BETA'), versions)).to eq(tokenized_version('3.1.1_BETA'))
+  end
+
+  it 'picks the latest including qualifiers' do
+    versions = %w[3.1.1 3.1.1_BETA 3.1.1_BETA.2 3.1.2 3.2.0]
+    expect(described_class.resolve(tokenized_version('3.1.1_+'), versions)).to eq(tokenized_version('3.1.1_BETA.2'))
+    expect(described_class.resolve(tokenized_version('3.1.1_BE+'), versions)).to eq(tokenized_version('3.1.1_BETA.2'))
+  end
+
   def tokenized_version(s)
     JavaBuildpack::Util::TokenizedVersion.new(s)
   end


### PR DESCRIPTION
Previous to this commit, if you have two versions say `3.1.1` and `3.1.1_BETA` the version matcher would incorrectly select `3.1.1_BETA`.  It would behave as if a wildcard was present even though it's not present.

This commit ensures that the same scenario will select version `3.1.1`, which is an exact match for the version requested.

This may result in a difference of behavior for some users. If you are impacted by this, you need to switch your requested version to `3.1.1_+`. Using the scenario above, this will return `3.1.1_BETA`.

Resolves #872 