### PR TITLE
fixed case in networkzone query parameter

### DIFF
--- a/lib/java_buildpack/framework/dynatrace_one_agent.rb
+++ b/lib/java_buildpack/framework/dynatrace_one_agent.rb
@@ -115,7 +115,7 @@ module JavaBuildpack
                        '&bitness=64' \
                        "&Api-Token=#{credentials[APITOKEN]}"
 
-        download_uri += "&networkzone=#{networkzone}" if networkzone?
+        download_uri += "&networkZone=#{networkzone}" if networkzone?
 
         ['latest', download_uri]
       end


### PR DESCRIPTION
Little fix in the case for the `networkzone` query parameter.
The z is now an uppercase Z :-)