### PR TITLE
Bump JProfiler to 12.x branch

### DIFF
--- a/config/jprofiler_profiler.yml
+++ b/config/jprofiler_profiler.yml
@@ -15,7 +15,7 @@
 
 # JMX configuration
 ---
-version: 11.+
+version: 12.+
 repository_root: https://download.run.pivotal.io/jprofiler
 enabled: false
 nowait: true


### PR DESCRIPTION
- Version bump was requeste by users
- Version 11.x has been EOL'd
- Version 11 is still on the downloads server. If you need to stick with 11.x, you may set `JBP_CONFIG_JPROFILER_PROFILER_VERSION` to `11.+`.

Resolves #914 
