### PR TITLE
Update default geode-store version 1.12.4

### DIFF
--- a/config/tomcat.yml
+++ b/config/tomcat.yml
@@ -41,6 +41,6 @@ redis_store:
   connection_pool_size: 2
 geode_store:
   # The version of Geode Store must be less than or equal to your Tanzu Gemfire for VMs version to ensure compatibility.
-  # The Geode Store version is pinned to 1.13.4 to be compatible with the most commonly used versions of Tanzu Gemfire for VMs.
-  version: 1.13.4
+  # The Geode Store version is pinned to 1.12.4 to be compatible with the most commonly used versions of Tanzu Gemfire for VMs.
+  version: 1.12.4
   repository_root: https://java-buildpack-tomcat-gemfire-store.s3-us-west-2.amazonaws.com


### PR DESCRIPTION
This changes ensures that the geode client is compatible with
existing customer deployments and bundles log4j v2.16.0.