### PR TITLE
Add Luna API shared library to library path for Java 9+

### DIFF
--- a/lib/java_buildpack/framework/luna_security_provider.rb
+++ b/lib/java_buildpack/framework/luna_security_provider.rb
@@ -62,6 +62,10 @@ module JavaBuildpack
 
         if @droplet.java_home.java_9_or_later?
           @droplet.root_libraries << luna_provider_jar
+
+          @droplet.environment_variables.add_environment_variable(
+            'LD_LIBRARY_PATH', "$LD_LIBRARY_PATH:#{ld_lib_path}"
+          )
         else
           @droplet.extension_directories << ext_dir
         end
@@ -126,6 +130,10 @@ module JavaBuildpack
 
       def lib_cklog
         @droplet.sandbox + 'libs/64/libcklog2.so'
+      end
+
+      def ld_lib_path
+        qualify_path(@droplet.sandbox, @droplet.root) + '/jsp/64/'
       end
 
       def setup_ext_dir

--- a/spec/java_buildpack/framework/luna_security_provider_spec.rb
+++ b/spec/java_buildpack/framework/luna_security_provider_spec.rb
@@ -219,7 +219,7 @@ describe JavaBuildpack::Framework::LunaSecurityProvider do
         delegate
       end
 
-      it 'adds JAR to classpath during compile in Java 9',
+      it 'adds JAR to classpath during compile in Java 9+',
          cache_fixture: 'stub-luna-security-provider.tar' do
 
         component.compile
@@ -227,18 +227,24 @@ describe JavaBuildpack::Framework::LunaSecurityProvider do
         expect(root_libraries).to include(droplet.sandbox + 'jsp/LunaProvider.jar')
       end
 
-      it 'adds JAR to classpath during release in Java 9' do
+      it 'adds JAR to classpath during release in Java 9+' do
         component.release
 
         expect(root_libraries).to include(droplet.sandbox + 'jsp/LunaProvider.jar')
       end
 
-      it 'adds does not add extension directory in Java 9' do
+      it 'adds does not add extension directory in Java 9+' do
         component.release
 
         expect(extension_directories).not_to include(droplet.sandbox + 'ext')
       end
 
+      it 'updates environment variables for Java 9+' do
+        component.release
+        expect(environment_variables).to include(
+          'LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/.java-buildpack/luna_security_provider/jsp/64/'
+        )
+      end
     end
 
     context do

--- a/spec/java_buildpack/framework/luna_security_provider_spec.rb
+++ b/spec/java_buildpack/framework/luna_security_provider_spec.rb
@@ -233,7 +233,7 @@ describe JavaBuildpack::Framework::LunaSecurityProvider do
         expect(root_libraries).to include(droplet.sandbox + 'jsp/LunaProvider.jar')
       end
 
-      it 'adds does not add extension directory in Java 9+' do
+      it 'does not add extension directory in Java 9+' do
         component.release
 
         expect(extension_directories).not_to include(droplet.sandbox + 'ext')


### PR DESCRIPTION
With Java 9, the extension directory functionality was dropped. This means the buildpack has to handle installation different for Java 8 and Java 9+. With Java 8, we add the required files to the extension directory. With Java 9, we add the required JAR file to the classpath, but this was not sufficient to load the required shared library. To fix this, we are adding the Luna API shared library to the LD_LIBRARY_PATH environment variable. The JVM uses this to locate shared libraries, so it can now find the shared library.