### PR TITLE
Create Traceable Javaagent Framework Extension 

### DIFF
--- a/config/components.yml
+++ b/config/components.yml
@@ -75,5 +75,6 @@ frameworks:
   - "JavaBuildpack::Framework::SkyWalkingAgent"
   - "JavaBuildpack::Framework::YourKitProfiler"
   - "JavaBuildpack::Framework::TakipiAgent"
+  - "JavaBuildpack::Framework::TraceableJavaagent"
   - "JavaBuildpack::Framework::JavaSecurity"
   - "JavaBuildpack::Framework::JavaOpts"

--- a/config/traceable_javaagent.yml
+++ b/config/traceable_javaagent.yml
@@ -1,0 +1,19 @@
+# Cloud Foundry Java Buildpack
+# Copyright 2013-2022 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration for the Traceable Javaagent
+---
+version: +
+repository_root: https://downloads.traceable.ai/agent/java/cloudfoundry/

--- a/docs/framework-traceable_javaagent.md
+++ b/docs/framework-traceable_javaagent.md
@@ -1,0 +1,38 @@
+# Traceable Javaagent Framework
+The [Traceable](https://traceable.ai) Javaagent Framework installs an agent that allows your application to be instrumented by the Traceable Java Tracing Agent. 
+
+The framework will configure the JVM to use the Traceable Javagent, which can be configured using Java system properties or environment variables. Configuration options are documented [here](https://docs.traceable.ai/docs/java)
+
+<table>
+  <tr>
+    <td><strong>Detection Criterion</strong></td><td>All must be true:
+        <ul>
+            <li><code>HT_REPORTING_ENDPOINT</code> or <code>-Dht.reporting.endpoint</code> defined and contain the HTTP endpoint of the Traceable Platform Agent endpoint for recieving traces</li>
+            <li><code>TA_OPA_ENDPOINT</code> or <code>-Dta.opa.endpoint</code> defined and contain the HTTP endpoint of the Traceable Platform Agent endpoint for providing OPA policies</li>
+        </ul>
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Tags</strong></td>
+    <td><code>traceable-javaagent=&lt;version&gt;</code></td>
+  </tr>
+</table>
+
+Tags are printed to standard output by the buildpack detect script
+
+## Configuration
+For general information on configuring the buildpack, including how to specify configuration values through environment variables, refer to [Configuration and Extension][].
+The framework uses the [`Repository` utility support][repositories] and so it supports the [version syntax][] defined there.
+
+The javaagent can be configured directly via environment variables or system properties as defined in the [Configuration of Traceable Javaagent][https://docs.traceable.ai/docs/java] documentation.
+
+
+| Name | Description
+| ---- | -----------
+| `repository_root` | The URL of the Traceable Javaagent repository index ([details][repositories]).
+| `version` | The Traceable Javaagent version to use. Candidate versions can be found in [this listing][https://downloads.traceable.ai/agent/java/cloudfoundry/index.yml].
+
+
+[Configuration and Extension]: ../README.md#configuration-and-extension
+[repositories]: extending-repositories.md
+[version syntax]: extending-repositories.md#version-syntax-and-ordering

--- a/lib/java_buildpack/framework/traceable_javaagent.rb
+++ b/lib/java_buildpack/framework/traceable_javaagent.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Cloud Foundry Java Buildpack
+# Copyright 2013-2022 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'java_buildpack/component/versioned_dependency_component'
+require 'java_buildpack/framework'
+
+module JavaBuildpack
+  module Framework
+
+    # Encapsulates the functionality for enabling the Traceable Java Agent
+    class TraceableJavaagent < JavaBuildpack::Component::VersionedDependencyComponent
+      include JavaBuildpack::Util
+
+      def initialize(context)
+        super(context)
+        @logger = JavaBuildpack::Logging::LoggerFactory.instance.get_logger TraceableJavaagent
+      end
+
+      # (see JavaBuildpack::Component::BaseComponent#compile)
+      def compile
+        download_jar
+      end
+
+      # (see JavaBuildpack::Component::BaseComponent#release)
+      def release
+        java_opts = @droplet.java_opts
+        java_opts.add_javaagent(@droplet.sandbox + jar_name)
+
+        if @application.environment.key?('HT_SERVICE_NAME') ||
+          java_opts.any? { |java_opt| java_opt =~ /ht.service.name/ }
+          return
+        end
+
+        app_name = @configuration['default_application_name'] || @application.details['application_name']
+        java_opts.add_system_property('ht.service.name', "\\\"#{app_name}\\\"")
+      end
+
+      protected
+
+      # (see JavaBuildpack::Component::VersionedDependencyComponent#supports?)
+      def supports?
+        java_opts = @droplet.java_opts
+        reporting_endpoint_specified = (@application.environment.key?('HT_REPORTING_ENDPOINT') &&
+        !@application.environment['HT_REPORTING_ENDPOINT'].empty?) ||
+          java_opts.any? { |java_opt| java_opt =~ /ht.reporting.endpoint/ }
+        opa_endpoint_specified = (@application.environment.key?('TA_OPA_ENDPOINT') &&
+        !@application.environment['TA_OPA_ENDPOINT'].empty?) ||
+          java_opts.any? { |java_opt| java_opt =~ /ta.reporting.endpoint/ }
+        reporting_endpoint_specified && opa_endpoint_specified
+      end
+    end
+  end
+end

--- a/spec/java_buildpack/framework/traceable_javaagent_spec.rb
+++ b/spec/java_buildpack/framework/traceable_javaagent_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# Cloud Foundry Java Buildpack
+# Copyright 2013-2022 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'component_helper'
+require 'java_buildpack/framework/traceable_javaagent'
+require 'java_buildpack/util/tokenized_version'
+
+describe JavaBuildpack::Framework::TraceableJavaagent do
+  include_context 'with component help'
+
+  let(:configuration) do
+    { 'default_application_version' => nil,
+      'default_application_name' => nil }
+  end
+
+  describe '#detect' do
+    subject(:detect) { component.detect }
+
+    it 'does not detect without an endpoint ' do
+      expect(detect).to be nil
+    end
+
+    context 'when endpoint is empty' do
+      let(:environment) { { 'HT_REPORTING_ENDPOINT' => '' } }
+
+      it { is_expected.to be nil }
+    end
+
+    context 'when endpoint is provided' do
+      let(:environment) do
+        {
+          'HT_REPORTING_ENDPOINT' => 'http://localhost:4317',
+          'TA_OPA_ENDPOINT' => 'http://localhost:8181'
+        }
+      end
+
+      it { is_expected.to eq("traceable-javaagent=#{version}") }
+    end
+  end
+
+  context 'when endpoint is provided' do
+    let(:environment) do
+      super().update({
+                       'HT_REPORTING_ENDPOINT' => 'http://localhost:4317',
+                       'TA_OPA_ENDPOINT' => 'http://localhost:8181'
+                     })
+    end
+
+    it 'compile downloads traceable-javaagent JAR', cache_fixture: 'stub-traceable-javaagent.jar' do
+      component.compile
+      expect(sandbox + "traceable_javaagent-#{version}.jar").to exist
+    end
+
+    it 'release updates JAVA_OPTS' do
+      component.release
+
+      expect(java_opts).to include(
+        "-javaagent:$PWD/.java-buildpack/traceable_javaagent/traceable_javaagent-#{version}.jar"
+      )
+      expect(java_opts).to include('-Dht.service.name=\"test-application-name\"')
+    end
+  end
+end


### PR DESCRIPTION
closes #931 

1.  Use case: Traceable is an API security solution. This framework extension enables cloudfoundry users to automatically instrument their applications using the java buildpack with the Traceable Java Agent. 
2. I've tested this using the provided test framework. In addition, I deployed the [spring-music](spring-music) application to a cloudfoundry  installation on VirtualBox, following instructions from the [cf-deployment repo](https://github.com/cloudfoundry/cf-deployment/tree/main/iaas-support/bosh-lite) and  [bosh-lite on VirtualBox](https://bosh.io/docs/bosh-lite/). I ran the spring-music application using my fork of the buildpack to test the changes with the command `cf push spring-music -b https://github.com/ryandens/java-buildpack.git#traceable-javaagent`
3. I've signed the CLA



If there's any other information you would like, please let me know! 