### PR TITLE
Disable ProtectApp

### DIFF
--- a/config/components.yml
+++ b/config/components.yml
@@ -66,7 +66,6 @@ frameworks:
   - "JavaBuildpack::Framework::MetricWriter"
   - "JavaBuildpack::Framework::NewRelicAgent"
   - "JavaBuildpack::Framework::PostgresqlJDBC"
-  - "JavaBuildpack::Framework::ProtectAppSecurityProvider"
   - "JavaBuildpack::Framework::RiverbedAppinternalsAgent"
   - "JavaBuildpack::Framework::SealightsAgent"
   - "JavaBuildpack::Framework::SeekerSecurityProvider"

--- a/config/protect_app_security_provider.yml
+++ b/config/protect_app_security_provider.yml
@@ -14,6 +14,9 @@
 # limitations under the License.
 
 # Configuration for the ProtectApp Security Provider framework
+
+# You must specify a the repository root of an ProtectApp repository. Please see the documentation for more detail.
+# e.g.  repository_root: "https://example.com/protectapp-installer/"
 ---
 version: 8.+
-repository_root: https://files.cf-hsm.io/protectapp-installer
+repository_root: ""


### PR DESCRIPTION
The ProtectApp download site has gone offline. This PR disables ProtectApp. You can re-enable it if you are able to how your own repository for the downloads.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>