### PR TITLE
Fixes package bug introduced in refactoring

### DIFF
--- a/rakelib/dependency_cache_task.rb
+++ b/rakelib/dependency_cache_task.rb
@@ -102,7 +102,9 @@ module Package
     def cache_task(uri)
       task uri do |t|
         @monitor.synchronize { rake_output_message "Caching #{t.name}" }
-        cache.get(t.name)
+        # rubocop:disable Lint/EmptyBlock
+        cache.get(t.name) {}
+        # rubocop:enable Lint/EmptyBlock
       end
 
       uri


### PR DESCRIPTION
PR #941 introduced a bug in packaging that wasn't caught by unit tests. The removal of this empty block generated a LocalJumpError. This PR adds it back and tells rubocop to ignore the empty block.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>