### PR TITLE
Remove Takipi Agent

### DIFF
--- a/config/components.yml
+++ b/config/components.yml
@@ -73,6 +73,5 @@ frameworks:
   - "JavaBuildpack::Framework::SpringInsight"
   - "JavaBuildpack::Framework::SkyWalkingAgent"
   - "JavaBuildpack::Framework::YourKitProfiler"
-  - "JavaBuildpack::Framework::TakipiAgent"
   - "JavaBuildpack::Framework::JavaSecurity"
   - "JavaBuildpack::Framework::JavaOpts"

--- a/config/takipi_agent.yml
+++ b/config/takipi_agent.yml
@@ -16,6 +16,6 @@
 # Configuration for the Takipi framework
 ---
 version: 4.+
-repository_root: https://get.takipi.com/cloudfoundry
+repository_root: ""
 node_name_prefix: node
 application_name: 


### PR DESCRIPTION
The download site for the Takipi Agent has gone dark, and attempts to alert the vendor and rectify the situation have failed. This component will no longer be enabled with the default distribution of the Java buildpack. You can re-enable it if you are able to host your own repository for the downloads.

If/when the vendor is able to resolve the situation, we can re-enable the agent by default in the buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>