### PR TITLE
Add default functionality & refactor packaging

### DIFF
--- a/.idea/runConfigurations/All_Tests__2_5_.xml
+++ b/.idea/runConfigurations/All_Tests__2_5_.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="All Tests (2.5)" type="RSpecRunConfigurationType" factoryName="RSpec" singleton="true">
     <module name="java-buildpack" />
     <predefined_log_file enabled="true" id="RUBY_RSPEC" />
-    <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="-e $stdout.sync=true;$stderr.sync=true;load($0=ARGV.shift)" />
+    <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="" />
     <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="WORK DIR" VALUE="$MODULE_DIR$" />
     <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="true" />
     <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="rbenv: 2.5.9" />
@@ -10,7 +10,7 @@
     <envs>
       <env name="JRUBY_OPTS" value="-X+O" />
     </envs>
-    <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="false" />
+    <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="DISABLE" bundleExecEnabled="false" />
     <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
     <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov">
       <COVERAGE_PATTERN ENABLED="true">

--- a/.idea/runConfigurations/All_Tests__2_7_.xml
+++ b/.idea/runConfigurations/All_Tests__2_7_.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="All Tests (2.7)" type="RSpecRunConfigurationType" factoryName="RSpec" singleton="true">
     <module name="java-buildpack" />
     <predefined_log_file enabled="true" id="RUBY_RSPEC" />
-    <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="-e $stdout.sync=true;$stderr.sync=true;load($0=ARGV.shift)" />
+    <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="" />
     <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="WORK DIR" VALUE="$MODULE_DIR$" />
     <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="true" />
     <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="rbenv: 2.7.6" />
@@ -10,7 +10,7 @@
     <envs>
       <env name="JRUBY_OPTS" value="-X+O" />
     </envs>
-    <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="false" />
+    <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="DISABLE" bundleExecEnabled="false" />
     <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
     <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov">
       <COVERAGE_PATTERN ENABLED="true">

--- a/.idea/runConfigurations/All_Tests__3_0_.xml
+++ b/.idea/runConfigurations/All_Tests__3_0_.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="All Tests (3.0)" type="RSpecRunConfigurationType" factoryName="RSpec" singleton="true">
     <module name="java-buildpack" />
     <predefined_log_file enabled="true" id="RUBY_RSPEC" />
-    <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="-e $stdout.sync=true;$stderr.sync=true;load($0=ARGV.shift)" />
+    <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="" />
     <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="WORK DIR" VALUE="$MODULE_DIR$" />
     <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="true" />
     <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="rbenv: 3.0.4" />
@@ -10,7 +10,7 @@
     <envs>
       <env name="JRUBY_OPTS" value="-X+O" />
     </envs>
-    <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="false" />
+    <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="DISABLE" bundleExecEnabled="false" />
     <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
     <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov">
       <COVERAGE_PATTERN ENABLED="true">

--- a/.idea/runConfigurations/Without_Integration_Tests__2_5_.xml
+++ b/.idea/runConfigurations/Without_Integration_Tests__2_5_.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Without Integration Tests (2.5)" type="RSpecRunConfigurationType" factoryName="RSpec" singleton="true">
     <module name="java-buildpack" />
     <predefined_log_file enabled="true" id="RUBY_RSPEC" />
-    <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="-e $stdout.sync=true;$stderr.sync=true;load($0=ARGV.shift)" />
+    <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="" />
     <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="WORK DIR" VALUE="$MODULE_DIR$" />
     <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="true" />
     <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="rbenv: 2.5.9" />
@@ -10,7 +10,7 @@
     <envs>
       <env name="JRUBY_OPTS" value="-X+O" />
     </envs>
-    <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="false" />
+    <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="DISABLE" bundleExecEnabled="false" />
     <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
     <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov">
       <COVERAGE_PATTERN ENABLED="true">

--- a/.idea/runConfigurations/Without_Integration_Tests__2_7_.xml
+++ b/.idea/runConfigurations/Without_Integration_Tests__2_7_.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Without Integration Tests (2.7)" type="RSpecRunConfigurationType" factoryName="RSpec" singleton="true">
     <module name="java-buildpack" />
     <predefined_log_file enabled="true" id="RUBY_RSPEC" />
-    <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="-e $stdout.sync=true;$stderr.sync=true;load($0=ARGV.shift)" />
+    <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="" />
     <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="WORK DIR" VALUE="$MODULE_DIR$" />
     <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="true" />
     <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="rbenv: 2.7.6" />
@@ -10,7 +10,7 @@
     <envs>
       <env name="JRUBY_OPTS" value="-X+O" />
     </envs>
-    <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="false" />
+    <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="DISABLE" bundleExecEnabled="false" />
     <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
     <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov">
       <COVERAGE_PATTERN ENABLED="true">

--- a/.idea/runConfigurations/Without_Integration_Tests__3_0_.xml
+++ b/.idea/runConfigurations/Without_Integration_Tests__3_0_.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Without Integration Tests (3.0)" type="RSpecRunConfigurationType" factoryName="RSpec" singleton="true">
     <module name="java-buildpack" />
     <predefined_log_file enabled="true" id="RUBY_RSPEC" />
-    <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="-e $stdout.sync=true;$stderr.sync=true;load($0=ARGV.shift)" />
+    <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="RUBY_ARGS" VALUE="" />
     <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="WORK DIR" VALUE="$MODULE_DIR$" />
     <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="true" />
     <RSPEC_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="rbenv: 3.0.4" />
@@ -10,7 +10,7 @@
     <envs>
       <env name="JRUBY_OPTS" value="-X+O" />
     </envs>
-    <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="false" />
+    <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="DISABLE" bundleExecEnabled="false" />
     <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
     <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov">
       <COVERAGE_PATTERN ENABLED="true">

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ $ cf set-staging-environment-variable-group '{"JBP_DEFAULT_OPEN_JDK_JRE":"{jre: 
 $ cf set-staging-environment-variable-group '{"JBP_CONFIG_REPOSITORY": "{default_repository_root: \"http://repo.example.io\" }"}'
 ```
 
+3. To change the default JVM vendor across all applications on a foundation. Be careful to ensure that your JSON is properly escaped.
+
+```bash
+$ cf set-staging-environment-variable-group '{"JBP_CONFIG_COMPONENTS": "{jres: [\"JavaBuildpack::Jre::ZuluJRE\"]}"}'
+```
+
 ### Application Developer
 
 1. To change the default version of Java to 11 and adjust the memory heuristics then apply this environment variable to the application.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cloud Foundry Java Buildpack
 
-The `java-buildpack` is a [Cloud Foundry][] buildpack for running JVM-based applications.  It is designed to run many JVM-based applications ([Grails][], [Groovy][], Java Main, [Play Framework][], [Spring Boot][], and Servlet) with no additional configuration, but supports configuration of the standard components, and extension to add custom components.
+The `java-buildpack` is a [Cloud Foundry][] buildpack for running JVM-based applications. It is designed to run many JVM-based applications ([Grails][], [Groovy][], Java Main, [Play Framework][], [Spring Boot][], and Servlet) with no additional configuration, but supports configuration of the standard components, and extension to add custom components.
 
 ## Usage
 To use this buildpack specify the URI of the repository when pushing an application to Cloud Foundry:
@@ -21,7 +21,21 @@ The following are _very_ simple examples for deploying the artifact types that w
 * [Spring Boot CLI](docs/example-spring_boot_cli.md)
 
 ## Configuration and Extension
-The buildpack default configuration can be overridden with an environment variable matching the configuration file you wish to override minus the `.yml` extension and with a prefix of `JBP_CONFIG`. It is not possible to add new configuration properties and properties with `nil` or empty values will be ignored by the buildpack (in this case you will have to extend the buildpack, see below). The value of the variable should be valid inline yaml, referred to as "flow style" in the yaml spec ([Wikipedia][] has a good description of this yaml syntax). For example, to change the default version of Java to 11 and adjust the memory heuristics apply this environment variable to the application.
+
+The buildpack default configuration can be overridden with an environment variable matching the configuration file you wish to override minus the `.yml` extension. It is not possible to add new configuration properties and properties with `nil` or empty values will be ignored by the buildpack (in this case you will have to extend the buildpack, see below). The value of the variable should be valid inline yaml, referred to as "flow style" in the yaml spec ([Wikipedia][] has a good description of this yaml syntax).
+
+There are two levels of overrides: operator and application developer.
+
+  - If you are an operator that wishes to override configuration across a foundation, you may do this by setting environment variable group entries that begin with a prefix of `JBP_DEFAULT`.
+  - If you are an application developer that wishes to override configuration for an individual application, you may do this by setting environment variables that begin with a prefix of `JBP_CONFIG`. 
+
+For example, to change the default version of Java to 11 across all applications.
+
+```bash
+$ cf set-staging-environment-variable-group '{"JBP_DEFAULT_OPEN_JDK_JRE":"{jre: {version: 11.+ }}"}'
+```
+
+To change the default version of Java to 11 and adjust the memory heuristics then apply this environment variable to the application.
 
 ```bash
 $ cf set-env my-application JBP_CONFIG_OPEN_JDK_JRE '{ jre: { version: 11.+ }, memory_calculator: { stack_threads: 25 } }'
@@ -63,7 +77,7 @@ See the [Environment Variables][] documentation for more information.
 
 To learn how to configure various properties of the buildpack, follow the "Configuration" links below.
 
-The buildpack supports extension through the use of Git repository forking. The easiest way to accomplish this is to use [GitHub's forking functionality][] to create a copy of this repository.  Make the required extension changes in the copy of the repository. Then specify the URL of the new repository when pushing Cloud Foundry applications. If the modifications are generally applicable to the Cloud Foundry community, please submit a [pull request][] with the changes. More information on extending the buildpack is available [here](docs/extending.md).
+The buildpack supports extension through the use of Git repository forking. The easiest way to accomplish this is to use [GitHub's forking functionality][] to create a copy of this repository. Make the required extension changes in the copy of the repository. Then specify the URL of the new repository when pushing Cloud Foundry applications. If the modifications are generally applicable to the Cloud Foundry community, please submit a [pull request][] with the changes. More information on extending the buildpack is available [here](docs/extending.md).
 
 ## Additional Documentation
 * [Design](docs/design.md)
@@ -141,12 +155,12 @@ The buildpack supports extension through the use of Git repository forking. The 
   * [jvmkill](https://github.com/cloudfoundry/jvmkill)
 
 ## Building Packages
-The buildpack can be packaged up so that it can be uploaded to Cloud Foundry using the `cf create-buildpack` and `cf update-buildpack` commands.  In order to create these packages, the rake `package` task is used.
+The buildpack can be packaged up so that it can be uploaded to Cloud Foundry using the `cf create-buildpack` and `cf update-buildpack` commands. In order to create these packages, the rake `package` task is used.
 
 Note that this process is not currently supported on Windows. It is possible it will work, but it is not tested, and no additional functionality has been added to make it work.
 
 ### Online Package
-The online package is a version of the buildpack that is as minimal as possible and is configured to connect to the network for all dependencies.  This package is about 50K in size.  To create the online package, run:
+The online package is a version of the buildpack that is as minimal as possible and is configured to connect to the network for all dependencies. This package is about 250K in size. To create the online package, run:
 
 ```bash
 $ bundle install
@@ -156,7 +170,7 @@ Creating build/java-buildpack-cfd6b17.zip
 ```
 
 ### Offline Package
-The offline package is a version of the buildpack designed to run without access to a network.  It packages the latest version of each dependency (as configured in the [`config/` directory][]) and [disables `remote_downloads`][]. This package is about 180M in size.  To create the offline package, use the `OFFLINE=true` argument:
+The offline package is a version of the buildpack designed to run without access to a network. It packages the latest version of each dependency (as configured in the [`config/` directory][]) and [disables `remote_downloads`][]. To create the offline package, use the `OFFLINE=true` argument:
 
 To pin the version of dependencies used by the buildpack to the ones currently resolvable use the `PINNED=true` argument. This will update the [`config/` directory][] to contain exact version of each dependency instead of version ranges.
 ```bash
@@ -166,7 +180,11 @@ $ bundle exec rake clean package OFFLINE=true PINNED=true
 Creating build/java-buildpack-offline-cfd6b17.zip
 ```
 
-Only packages referenced in the [`config/components.yml` file](config/components.yml) will be cached. Additional packages may be added using the `ADD_TO_CACHE` argument. The value of `ADD_TO_CACHE` should be set to the name of a `.yml` file in the [`config/` directory][] with the `.yml` file extension omitted (e.g. `sap_machine_jre`). Multiple file names may be separated by commas. This is useful to add additional JREs. These additional components will not be enabled by default and must be explicitly enabled in the application with the `JBP_CONFIG_COMPONENTS` environment variable.
+If you would rather specify the exact version to which the buildpack should bundle, you may manually edit the [`config/` file](`config/`) for the component and indicate the specific version to use. For most components, there is a single `version` property which defaults to a pattern to match the latest version. By setting the `version` property to a fixed version, the buildpack will install that exact version when you run the package command. For JRE config files, like [`config/open_jdk_jre.yml`](config/open_jdk_jre.yml), you need to set the `version_lines` array to include the specific version you'd like to install. By default, the `version_lines` array is going to have a pattern entry for each major version line that matches to the latest patch version. You can override the items in the `version_lines` array to set a specific versions to use when packaging the buildpack. For a JRE, the `jre.version` property is used to set the default version line and must match one of the entries in the `version_lines` property.
+
+This package size will vary depending on what dependencies are included. You can reduce the size by removing unused components, because only packages referenced in the [`config/components.yml` file](config/components.yml) will be cached. In addition, you can remove entries from the `version_lines` array in JRE configuration files, this removes that JRE version line, to further reduce the file size. 
+
+Additional packages may be added using the `ADD_TO_CACHE` argument. The value of `ADD_TO_CACHE` should be set to the name of a `.yml` file in the [`config/` directory][] with the `.yml` file extension omitted (e.g. `sap_machine_jre`). Multiple file names may be separated by commas. This is useful to add additional JREs. These additional components will not be enabled by default and must be explicitly enabled in the application with the `JBP_CONFIG_COMPONENTS` environment variable.
 
 ```bash
 $ bundle install
@@ -179,7 +197,7 @@ Creating build/java-buildpack-offline-cfd6b17.zip
 ```
 
 ### Package Versioning
-Keeping track of different versions of the buildpack can be difficult.  To help with this, the rake `package` task puts a version discriminator in the name of the created package file.  The default value for this discriminator is the current Git hash (e.g. `cfd6b17`).  To change the version when creating a package, use the `VERSION=<VERSION>` argument:
+Keeping track of different versions of the buildpack can be difficult. To help with this, the rake `package` task puts a version discriminator in the name of the created package file. The default value for this discriminator is the current Git hash (e.g. `cfd6b17`). To change the version when creating a package, use the `VERSION=<VERSION>` argument:
 
 ```bash
 $ bundle install
@@ -190,9 +208,13 @@ Creating build/java-buildpack-2.1.zip
 
 ### Packaging Caveats
 
-1. When pinning versions, only the default JRE version is pinned. There is [special handling to package additional versions of a JRE](https://github.com/cloudfoundry/java-buildpack/blob/main/rakelib/dependency_cache_task.rb#L128-L144) and the way this works, it will pick the latest version at the time you package not at the time of the version's release.
-2. The `index.yml` file for a dependencie is packaged in the buildpack cache when building offline buildpacks. The `index.yml` file isn't versioned with the release, so if you package an offline buildpack for an older release, it will pull the current `index.yml`, not the one from the time of the release. This can result in errors if a user tells the buildpack to install the latest version of a default dependency, because the latest version is calculated from the `index.yml` file which has more recent versions than what are packaged in the offline buildpack. Because of #1, this only impacts the default JRE. Non-default JREs always package the most recent version, which is also the most recent version in `index.yml` at the time you package the offline buildpack.
-3. Because of #1 and #2, it is not present to accurately reproduce packages of the buildpack, after releases have been cut. If building pinning or offline buildpacks, it is suggested to build them as soon as possible after a release is cut and save the produced artifact.
+1. Prior to version 4.51 when pinning versions, only the default JRE version is pinned. There is [special handling to package additional versions of a JRE](https://github.com/cloudfoundry/java-buildpack/blob/main/rakelib/dependency_cache_task.rb#L128-L144) and the way this works, it will pick the latest version at the time you package not at the time of the version's release. Starting with version 4.51, the version number for all JRE version lines is tracked in the `config/` file.
+
+2. The `index.yml` file for a dependency is packaged in the buildpack cache when building offline buildpacks. The `index.yml` file isn't versioned with the release, so if you package an offline buildpack later after the release was tagged, it will pull the current `index.yml`, not the one from the time of the release. This can result in errors at build time if a user tells the buildpack to install the latest version of a dependency because the latest version is calculated from the `index.yml` file which has more recent versions than what are packaged in the offline buildpack. For example, if the user says give me Java `11._+` and the buildpack is pinned to Java `11.0.13_8` but at the time you packaged the buildpack the latest version in `index.yml` is `11.0.15_10` then the user will get an error. The buildpack will want to install `11.0.15_10` but it won't be present because `11.0.13_8` is all that's in the buildpack.
+
+    Because of #1 for versions prior to 4.51, this only impacts the default JRE. Non-default JREs always package the most recent version, which is also the most recent version in `index.yml` at the time you package the offline buildpack. For 4.51 and up, this can impact all versions.
+
+4. Because of #1 and #2, it is not possible to accurately reproduce packages of the buildpack, after releases have been cut. If building pinned or offline buildpacks, it is suggested to build them as soon as possible after a release is cut and save the produced artifact. Alternatively, you would need to maintain your own buildpack dependency repository and keep snapshots of the buildpack dependency repository for each buildpack release you'd like to be able to rebuild.
 
 See [#892](https://github.com/cloudfoundry/java-buildpack/issues/892#issuecomment-880212806) for additional details.
 

--- a/README.md
+++ b/README.md
@@ -29,44 +29,56 @@ There are two levels of overrides: operator and application developer.
   - If you are an operator that wishes to override configuration across a foundation, you may do this by setting environment variable group entries that begin with a prefix of `JBP_DEFAULT`.
   - If you are an application developer that wishes to override configuration for an individual application, you may do this by setting environment variables that begin with a prefix of `JBP_CONFIG`. 
 
-For example, to change the default version of Java to 11 across all applications.
+Here are some examples:
+
+### Operator
+
+1. To change the default version of Java to 11 across all applications on a foundation.
 
 ```bash
 $ cf set-staging-environment-variable-group '{"JBP_DEFAULT_OPEN_JDK_JRE":"{jre: {version: 11.+ }}"}'
 ```
 
-To change the default version of Java to 11 and adjust the memory heuristics then apply this environment variable to the application.
+2. To change the default repository root across all applications on a foundation. Be careful to ensure that your JSON is properly escaped.
+
+```bash
+$ cf set-staging-environment-variable-group '{"JBP_CONFIG_REPOSITORY": "{default_repository_root: \"http://repo.example.io\" }"}'
+```
+
+### Application Developer
+
+1. To change the default version of Java to 11 and adjust the memory heuristics then apply this environment variable to the application.
 
 ```bash
 $ cf set-env my-application JBP_CONFIG_OPEN_JDK_JRE '{ jre: { version: 11.+ }, memory_calculator: { stack_threads: 25 } }'
 ```
 
-If the key or value contains a special character such as `:` it should be escaped with double quotes. For example, to change the default repository path for the buildpack.
+2. If the key or value contains a special character such as `:` it should be escaped with double quotes. For example, to change the default repository path for the buildpack.
 
 ```bash
 $ cf set-env my-application JBP_CONFIG_REPOSITORY '{ default_repository_root: "http://repo.example.io" }'
 ```
 
-If the key or value contains an environment variable that you want to bind at runtime you need to escape it from your shell. For example, to add command line arguments containing an environment variable to a [Java Main](docs/container-java_main.md) application.
+3. If the key or value contains an environment variable that you want to bind at runtime you need to escape it from your shell. For example, to add command line arguments containing an environment variable to a [Java Main](docs/container-java_main.md) application.
 
 ```bash
 $ cf set-env my-application JBP_CONFIG_JAVA_MAIN '{ arguments: "--server.port=9090 --foo=bar" }'
 ```
 
-An example of configuration is to specify a `javaagent` that is packaged within an application.
+4. An example of configuration is to specify a `javaagent` that is packaged within an application.
 
 ```bash
 $ cf set-env my-application JAVA_OPTS '-javaagent:app/META-INF/myagent.jar -Dmyagent.config_file=app/META-INF/my_agent.conf'
 ```
 
-Environment variable can also be specified in the applications `manifest` file. For example, to specify an environment variable in an applications manifest file that disables Auto-reconfiguration.
+5. Environment variable can also be specified in the applications `manifest` file. For example, to specify an environment variable in an applications manifest file that disables Auto-reconfiguration.
 
 ```bash
 env:
   JBP_CONFIG_SPRING_AUTO_RECONFIGURATION: '{ enabled: false }'
 ```
 
-This final example shows how to change the version of Tomcat that is used by the buildpack with an environment variable specified in the applications manifest file.
+6. This final example shows how to change the version of Tomcat that is used by the buildpack with an environment variable specified in the applications manifest file.
 
 ```bash
 env:

--- a/config/graal_vm_jre.yml
+++ b/config/graal_vm_jre.yml
@@ -19,6 +19,8 @@
 ---
 jre:
   version: 19.3.+
+  version_lines:
+    - 19.3.+
   repository_root: ""
 jvmkill_agent:
   version: 1.+

--- a/config/graal_vm_jre.yml
+++ b/config/graal_vm_jre.yml
@@ -18,9 +18,10 @@
 # e.g.  repository_root: "https://example.com/graalvm-jre/{platform}/{architecture}"
 ---
 jre:
-  version: 19.3.+
+  version: 22.1.+
   version_lines:
-    - 19.3.+
+    - 22.1.+
+    - 21.3.+
   repository_root: ""
 jvmkill_agent:
   version: 1.+

--- a/config/ibm_jre.yml
+++ b/config/ibm_jre.yml
@@ -20,9 +20,7 @@ jre:
   version: 1.8.+
   version_lines:
     - 1.8.+
-    - 11.+
-    - 17.+
-  repository_root: https://raw.githubusercontent.com/ibmruntimes/ci.docker/master/ibmjava/meta/jre/linux/x86_64
+  repository_root: https://raw.githubusercontent.com/ibmruntimes/ci.docker/master/ibmjava/meta/jre/linux/{architecture}
   heap_ratio: 0.75
 jvmkill_agent:
   version: 1.+

--- a/config/ibm_jre.yml
+++ b/config/ibm_jre.yml
@@ -18,6 +18,10 @@
 ---
 jre:
   version: 1.8.+
+  version_lines:
+    - 1.8.+
+    - 11.+
+    - 17.+
   repository_root: https://raw.githubusercontent.com/ibmruntimes/ci.docker/master/ibmjava/meta/jre/linux/x86_64
   heap_ratio: 0.75
 jvmkill_agent:

--- a/config/open_jdk_jre.yml
+++ b/config/open_jdk_jre.yml
@@ -14,10 +14,13 @@
 # limitations under the License.
 
 # Configuration for JRE repositories keyed by vendor
-# If Java 7 is required, permgen will be used instead of metaspace. Please see the documentation for more detail.
 ---
 jre:
   version: 1.8.0_+
+  version_lines:
+  - 1.8.0_+
+  - 11.+
+  - 17.+
   repository_root: "{default.repository.root}/openjdk/{platform}/{architecture}"
 jvmkill_agent:
   version: 1.+

--- a/config/oracle_jre.yml
+++ b/config/oracle_jre.yml
@@ -21,6 +21,10 @@
 ---
 jre:
   version: 1.8.0_+
+  version_lines:
+    - 1.8.0_+
+    - 11.+
+    - 17.+
   repository_root: ""
 jvmkill_agent:
   version: 1.+

--- a/config/packaging.yml
+++ b/config/packaging.yml
@@ -1,0 +1,190 @@
+# Cloud Foundry Java Buildpack
+# Copyright 2013-2022 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+access_logging_support:
+  name: Tomcat Access Logging Support
+  cve_notes: Included inline above
+  release_notes: Included inline above
+
+agent:
+  name: Java Memory Assistant Agent
+
+app_dynamics_agent:
+  name: AppDynamics Agent
+  release_notes: '[Release Notes](https://docs.appdynamics.com/4.5.x/en/product-and-release-announcements/release-notes/language-agent-notes/java-agent-notes)'
+
+azure_application_insights_agent:
+  name: Azure Application Insights Agent
+  release_notes: '[Release Notes](https://github.com/Microsoft/ApplicationInsights-Java/releases)'
+
+clean_up:
+  name: Java Memory Assistant Clean Up
+
+client_certificate_mapper:
+  name: Client Certificate Mapper
+  cve_notes: 'Included inline above'
+  release_notes: 'Included inline above'
+
+container_customizer:
+  name: Spring Boot Container Customizer
+  cve_notes: 'Included inline above'
+  release_notes: 'Included inline above'
+
+container_security_provider:
+  name: Container Security Provider
+  cve_notes: 'Included inline above'
+  release_notes: 'Included inline above'
+
+contrast_security_agent:
+  name: Contrast Security Agent
+  release_notes: '[Release Notes](https://docs.contrastsecurity.com/en/java-agent-release-notes.html)'
+
+datadog_javaagent:
+  name: Datadog APM Javaagent
+  release_notes: '[Release Notes](https://github.com/DataDog/dd-trace-java/releases)'
+
+dynatrace_one_agent:
+  name: Dynatrace OneAgent
+  release_notes: '[Release Notes](https://www.dynatrace.com/support/help/whats-new/release-notes/#oneagent)'
+
+elastic_apm_agent:
+  name: Elastic APM Agent
+  release_notes: '[Release Notes](https://www.elastic.co/guide/en/apm/agent/java/current/release-notes.html)'
+
+geode_store:
+  name: Geode Tomcat Session Store
+
+google_stackdriver_debugger:
+  name: Google Stackdriver Debugger
+  release_notes: '[Release Notes](https://cloud.google.com/debugger/docs/release-notes)'
+
+google_stackdriver_profiler:
+  name: Google Stackdriver Profiler
+  release_notes: '[Release Notes](https://cloud.google.com/profiler/docs/release-notes)'
+
+groovy:
+  name: Groovy
+  release_notes: '[Release Notes](http://www.groovy-lang.org/releases.html)'
+
+introscope_agent:
+  name: CA Introscope APM Framework
+
+jacoco_agent:
+  name: JaCoCo Agent
+  release_notes: '[Release Notes](https://github.com/jacoco/jacoco/releases)'
+
+jprofiler_profiler:
+  name: JProfiler Profiler
+  release_notes: '[ChangeLog](https://www.ej-technologies.com/download/jprofiler/changelog.html)'
+
+jre:
+  name: OpenJDK JRE 8
+  cve_notes: '[Risk Matrix](https://www.oracle.com/security-alerts/cpujul2022.html#AppendixJAVA)'
+  release_notes: '[Release Notes](https://bell-sw.com/pages/liberica-release-notes-8u342/)'
+
+jre-11:
+  name: OpenJDK JRE 11
+  cve_notes: '[Risk Matrix](https://www.oracle.com/security-alerts/cpujul2022.html#AppendixJAVA)'
+  release_notes: '[Release Notes](https://bell-sw.com/pages/liberica-release-notes-11.0.16/)'
+
+jre-17:
+  name: OpenJDK JRE 17
+  cve_notes: '[Risk Matrix](https://www.oracle.com/security-alerts/cpujul2022.html#AppendixJAVA)'
+  release_notes: '[Release Notes](https://bell-sw.com/pages/liberica-release-notes-17.0.4/)'
+
+jrebel_agent:
+  name: JRebel Agent
+  release_notes: '[ChangeLog](https://www.jrebel.com/products/jrebel/changelog)'
+
+jvmkill_agent:
+  name: jvmkill Agent
+  cve_notes: 'Included inline above'
+  release_notes: 'Included inline above'
+
+lifecycle_support:
+  name: Tomcat Lifecycle Support
+  cve_notes: 'Included inline above'
+  release_notes: 'Included inline above'
+
+logging_support:
+  name: Tomcat Logging Support
+  cve_notes: 'Included inline above'
+  release_notes: 'Included inline above'
+
+luna_security_provider:
+  name: Gemalto Luna Security Provider
+  release_notes: '[Release Notes](https://www.thalesdocs.com/gphsm/luna/7/docs/network/Content/CRN/Luna/CRN_Luna.htm)'
+
+maria_db_jdbc:
+  name: MariaDB JDBC Driver
+  release_notes: '[Release Notes](https://mariadb.com/kb/en/mariadb-connector-j-274-release-notes/)'
+
+memory_calculator:
+  name: Memory Calculator
+  cve_notes: 'Included inline above'
+  release_notes: 'Included inline above'
+
+metric_writer:
+  name: Metric Writer
+  cve_notes: 'Included inline above'
+  release_notes: 'Included inline above'
+
+new_relic_agent:
+  name: New Relic Agent
+  release_notes: '[Release Notes](https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes/)'
+
+postgresql_jdbc:
+  name: PostgreSQL JDBC Driver
+  release_notes: '[ChangeLog](https://jdbc.postgresql.org/documentation/changelog.html)'
+
+protect_app_security_provider:
+  name: Gemalto ProtectApp Security Provider
+
+redis_store:
+  name: Redis Session Store
+  cve_notes: 'Included inline above'
+  release_notes: 'Included inline above'
+
+riverbed_appinternals_agent:
+  name: Riverbed Appinternals Agent
+
+sealights_agent:
+  name: SeaLights Agent
+
+sky_walking_agent:
+  name: SkyWalking
+  release_notes: '[ChangeLog](https://github.com/apache/skywalking/tree/master/changes)'
+
+spring_auto_reconfiguration:
+  name: Spring Auto-reconfiguration
+  cve_notes: 'Included inline above'
+  release_notes: 'Included inline above'
+
+spring_boot_cli:
+  name: Spring Boot CLI
+
+takipi_agent:
+  name: Takipi Agent
+  release_notes: '[Release Notes](https://doc.overops.com/docs/whats-new)'
+
+tomcat:
+  name: Tomcat
+  cve_notes: '[Security](https://tomcat.apache.org/security-9.html)'
+  release_notes: '[ChangeLog](https://tomcat.apache.org/tomcat-9.0-doc/changelog.html)'
+
+your_kit_profiler:
+  name: YourKit Profiler
+  release_notes: '[Release Notes](https://www.yourkit.com/download/yjp_2022_3_builds.jsp)'

--- a/config/sap_machine_jre.yml
+++ b/config/sap_machine_jre.yml
@@ -18,6 +18,10 @@
 ---
 jre:
   version: 11.+
+  version_lines:
+    - 1.8.0_+
+    - 11.+
+    - 17.+
   repository_root: "https://sap.github.io/SapMachine/assets/cf/jre/linux/{architecture}"
 jvmkill_agent:
   version: 1.+

--- a/config/sap_machine_jre.yml
+++ b/config/sap_machine_jre.yml
@@ -19,7 +19,6 @@
 jre:
   version: 11.+
   version_lines:
-    - 1.8.0_+
     - 11.+
     - 17.+
   repository_root: "https://sap.github.io/SapMachine/assets/cf/jre/linux/{architecture}"

--- a/config/zulu_jre.yml
+++ b/config/zulu_jre.yml
@@ -24,7 +24,6 @@ jre:
   version_lines:
     - 1.8.0_+
     - 11.+
-    - 17.+
   repository_root: "https://cdn.azul.com/zulu/bin"
 jvmkill_agent:
   version: 1.+

--- a/config/zulu_jre.yml
+++ b/config/zulu_jre.yml
@@ -21,6 +21,10 @@
 ---
 jre:
   version: 1.8.0_+
+  version_lines:
+    - 1.8.0_+
+    - 11.+
+    - 17.+
   repository_root: "https://cdn.azul.com/zulu/bin"
 jvmkill_agent:
   version: 1.+

--- a/java-buildpack.iml
+++ b/java-buildpack.iml
@@ -9,7 +9,7 @@
         <RAKE_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="false" />
         <RAKE_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="" />
         <RAKE_RUN_CONFIG_SETTINGS_ID NAME="myPassParentEnvs" VALUE="true" />
-        <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="false" />
+        <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="DISABLE" bundleExecEnabled="false" />
         <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
         <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov">
           <COVERAGE_PATTERN ENABLED="true">
@@ -35,7 +35,7 @@
         <RAKE_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="false" />
         <RAKE_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="rbenv: 2.3.8" />
         <RAKE_RUN_CONFIG_SETTINGS_ID NAME="myPassParentEnvs" VALUE="true" />
-        <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="false" />
+        <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="DISABLE" bundleExecEnabled="false" />
         <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
         <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov">
           <COVERAGE_PATTERN ENABLED="true">
@@ -61,7 +61,7 @@
         <RAKE_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="false" />
         <RAKE_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="" />
         <RAKE_RUN_CONFIG_SETTINGS_ID NAME="myPassParentEnvs" VALUE="true" />
-        <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="false" />
+        <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="DISABLE" bundleExecEnabled="false" />
         <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
         <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov">
           <COVERAGE_PATTERN ENABLED="true">
@@ -87,7 +87,7 @@
         <RAKE_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="false" />
         <RAKE_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="" />
         <RAKE_RUN_CONFIG_SETTINGS_ID NAME="myPassParentEnvs" VALUE="true" />
-        <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="false" />
+        <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="DISABLE" bundleExecEnabled="false" />
         <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
         <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov">
           <COVERAGE_PATTERN ENABLED="true">
@@ -113,7 +113,7 @@
         <RAKE_RUN_CONFIG_SETTINGS_ID NAME="SHOULD_USE_SDK" VALUE="false" />
         <RAKE_RUN_CONFIG_SETTINGS_ID NAME="ALTERN_SDK_NAME" VALUE="" />
         <RAKE_RUN_CONFIG_SETTINGS_ID NAME="myPassParentEnvs" VALUE="true" />
-        <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="false" />
+        <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="DISABLE" bundleExecEnabled="false" />
         <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
         <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov">
           <COVERAGE_PATTERN ENABLED="true">
@@ -143,7 +143,7 @@
         <envs>
           <env name="JRUBY_OPTS" value="-X+O" />
         </envs>
-        <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="false" />
+        <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="DISABLE" bundleExecEnabled="false" />
         <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
         <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov">
           <COVERAGE_PATTERN ENABLED="true">
@@ -181,7 +181,7 @@
         <envs>
           <env name="JRUBY_OPTS" value="-X+O" />
         </envs>
-        <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="false" />
+        <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="DISABLE" bundleExecEnabled="false" />
         <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
         <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov">
           <COVERAGE_PATTERN ENABLED="true">
@@ -225,7 +225,7 @@
         <envs>
           <env name="JRUBY_OPTS" value="-X+O" />
         </envs>
-        <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="false" />
+        <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="DISABLE" bundleExecEnabled="false" />
         <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
         <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov">
           <COVERAGE_PATTERN ENABLED="true">
@@ -263,7 +263,7 @@
         <envs>
           <env name="JRUBY_OPTS" value="-X+O" />
         </envs>
-        <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="false" />
+        <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="DISABLE" bundleExecEnabled="false" />
         <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
         <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov">
           <COVERAGE_PATTERN ENABLED="true">
@@ -307,7 +307,7 @@
         <envs>
           <env name="JRUBY_OPTS" value="-X+O" />
         </envs>
-        <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="false" />
+        <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="DISABLE" bundleExecEnabled="false" />
         <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
         <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov">
           <COVERAGE_PATTERN ENABLED="true">
@@ -345,7 +345,7 @@
         <envs>
           <env name="JRUBY_OPTS" value="-X+O" />
         </envs>
-        <EXTENSION ID="BundlerRunConfigurationExtension" bundleExecEnabled="false" />
+        <EXTENSION ID="BundlerRunConfigurationExtension" BUNDLE_MODE="DISABLE" bundleExecEnabled="false" />
         <EXTENSION ID="JRubyRunConfigurationExtension" NailgunExecEnabled="false" />
         <EXTENSION ID="RubyCoverageRunConfigurationExtension" track_test_folders="true" runner="rcov">
           <COVERAGE_PATTERN ENABLED="true">
@@ -386,39 +386,301 @@
     </content>
     <orderEntry type="jdk" jdkName="rbenv: 3.0.4" jdkType="RUBY_SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" scope="PROVIDED" name="addressable (v2.8.0, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="ast (v2.4.2, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="bundler (v2.3.12, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="crack (v0.4.5, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="diff-lcs (v1.5.0, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="hashdiff (v1.0.1, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="parallel (v1.22.1, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="parser (v3.1.2.0, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="public_suffix (v4.0.7, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rainbow (v3.1.1, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rake (v13.0.6, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="redcarpet (v3.5.1, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="regexp_parser (v2.3.1, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rexml (v3.2.5, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec (v3.11.0, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-core (v3.11.0, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-expectations (v3.11.0, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-mocks (v3.11.1, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rspec-support (v3.11.0, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rubocop (v1.28.2, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rubocop-ast (v1.17.0, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rubocop-rspec (v2.10.0, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="ruby-progressbar (v1.11.0, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="rubyzip (v2.3.2, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="tee (v1.0.0, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="terminal-table (v3.0.2, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="unicode-display_width (v2.1.0, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="webmock (v3.14.0, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="webrick (v1.7.0, rbenv: 2.5.9) [gem]" level="application" />
-    <orderEntry type="library" scope="PROVIDED" name="yard (v0.9.27, rbenv: 2.5.9) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="addressable (v2.8.0, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="ast (v2.4.2, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="bundler (v2.3.12, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="crack (v0.4.5, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="diff-lcs (v1.5.0, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="hashdiff (v1.0.1, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="parallel (v1.22.1, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="parser (v3.1.2.0, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="public_suffix (v4.0.7, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rainbow (v3.1.1, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rake (v13.0.6, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="redcarpet (v3.5.1, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="regexp_parser (v2.3.1, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rexml (v3.2.5, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec (v3.11.0, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-core (v3.11.0, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-expectations (v3.11.0, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-mocks (v3.11.1, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rspec-support (v3.11.0, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubocop (v1.28.2, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubocop-ast (v1.17.0, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubocop-rspec (v2.10.0, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="ruby-progressbar (v1.11.0, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="rubyzip (v2.3.2, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="tee (v1.0.0, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="terminal-table (v3.0.2, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="unicode-display_width (v2.1.0, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="webmock (v3.14.0, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="webrick (v1.7.0, rbenv: 3.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="yard (v0.9.27, rbenv: 3.0.4) [gem]" level="application" />
   </component>
   <component name="RModuleSettingsStorage">
     <LOAD_PATH number="4" string0="$MODULE_DIR$/lib" string1="$MODULE_DIR$/spec" string2="$MODULE_DIR$/bin" string3="$MODULE_DIR$/spec/bin" />
     <I18N_FOLDERS number="0" />
+  </component>
+  <component name="RakeTasksCache">
+    <option name="myRootTask">
+      <RakeTaskImpl id="rake">
+        <subtasks>
+          <RakeTaskImpl description="Check that all APIs have been documented" fullCommand="check_api_doc" id="check_api_doc" />
+          <RakeTaskImpl description="Remove any temporary products" fullCommand="clean" id="clean" />
+          <RakeTaskImpl description="Remove any generated files" fullCommand="clobber" id="clobber" />
+          <RakeTaskImpl description="Create packaged buildpack" fullCommand="package" id="package" />
+          <RakeTaskImpl description="Run RuboCop" fullCommand="rubocop" id="rubocop" />
+          <RakeTaskImpl id="rubocop">
+            <subtasks>
+              <RakeTaskImpl description="Auto-correct RuboCop offenses" fullCommand="rubocop:auto_correct" id="auto_correct" />
+            </subtasks>
+          </RakeTaskImpl>
+          <RakeTaskImpl description="Run RSpec code examples" fullCommand="spec" id="spec" />
+          <RakeTaskImpl description="Display the versions of buildpack dependencies in human readable form" fullCommand="versions" id="versions" />
+          <RakeTaskImpl id="versions">
+            <subtasks>
+              <RakeTaskImpl description="Display the versions of buildpack dependencies in JSON form" fullCommand="versions:json" id="json" />
+              <RakeTaskImpl description="Display the versions of buildpack dependencies in Markdown form" fullCommand="versions:markdown" id="markdown" />
+              <RakeTaskImpl description="Display the versions of buildpack dependencies in YAML form" fullCommand="versions:yaml" id="yaml" />
+            </subtasks>
+          </RakeTaskImpl>
+          <RakeTaskImpl description="Generate YARD Documentation" fullCommand="yard" id="yard" />
+          <RakeTaskImpl description="" fullCommand="build" id="build" />
+          <RakeTaskImpl description="" fullCommand="build/java-buildpack-6f691a4c.zip" id="build/java-buildpack-6f691a4c.zip" />
+          <RakeTaskImpl description="" fullCommand="build/staging" id="build/staging" />
+          <RakeTaskImpl description="" fullCommand="build/staging/LICENSE" id="build/staging/LICENSE" />
+          <RakeTaskImpl description="" fullCommand="build/staging/NOTICE" id="build/staging/NOTICE" />
+          <RakeTaskImpl description="" fullCommand="build/staging/bin" id="build/staging/bin" />
+          <RakeTaskImpl description="" fullCommand="build/staging/bin/compile" id="build/staging/bin/compile" />
+          <RakeTaskImpl description="" fullCommand="build/staging/bin/detect" id="build/staging/bin/detect" />
+          <RakeTaskImpl description="" fullCommand="build/staging/bin/finalize" id="build/staging/bin/finalize" />
+          <RakeTaskImpl description="" fullCommand="build/staging/bin/release" id="build/staging/bin/release" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config" id="build/staging/config" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/app_dynamics_agent.yml" id="build/staging/config/app_dynamics_agent.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/aspectj_weaver_agent.yml" id="build/staging/config/aspectj_weaver_agent.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/azure_application_insights_agent.yml" id="build/staging/config/azure_application_insights_agent.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/cache.yml" id="build/staging/config/cache.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/client_certificate_mapper.yml" id="build/staging/config/client_certificate_mapper.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/components.yml" id="build/staging/config/components.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/container_customizer.yml" id="build/staging/config/container_customizer.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/container_security_provider.yml" id="build/staging/config/container_security_provider.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/contrast_security_agent.yml" id="build/staging/config/contrast_security_agent.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/datadog_javaagent.yml" id="build/staging/config/datadog_javaagent.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/debug.yml" id="build/staging/config/debug.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/dist_zip.yml" id="build/staging/config/dist_zip.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/dist_zip_like.yml" id="build/staging/config/dist_zip_like.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/elastic_apm_agent.yml" id="build/staging/config/elastic_apm_agent.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/google_stackdriver_debugger.yml" id="build/staging/config/google_stackdriver_debugger.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/google_stackdriver_profiler.yml" id="build/staging/config/google_stackdriver_profiler.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/graal_vm_jre.yml" id="build/staging/config/graal_vm_jre.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/groovy.yml" id="build/staging/config/groovy.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/ibm_jre.yml" id="build/staging/config/ibm_jre.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/introscope_agent.yml" id="build/staging/config/introscope_agent.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/jacoco_agent.yml" id="build/staging/config/jacoco_agent.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/java_main.yml" id="build/staging/config/java_main.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/java_memory_assistant.yml" id="build/staging/config/java_memory_assistant.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/java_opts.yml" id="build/staging/config/java_opts.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/jmx.yml" id="build/staging/config/jmx.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/jprofiler_profiler.yml" id="build/staging/config/jprofiler_profiler.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/jrebel_agent.yml" id="build/staging/config/jrebel_agent.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/logging.yml" id="build/staging/config/logging.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/luna_security_provider.yml" id="build/staging/config/luna_security_provider.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/maria_db_jdbc.yml" id="build/staging/config/maria_db_jdbc.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/metric_writer.yml" id="build/staging/config/metric_writer.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/new_relic_agent.yml" id="build/staging/config/new_relic_agent.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/open_jdk_jre.yml" id="build/staging/config/open_jdk_jre.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/oracle_jre.yml" id="build/staging/config/oracle_jre.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/packaging.yml" id="build/staging/config/packaging.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/platform.yml" id="build/staging/config/platform.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/postgresql_jdbc.yml" id="build/staging/config/postgresql_jdbc.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/protect_app_security_provider.yml" id="build/staging/config/protect_app_security_provider.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/repository.yml" id="build/staging/config/repository.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/riverbed_appinternals_agent.yml" id="build/staging/config/riverbed_appinternals_agent.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/sap_machine_jre.yml" id="build/staging/config/sap_machine_jre.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/sealights_agent.yml" id="build/staging/config/sealights_agent.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/sky_walking_agent.yml" id="build/staging/config/sky_walking_agent.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/spring_auto_reconfiguration.yml" id="build/staging/config/spring_auto_reconfiguration.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/spring_boot_cli.yml" id="build/staging/config/spring_boot_cli.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/takipi_agent.yml" id="build/staging/config/takipi_agent.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/tomcat.yml" id="build/staging/config/tomcat.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/version.yml" id="build/staging/config/version.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/your_kit_profiler.yml" id="build/staging/config/your_kit_profiler.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/config/zulu_jre.yml" id="build/staging/config/zulu_jre.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib" id="build/staging/lib" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack" id="build/staging/lib/java_buildpack" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack.rb" id="build/staging/lib/java_buildpack.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/buildpack.rb" id="build/staging/lib/java_buildpack/buildpack.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/buildpack_version.rb" id="build/staging/lib/java_buildpack/buildpack_version.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/component" id="build/staging/lib/java_buildpack/component" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/component.rb" id="build/staging/lib/java_buildpack/component.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/component/additional_libraries.rb" id="build/staging/lib/java_buildpack/component/additional_libraries.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/component/application.rb" id="build/staging/lib/java_buildpack/component/application.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/component/base_component.rb" id="build/staging/lib/java_buildpack/component/base_component.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/component/droplet.rb" id="build/staging/lib/java_buildpack/component/droplet.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/component/environment_variables.rb" id="build/staging/lib/java_buildpack/component/environment_variables.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/component/extension_directories.rb" id="build/staging/lib/java_buildpack/component/extension_directories.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/component/immutable_java_home.rb" id="build/staging/lib/java_buildpack/component/immutable_java_home.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/component/java_opts.rb" id="build/staging/lib/java_buildpack/component/java_opts.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/component/modular_component.rb" id="build/staging/lib/java_buildpack/component/modular_component.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/component/mutable_java_home.rb" id="build/staging/lib/java_buildpack/component/mutable_java_home.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/component/networking.rb" id="build/staging/lib/java_buildpack/component/networking.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/component/root_libraries.rb" id="build/staging/lib/java_buildpack/component/root_libraries.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/component/security_providers.rb" id="build/staging/lib/java_buildpack/component/security_providers.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/component/services.rb" id="build/staging/lib/java_buildpack/component/services.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/component/versioned_dependency_component.rb" id="build/staging/lib/java_buildpack/component/versioned_dependency_component.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container" id="build/staging/lib/java_buildpack/container" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container.rb" id="build/staging/lib/java_buildpack/container.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container/dist_zip.rb" id="build/staging/lib/java_buildpack/container/dist_zip.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container/dist_zip_like.rb" id="build/staging/lib/java_buildpack/container/dist_zip_like.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container/groovy.rb" id="build/staging/lib/java_buildpack/container/groovy.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container/java_main.rb" id="build/staging/lib/java_buildpack/container/java_main.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container/play_framework.rb" id="build/staging/lib/java_buildpack/container/play_framework.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container/ratpack.rb" id="build/staging/lib/java_buildpack/container/ratpack.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container/spring_boot.rb" id="build/staging/lib/java_buildpack/container/spring_boot.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container/spring_boot_cli.rb" id="build/staging/lib/java_buildpack/container/spring_boot_cli.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container/tomcat" id="build/staging/lib/java_buildpack/container/tomcat" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container/tomcat.rb" id="build/staging/lib/java_buildpack/container/tomcat.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container/tomcat/tomcat_access_logging_support.rb" id="build/staging/lib/java_buildpack/container/tomcat/tomcat_access_logging_support.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container/tomcat/tomcat_external_configuration.rb" id="build/staging/lib/java_buildpack/container/tomcat/tomcat_external_configuration.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container/tomcat/tomcat_geode_store.rb" id="build/staging/lib/java_buildpack/container/tomcat/tomcat_geode_store.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container/tomcat/tomcat_insight_support.rb" id="build/staging/lib/java_buildpack/container/tomcat/tomcat_insight_support.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container/tomcat/tomcat_instance.rb" id="build/staging/lib/java_buildpack/container/tomcat/tomcat_instance.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container/tomcat/tomcat_lifecycle_support.rb" id="build/staging/lib/java_buildpack/container/tomcat/tomcat_lifecycle_support.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container/tomcat/tomcat_logging_support.rb" id="build/staging/lib/java_buildpack/container/tomcat/tomcat_logging_support.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container/tomcat/tomcat_redis_store.rb" id="build/staging/lib/java_buildpack/container/tomcat/tomcat_redis_store.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container/tomcat/tomcat_setenv.rb" id="build/staging/lib/java_buildpack/container/tomcat/tomcat_setenv.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/container/tomcat/tomcat_utils.rb" id="build/staging/lib/java_buildpack/container/tomcat/tomcat_utils.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework" id="build/staging/lib/java_buildpack/framework" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework.rb" id="build/staging/lib/java_buildpack/framework.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/app_dynamics_agent.rb" id="build/staging/lib/java_buildpack/framework/app_dynamics_agent.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/aspectj_weaver_agent.rb" id="build/staging/lib/java_buildpack/framework/aspectj_weaver_agent.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/azure_application_insights_agent.rb" id="build/staging/lib/java_buildpack/framework/azure_application_insights_agent.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/checkmarx_iast_agent.rb" id="build/staging/lib/java_buildpack/framework/checkmarx_iast_agent.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/client_certificate_mapper.rb" id="build/staging/lib/java_buildpack/framework/client_certificate_mapper.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/container_customizer.rb" id="build/staging/lib/java_buildpack/framework/container_customizer.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/container_security_provider.rb" id="build/staging/lib/java_buildpack/framework/container_security_provider.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/contrast_security_agent.rb" id="build/staging/lib/java_buildpack/framework/contrast_security_agent.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/datadog_javaagent.rb" id="build/staging/lib/java_buildpack/framework/datadog_javaagent.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/debug.rb" id="build/staging/lib/java_buildpack/framework/debug.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/dynatrace_one_agent.rb" id="build/staging/lib/java_buildpack/framework/dynatrace_one_agent.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/elastic_apm_agent.rb" id="build/staging/lib/java_buildpack/framework/elastic_apm_agent.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/google_stackdriver_debugger.rb" id="build/staging/lib/java_buildpack/framework/google_stackdriver_debugger.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/google_stackdriver_profiler.rb" id="build/staging/lib/java_buildpack/framework/google_stackdriver_profiler.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/introscope_agent.rb" id="build/staging/lib/java_buildpack/framework/introscope_agent.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/jacoco_agent.rb" id="build/staging/lib/java_buildpack/framework/jacoco_agent.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/java_memory_assistant" id="build/staging/lib/java_buildpack/framework/java_memory_assistant" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/java_memory_assistant.rb" id="build/staging/lib/java_buildpack/framework/java_memory_assistant.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/java_memory_assistant/agent.rb" id="build/staging/lib/java_buildpack/framework/java_memory_assistant/agent.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/java_memory_assistant/clean_up.rb" id="build/staging/lib/java_buildpack/framework/java_memory_assistant/clean_up.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/java_memory_assistant/heap_dump_folder.rb" id="build/staging/lib/java_buildpack/framework/java_memory_assistant/heap_dump_folder.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/java_opts.rb" id="build/staging/lib/java_buildpack/framework/java_opts.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/java_security.rb" id="build/staging/lib/java_buildpack/framework/java_security.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/jmx.rb" id="build/staging/lib/java_buildpack/framework/jmx.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/jprofiler_profiler.rb" id="build/staging/lib/java_buildpack/framework/jprofiler_profiler.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/jrebel_agent.rb" id="build/staging/lib/java_buildpack/framework/jrebel_agent.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/luna_security_provider.rb" id="build/staging/lib/java_buildpack/framework/luna_security_provider.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/maria_db_jdbc.rb" id="build/staging/lib/java_buildpack/framework/maria_db_jdbc.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/metric_writer.rb" id="build/staging/lib/java_buildpack/framework/metric_writer.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/multi_buildpack.rb" id="build/staging/lib/java_buildpack/framework/multi_buildpack.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/new_relic_agent.rb" id="build/staging/lib/java_buildpack/framework/new_relic_agent.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/postgresql_jdbc.rb" id="build/staging/lib/java_buildpack/framework/postgresql_jdbc.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/protect_app_security_provider.rb" id="build/staging/lib/java_buildpack/framework/protect_app_security_provider.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/riverbed_appinternals_agent.rb" id="build/staging/lib/java_buildpack/framework/riverbed_appinternals_agent.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/sealights_agent.rb" id="build/staging/lib/java_buildpack/framework/sealights_agent.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/seeker_security_provider.rb" id="build/staging/lib/java_buildpack/framework/seeker_security_provider.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/sky_walking_agent.rb" id="build/staging/lib/java_buildpack/framework/sky_walking_agent.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/spring_auto_reconfiguration.rb" id="build/staging/lib/java_buildpack/framework/spring_auto_reconfiguration.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/spring_insight.rb" id="build/staging/lib/java_buildpack/framework/spring_insight.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/takipi_agent.rb" id="build/staging/lib/java_buildpack/framework/takipi_agent.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/framework/your_kit_profiler.rb" id="build/staging/lib/java_buildpack/framework/your_kit_profiler.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/jre" id="build/staging/lib/java_buildpack/jre" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/jre.rb" id="build/staging/lib/java_buildpack/jre.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/jre/graal_vm_jre.rb" id="build/staging/lib/java_buildpack/jre/graal_vm_jre.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/jre/ibm_jre.rb" id="build/staging/lib/java_buildpack/jre/ibm_jre.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/jre/ibm_jre_initializer.rb" id="build/staging/lib/java_buildpack/jre/ibm_jre_initializer.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/jre/jvmkill_agent.rb" id="build/staging/lib/java_buildpack/jre/jvmkill_agent.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/jre/open_jdk_jre.rb" id="build/staging/lib/java_buildpack/jre/open_jdk_jre.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/jre/open_jdk_like.rb" id="build/staging/lib/java_buildpack/jre/open_jdk_like.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/jre/open_jdk_like_jre.rb" id="build/staging/lib/java_buildpack/jre/open_jdk_like_jre.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/jre/open_jdk_like_memory_calculator.rb" id="build/staging/lib/java_buildpack/jre/open_jdk_like_memory_calculator.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/jre/open_jdk_like_security_providers.rb" id="build/staging/lib/java_buildpack/jre/open_jdk_like_security_providers.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/jre/oracle_jre.rb" id="build/staging/lib/java_buildpack/jre/oracle_jre.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/jre/sap_machine_jre.rb" id="build/staging/lib/java_buildpack/jre/sap_machine_jre.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/jre/zulu_jre.rb" id="build/staging/lib/java_buildpack/jre/zulu_jre.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/logging" id="build/staging/lib/java_buildpack/logging" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/logging.rb" id="build/staging/lib/java_buildpack/logging.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/logging/delegating_logger.rb" id="build/staging/lib/java_buildpack/logging/delegating_logger.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/logging/logger_factory.rb" id="build/staging/lib/java_buildpack/logging/logger_factory.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/repository" id="build/staging/lib/java_buildpack/repository" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/repository.rb" id="build/staging/lib/java_buildpack/repository.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/repository/configured_item.rb" id="build/staging/lib/java_buildpack/repository/configured_item.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/repository/repository_index.rb" id="build/staging/lib/java_buildpack/repository/repository_index.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/repository/version_resolver.rb" id="build/staging/lib/java_buildpack/repository/version_resolver.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util" id="build/staging/lib/java_buildpack/util" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util.rb" id="build/staging/lib/java_buildpack/util.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/cache" id="build/staging/lib/java_buildpack/util/cache" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/cache.rb" id="build/staging/lib/java_buildpack/util/cache.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/cache/application_cache.rb" id="build/staging/lib/java_buildpack/util/cache/application_cache.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/cache/cache_factory.rb" id="build/staging/lib/java_buildpack/util/cache/cache_factory.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/cache/cached_file.rb" id="build/staging/lib/java_buildpack/util/cache/cached_file.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/cache/download_cache.rb" id="build/staging/lib/java_buildpack/util/cache/download_cache.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/cache/inferred_network_failure.rb" id="build/staging/lib/java_buildpack/util/cache/inferred_network_failure.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/cache/internet_availability.rb" id="build/staging/lib/java_buildpack/util/cache/internet_availability.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/class_file_utils.rb" id="build/staging/lib/java_buildpack/util/class_file_utils.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/colorize.rb" id="build/staging/lib/java_buildpack/util/colorize.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/configuration_utils.rb" id="build/staging/lib/java_buildpack/util/configuration_utils.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/constantize.rb" id="build/staging/lib/java_buildpack/util/constantize.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/dash_case.rb" id="build/staging/lib/java_buildpack/util/dash_case.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/external_config.rb" id="build/staging/lib/java_buildpack/util/external_config.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/file_enumerable.rb" id="build/staging/lib/java_buildpack/util/file_enumerable.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/filtering_pathname.rb" id="build/staging/lib/java_buildpack/util/filtering_pathname.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/find_single_directory.rb" id="build/staging/lib/java_buildpack/util/find_single_directory.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/format_duration.rb" id="build/staging/lib/java_buildpack/util/format_duration.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/groovy_utils.rb" id="build/staging/lib/java_buildpack/util/groovy_utils.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/jar_finder.rb" id="build/staging/lib/java_buildpack/util/jar_finder.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/java_main_utils.rb" id="build/staging/lib/java_buildpack/util/java_main_utils.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/play" id="build/staging/lib/java_buildpack/util/play" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/play.rb" id="build/staging/lib/java_buildpack/util/play.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/play/base.rb" id="build/staging/lib/java_buildpack/util/play/base.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/play/factory.rb" id="build/staging/lib/java_buildpack/util/play/factory.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/play/post22.rb" id="build/staging/lib/java_buildpack/util/play/post22.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/play/post22_dist.rb" id="build/staging/lib/java_buildpack/util/play/post22_dist.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/play/post22_staged.rb" id="build/staging/lib/java_buildpack/util/play/post22_staged.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/play/pre22.rb" id="build/staging/lib/java_buildpack/util/play/pre22.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/play/pre22_dist.rb" id="build/staging/lib/java_buildpack/util/play/pre22_dist.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/play/pre22_staged.rb" id="build/staging/lib/java_buildpack/util/play/pre22_staged.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/properties.rb" id="build/staging/lib/java_buildpack/util/properties.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/qualify_path.rb" id="build/staging/lib/java_buildpack/util/qualify_path.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/ratpack_utils.rb" id="build/staging/lib/java_buildpack/util/ratpack_utils.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/sanitizer.rb" id="build/staging/lib/java_buildpack/util/sanitizer.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/shell.rb" id="build/staging/lib/java_buildpack/util/shell.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/snake_case.rb" id="build/staging/lib/java_buildpack/util/snake_case.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/space_case.rb" id="build/staging/lib/java_buildpack/util/space_case.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/spring_boot_utils.rb" id="build/staging/lib/java_buildpack/util/spring_boot_utils.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/start_script.rb" id="build/staging/lib/java_buildpack/util/start_script.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/to_b.rb" id="build/staging/lib/java_buildpack/util/to_b.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/lib/java_buildpack/util/tokenized_version.rb" id="build/staging/lib/java_buildpack/util/tokenized_version.rb" />
+          <RakeTaskImpl description="" fullCommand="build/staging/resources" id="build/staging/resources" />
+          <RakeTaskImpl description="" fullCommand="build/staging/resources/app_dynamics_agent" id="build/staging/resources/app_dynamics_agent" />
+          <RakeTaskImpl description="" fullCommand="build/staging/resources/app_dynamics_agent/defaults" id="build/staging/resources/app_dynamics_agent/defaults" />
+          <RakeTaskImpl description="" fullCommand="build/staging/resources/app_dynamics_agent/defaults/conf" id="build/staging/resources/app_dynamics_agent/defaults/conf" />
+          <RakeTaskImpl description="" fullCommand="build/staging/resources/app_dynamics_agent/defaults/conf/app-agent-config.xml" id="build/staging/resources/app_dynamics_agent/defaults/conf/app-agent-config.xml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/resources/azure_application_insights_agent" id="build/staging/resources/azure_application_insights_agent" />
+          <RakeTaskImpl description="" fullCommand="build/staging/resources/azure_application_insights_agent/AI-Agent.xml" id="build/staging/resources/azure_application_insights_agent/AI-Agent.xml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/resources/luna_security_provider" id="build/staging/resources/luna_security_provider" />
+          <RakeTaskImpl description="" fullCommand="build/staging/resources/luna_security_provider/Chrystoki.conf" id="build/staging/resources/luna_security_provider/Chrystoki.conf" />
+          <RakeTaskImpl description="" fullCommand="build/staging/resources/new_relic_agent" id="build/staging/resources/new_relic_agent" />
+          <RakeTaskImpl description="" fullCommand="build/staging/resources/new_relic_agent/newrelic.yml" id="build/staging/resources/new_relic_agent/newrelic.yml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/resources/protect_app_security_provider" id="build/staging/resources/protect_app_security_provider" />
+          <RakeTaskImpl description="" fullCommand="build/staging/resources/protect_app_security_provider/IngrianNAE.properties" id="build/staging/resources/protect_app_security_provider/IngrianNAE.properties" />
+          <RakeTaskImpl description="" fullCommand="build/staging/resources/tomcat" id="build/staging/resources/tomcat" />
+          <RakeTaskImpl description="" fullCommand="build/staging/resources/tomcat/conf" id="build/staging/resources/tomcat/conf" />
+          <RakeTaskImpl description="" fullCommand="build/staging/resources/tomcat/conf/context.xml" id="build/staging/resources/tomcat/conf/context.xml" />
+          <RakeTaskImpl description="" fullCommand="build/staging/resources/tomcat/conf/logging.properties" id="build/staging/resources/tomcat/conf/logging.properties" />
+          <RakeTaskImpl description="" fullCommand="build/staging/resources/tomcat/conf/server.xml" id="build/staging/resources/tomcat/conf/server.xml" />
+          <RakeTaskImpl description="" fullCommand="default" id="default" />
+        </subtasks>
+      </RakeTaskImpl>
+    </option>
   </component>
 </module>

--- a/rakelib/utils.rb
+++ b/rakelib/utils.rb
@@ -36,7 +36,7 @@ module Utils
       end
 
       def openjdk_jre?(configuration)
-        configuration['component_id'] == 'open_jdk_jre' && configuration['sub_component_id'].start_with?('jre')
+        configuration['component_id'].end_with?('_jre') && configuration['sub_component_id'].start_with?('jre')
       end
 
       def java_version_lines(configuration, configurations)

--- a/rakelib/utils.rb
+++ b/rakelib/utils.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# Cloud Foundry Java Buildpack
+# Copyright 2013-2022 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Utils
+  class VersionUtils
+    class << self
+      def version_wildcard?(version_pattern)
+        version_pattern.include? '+'
+      end
+
+      def version(configuration, index)
+        matched_version(configuration['version'], index.keys)
+      end
+
+      def matched_version(version_pattern, versions)
+        JavaBuildpack::Repository::VersionResolver
+          .resolve(JavaBuildpack::Util::TokenizedVersion.new(version_pattern), versions)
+      end
+
+      def version_matches?(version_pattern, versions)
+        !matched_version(version_pattern, versions).nil?
+      end
+
+      def openjdk_jre?(configuration)
+        configuration['component_id'] == 'open_jdk_jre' && configuration['sub_component_id'].start_with?('jre')
+      end
+
+      def java_version_lines(configuration, configurations)
+        configuration['version_lines'].each do |v|
+          next if version_line_matches?(configuration, v)
+
+          c1 = configuration.clone
+          c1['sub_component_id'] = "jre-#{v.split('.')[0]}"
+          c1['version'] = v
+          configurations << c1
+        end
+      end
+
+      def version_line_matches?(configuration, v)
+        return true if v == configuration['version']
+        return false if version_wildcard? v
+
+        version_matches?(configuration['version'], [v])
+      end
+    end
+  end
+end

--- a/rakelib/versions_task.rb
+++ b/rakelib/versions_task.rb
@@ -24,6 +24,7 @@ require 'java_buildpack/util/cache/download_cache'
 require 'json'
 require 'rake/tasklib'
 require 'rakelib/package'
+require 'rakelib/utils'
 require 'terminal-table'
 require 'yaml'
 
@@ -35,6 +36,8 @@ module Package
 
     def initialize
       JavaBuildpack::Logging::LoggerFactory.instance.setup "#{BUILD_DIR}/"
+
+      @pkgcfg = nil
 
       version_task
 
@@ -51,134 +54,9 @@ module Package
 
     DEFAULT_REPOSITORY_ROOT_PATTERN = /\{default.repository.root\}/.freeze
 
-    NAME_MAPPINGS = {
-      'access_logging_support' => 'Tomcat Access Logging Support',
-      'agent' => 'Java Memory Assistant Agent',
-      'app_dynamics_agent' => 'AppDynamics Agent',
-      'azure_application_insights_agent' => 'Azure Application Insights Agent',
-      'clean_up' => 'Java Memory Assistant Clean Up',
-      'client_certificate_mapper' => 'Client Certificate Mapper',
-      'container_customizer' => 'Spring Boot Container Customizer',
-      'container_security_provider' => 'Container Security Provider',
-      'contrast_security_agent' => 'Contrast Security Agent',
-      'datadog_javaagent' => 'Datadog APM Javaagent',
-      'dynatrace_one_agent' => 'Dynatrace OneAgent',
-      'elastic_apm_agent' => 'Elastic APM Agent',
-      'geode_store' => 'Geode Tomcat Session Store',
-      'google_stackdriver_debugger' => 'Google Stackdriver Debugger',
-      'google_stackdriver_profiler' => 'Google Stackdriver Profiler',
-      'groovy' => 'Groovy',
-      'introscope_agent' => 'CA Introscope APM Framework',
-      'jacoco_agent' => 'JaCoCo Agent',
-      'jprofiler_profiler' => 'JProfiler Profiler',
-      'jre' => 'OpenJDK JRE',
-      'jre-11' => 'OpenJDK JRE 11',
-      'jre-17' => 'OpenJDK JRE 17',
-      'jrebel_agent' => 'JRebel Agent',
-      'jvmkill_agent' => 'jvmkill Agent',
-      'lifecycle_support' => 'Tomcat Lifecycle Support',
-      'logging_support' => 'Tomcat Logging Support',
-      'luna_security_provider' => 'Gemalto Luna Security Provider',
-      'maria_db_jdbc' => 'MariaDB JDBC Driver',
-      'memory_calculator' => 'Memory Calculator',
-      'metric_writer' => 'Metric Writer',
-      'new_relic_agent' => 'New Relic Agent',
-      'postgresql_jdbc' => 'PostgreSQL JDBC Driver',
-      'protect_app_security_provider' => 'Gemalto ProtectApp Security Provider',
-      'redis_store' => 'Redis Session Store',
-      'riverbed_appinternals_agent' => 'Riverbed Appinternals Agent',
-      'sealights_agent' => 'SeaLights Agent',
-      'sky_walking_agent' => 'SkyWalking',
-      'spring_auto_reconfiguration' => 'Spring Auto-reconfiguration',
-      'spring_boot_cli' => 'Spring Boot CLI',
-      'takipi_agent' => 'Takipi Agent',
-      'tomcat' => 'Tomcat',
-      'your_kit_profiler' => 'YourKit Profiler'
-    }.freeze
-
-    NOTE_LINKS = {
-      'access_logging_support' => { 'cve' => 'Included inline above', 'release' => 'Included inline above' },
-      'agent' => { 'cve' => '', 'release' => '' },
-      'app_dynamics_agent' => {
-        'cve' => '',
-        'release' => '[Release Notes](https://docs.appdynamics.com/4.5.x/en/product-and-' \
-                     'release-announcements/release-notes/language-agent-notes/java-agent-notes)'
-      },
-      'azure_application_insights_agent' =>
-        { 'cve' => '',
-          'release' => '[Release Notes](https://github.com/Microsoft/ApplicationInsights-Java/releases)' },
-      'clean_up' => { 'cve' => '', 'release' => '' },
-      'client_certificate_mapper' => { 'cve' => 'Included inline above', 'release' => 'Included inline above' },
-      'container_customizer' => { 'cve' => 'Included inline above', 'release' => 'Included inline above' },
-      'container_security_provider' => { 'cve' => 'Included inline above', 'release' => 'Included inline above' },
-      'contrast_security_agent' =>
-        { 'cve' => '',
-          'release' => '[Release Notes](https://docs.contrastsecurity.com/en/java-agent-release-notes.html)' },
-      'datadog_javaagent' => { 'cve' => '',
-                               'release' => '[Release Notes](https://github.com/DataDog/dd-trace-java/releases)' },
-      'dynatrace_one_agent' =>
-        { 'cve' => '',
-          'release' => '[Release Notes](https://www.dynatrace.com/support/help/whats-new/release-notes/#oneagent)' },
-      'elastic_apm_agent' =>
-        { 'cve' => '',
-          'release' => '[Release Notes](https://www.elastic.co/guide/en/apm/agent/java/current/release-notes.html)' },
-      'geode_store' => { 'cve' => '', 'release' => '' },
-      'google_stackdriver_debugger' =>
-        { 'cve' => '',
-          'release' => '[Release Notes](https://cloud.google.com/debugger/docs/release-notes)' },
-      'google_stackdriver_profiler' =>
-        { 'cve' => '',
-          'release' => '[Release Notes](https://cloud.google.com/profiler/docs/release-notes)' },
-      'groovy' => { 'cve' => '', 'release' => '[Release Notes](http://www.groovy-lang.org/releases.html)' },
-      'introscope_agent' => { 'cve' => '', 'release' => '' },
-      'jacoco_agent' => { 'cve' => '', 'release' => '[Release Notes](https://github.com/jacoco/jacoco/releases)' },
-      'jprofiler_profiler' =>
-        { 'cve' => '',
-          'release' => '[ChangeLog](https://www.ej-technologies.com/download/jprofiler/changelog.html)' },
-      'jre' => { 'cve' => '[Risk Matrix](https://www.oracle.com/security-alerts/cpujul2022.html#AppendixJAVA)',
-                 'release' => '[Release Notes](https://bell-sw.com/pages/liberica-release-notes-8u342/)' },
-      'jre-11' => { 'cve' => '[Risk Matrix](https://www.oracle.com/security-alerts/cpujul2022.html#AppendixJAVA)',
-                    'release' => '[Release Notes](https://bell-sw.com/pages/liberica-release-notes-11.0.16/)' },
-      'jre-17' => { 'cve' => '[Risk Matrix](https://www.oracle.com/security-alerts/cpujul2022.html#AppendixJAVA)',
-                    'release' => '[Release Notes](https://bell-sw.com/pages/liberica-release-notes-17.0.4/)' },
-      'jrebel_agent' => { 'cve' => '', 'release' => '[ChangeLog](https://www.jrebel.com/products/jrebel/changelog)' },
-      'jvmkill_agent' => { 'cve' => 'Included inline above', 'release' => 'Included inline above' },
-      'lifecycle_support' => { 'cve' => 'Included inline above', 'release' => 'Included inline above' },
-      'logging_support' => { 'cve' => 'Included inline above', 'release' => 'Included inline above' },
-      'luna_security_provider' =>
-        { 'cve' => '',
-          'release' =>
-            '[Release Notes](https://www.thalesdocs.com/gphsm/luna/7/docs/network/Content/CRN/Luna/CRN_Luna.htm)' },
-      'maria_db_jdbc' =>
-        { 'cve' => '',
-          'release' => '[Release Notes](https://mariadb.com/kb/en/mariadb-connector-j-274-release-notes/)' },
-      'memory_calculator' => { 'cve' => 'Included inline above', 'release' => 'Included inline above' },
-      'metric_writer' => { 'cve' => 'Included inline above', 'release' => 'Included inline above' },
-      'new_relic_agent' =>
-        { 'cve' => '',
-          'release' =>
-            '[Release Notes](https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes/)' },
-      'postgresql_jdbc' => { 'cve' => '',
-                             'release' => '[ChangeLog](https://jdbc.postgresql.org/documentation/changelog.html)' },
-      'protect_app_security_provider' => { 'cve' => '', 'release' => '' },
-      'redis_store' => { 'cve' => 'Included inline above', 'release' => 'Included inline above' },
-      'riverbed_appinternals_agent' => { 'cve' => '', 'release' => '' },
-      'sealights_agent' => { 'cve' => '', 'release' => '' },
-      'sky_walking_agent' => { 'cve' => '',
-                               'release' => '[ChangeLog](https://github.com/apache/skywalking/tree/master/changes)' },
-      'spring_auto_reconfiguration' => { 'cve' => 'Included inline above', 'release' => 'Included inline above' },
-      'spring_boot_cli' => { 'cve' => '', 'release' => '' },
-      'takipi_agent' => { 'cve' => '', 'release' => '[Release Notes](https://doc.overops.com/docs/whats-new)' },
-      'tomcat' => { 'cve' => '[Security](https://tomcat.apache.org/security-9.html)',
-                    'release' => '[ChangeLog](https://tomcat.apache.org/tomcat-9.0-doc/changelog.html)' },
-      'your_kit_profiler' => { 'cve' => '',
-                               'release' => '[Release Notes](https://www.yourkit.com/download/yjp_2022_3_builds.jsp)' }
-    }.freeze
-
     PLATFORM_PATTERN = /\{platform\}/.freeze
 
-    private_constant :ARCHITECTURE_PATTERN, :DEFAULT_REPOSITORY_ROOT_PATTERN, :NAME_MAPPINGS,
-                     :PLATFORM_PATTERN, :NOTE_LINKS
+    private_constant :ARCHITECTURE_PATTERN, :DEFAULT_REPOSITORY_ROOT_PATTERN, :PLATFORM_PATTERN
 
     def augment(raw, key, pattern, candidates, &block)
       if raw.respond_to? :at
@@ -227,40 +105,6 @@ module Package
       configuration('components').values.flatten.map { |component| component.split('::').last.snake_case }
     end
 
-    def configuration(id)
-      JavaBuildpack::Util::ConfigurationUtils.load(id, false, false)
-    end
-
-    def configurations(component_id, configuration, sub_component_id = nil)
-      configurations = []
-
-      if repository_configuration?(configuration)
-        configuration['component_id'] = component_id
-        configuration['sub_component_id'] = sub_component_id if sub_component_id
-
-        if component_id == 'open_jdk_jre' && sub_component_id == 'jre'
-          c1 = configuration.clone
-          c1['sub_component_id'] = 'jre-11'
-          c1['version'] = '11.+'
-
-          configurations << c1
-        end
-
-        if component_id == 'open_jdk_jre' && sub_component_id == 'jre'
-          c1 = configuration.clone
-          c1['sub_component_id'] = 'jre-17'
-          c1['version'] = '17.+'
-
-          configurations << c1
-        end
-        configurations << configuration
-      else
-        configuration.each { |k, v| configurations << configurations(component_id, v, k) if v.is_a? Hash }
-      end
-
-      configurations
-    end
-
     def default_repository_root
       configuration('repository')['default_repository_root'].chomp('/')
     end
@@ -268,7 +112,7 @@ module Package
     def get_from_cache(cache, configuration, index_configuration)
       cache.get(index_configuration[:uri]) do |f|
         index = YAML.safe_load f
-        found_version = version(configuration, index)
+        found_version = Utils::VersionUtils.version(configuration, index)
 
         if found_version.nil?
           raise "Unable to resolve version '#{configuration['version']}' for platform " \
@@ -300,7 +144,7 @@ module Package
       index_configuration(configuration).each do |index_configuration|
         version, uri = get_from_cache(cache, configuration, index_configuration)
 
-        name = NAME_MAPPINGS[id]
+        name = packaging[id]['name']
         raise "Unable to resolve name for '#{id}'" unless name
 
         dependency_versions << {
@@ -308,28 +152,10 @@ module Package
           'name' => name,
           'uri' => uri,
           'version' => version,
-          'cve_link' => NOTE_LINKS[id]['cve'],
-          'release_notes_link' => NOTE_LINKS[id]['release']
+          'cve_link' => packaging[id]['cve_notes'] || '',
+          'release_notes_link' => packaging[id]['release_notes'] || ''
         }
       end
-    end
-
-    def index_configuration(configuration)
-      [configuration['repository_root']]
-        .map { |r| { uri: r } }
-        .map { |r| augment_repository_root r }
-        .map { |r| augment_platform r }
-        .map { |r| augment_architecture r }
-        .map { |r| augment_path r }.flatten
-    end
-
-    def repository_configuration?(configuration)
-      configuration['version'] && configuration['repository_root']
-    end
-
-    def version(configuration, index)
-      JavaBuildpack::Repository::VersionResolver
-        .resolve(JavaBuildpack::Util::TokenizedVersion.new(configuration['version']), index.keys)
     end
 
     def version_task

--- a/spec/java_buildpack/util/configuration_utils_spec.rb
+++ b/spec/java_buildpack/util/configuration_utils_spec.rb
@@ -102,6 +102,66 @@ describe JavaBuildpack::Util::ConfigurationUtils do
     context do
 
       let(:environment) do
+        { 'JBP_DEFAULT_TEST' => '{bar: {alpha: {one: 3, two: {one: 3}}, bravo: newValue}, foo: lion}' }
+      end
+
+      it 'overlays operator default matching environment variables' do
+
+        expect(described_class.load('test')).to eq('foo' => { 'one' => '1', 'two' => 2 },
+                                                   'bar' => { 'alpha' => { 'one' => 3, 'two' => 'dog' } },
+                                                   'version' => '1.7.1')
+      end
+
+    end
+
+    context do
+
+      let(:environment) do
+        { 'JBP_DEFAULT_TEST' => '{version: 1.8.+}' }
+      end
+
+      it 'overlays operator default config' do
+        expect(described_class.load('test')).to eq('foo' => { 'one' => '1', 'two' => 2 },
+                                                   'bar' => { 'alpha' => { 'one' => 'cat', 'two' => 'dog' } },
+                                                   'version' => '1.8.+')
+      end
+
+    end
+
+    context do
+
+      let(:environment) do
+        { 'JBP_DEFAULT_TEST' => '{version: 11.+}',
+          'JBP_CONFIG_TEST' => '{version: 17.+}' }
+      end
+
+      it 'overlays operator default config and environment variable config' do
+        expect(described_class.load('test')).to eq('foo' => { 'one' => '1', 'two' => 2 },
+                                                   'bar' => { 'alpha' => { 'one' => 'cat', 'two' => 'dog' } },
+                                                   'version' => '17.+')
+      end
+
+    end
+
+    context do
+
+      let(:environment) do
+        { 'JBP_DEFAULT_TEST' => '{bar: {alpha: {one: 3, two: {one: 3}}, bravo: newValue}}',
+          'JBP_CONFIG_TEST' => '{bar: {alpha: {one: 9, two: {one: 3}}, bravo: newValue}}' }
+      end
+
+      it 'overlays operator default matching and environment variables' do
+
+        expect(described_class.load('test')).to eq('foo' => { 'one' => '1', 'two' => 2 },
+                                                   'bar' => { 'alpha' => { 'one' => 9, 'two' => 'dog' } },
+                                                   'version' => '1.7.1')
+      end
+
+    end
+
+    context do
+
+      let(:environment) do
         { 'JBP_CONFIG_TEST' => 'Not an array or a hash' }
       end
 


### PR DESCRIPTION
1. Adds an environment variable that can be used by operations teams to set default values. Operator defaults override buildpack defaults, but are overridden by application developer values. Operator defaults are set by exposing an environment variable of the pattern `JBP_DEFAULT_<config-file>='<inline-yaml>'`. So to set a default Java version, `JBP_DEFAULT_OPEN_JDK_JRE='{ jre: { version: 11.+ }}'`.

2. Adds `config/packaging.yml`. This contains the list of component data. Each component gets a name, CVE notes link and release notes link. This information is used by the `rake versions` command to generate a nice set of release notes for each package. This information was refactored out of the scripts (was previously hard-coded).

3. Each `config/<jre>.yml` file has been given a `jre.version_lines` property. This is a list of the supported version lines for that JRE. It defaults to using pattern matching to pick the latest 1.8, 11 and 17 versions. If you are packaging your own version of the buildpack and want to limit the version lines included, perhaps to reduce the size of the generated buildpack file, you can edit this list and remove entries. Theh package script will only include what is listed in this array.

4. When pinning versions, the packaging script will now update each `config/<jre>yml` file's `jre.version_lines` list with the pinned versions, in addition to `jre.version`. This allows you to have a list of every version line bundled with the buildpack when a release is cut (previously, only 1.8 was committed to source control). This helps when rebuilding a version of the Java buildpack at a later date, as you'll have the exact set of Java versions which should be included.

5. You may change the default version of Java that is selected during a build of the Java buildpack by setting the `config/<jre>.yml` file's `jre.version` value. This needs to match one of the entries in `jre.version_lines`. Then follow the standard packaging steps the the buildpack that's generated will use the selected version of Java by default.

Resolves #938 #892 #886 

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>