### PR TITLE
Require missing library

### DIFF
--- a/lib/java_buildpack/jre/ibm_jre_initializer.rb
+++ b/lib/java_buildpack/jre/ibm_jre_initializer.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 require 'fileutils'
+require 'tempfile'
 require 'java_buildpack/component/versioned_dependency_component'
 require 'java_buildpack/jre'
 require 'java_buildpack/util/tokenized_version'


### PR DESCRIPTION
After refactoring for Ruby 3.0 compatibility, it looks like there's now a missing dependency. This PR adds the missing 'tempfile' require.

Resolves #955 

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>