### PR TITLE
Disables the SAR library by default

### DIFF
--- a/config/spring_auto_reconfiguration.yml
+++ b/config/spring_auto_reconfiguration.yml
@@ -19,4 +19,4 @@
 ---
 version: 2.+
 repository_root: "{default.repository.root}/auto-reconfiguration"
-enabled: true
+enabled: false


### PR DESCRIPTION
As per notices and issue #951, this PR disables Spring Auto Reconfiguration by default.