### PR TITLE
Handle Dynatrace API Token in the sanitizer

### DIFF
--- a/lib/java_buildpack/util/sanitizer.rb
+++ b/lib/java_buildpack/util/sanitizer.rb
@@ -18,36 +18,55 @@
 # A mixin that adds the ability to turn a +String+ into sanitized uri
 class String
 
+  # Takes the uri query params and strips out credentials
+  #
+  # @return [String] the sanitized query params
+  def handle_params(params)
+    keywords = /key
+               |password
+               |username
+               |cred(ential)*(s)*
+               |password
+               |token
+               |api[-_]token
+               |api
+               |auth(entication)*
+               |access[-_]token
+               |secret[-_]token/ix
+
+    query_params = ''
+
+    params.each do |key, value|
+      match = key.match(keywords)
+
+      if match
+        params[key] = if match[0] == 'Api-Token' && value =~ /dt\w*/
+                        value.gsub(/(dt\w*\.\w*)\.\w*/, '\1.REDACTED')
+                      else
+                        '***'
+                      end
+      end
+
+      query_params += key + '=' + params[key] + '&'
+    end
+
+    query_params
+  end
+
   # Takes a uri and strips out any credentials it may contain.
   #
   # @return [String] the sanitized uri
   def sanitize_uri
-    keywords = /key|password|username|cred[entials]*[s]*|password|token|api[-_]token|api|auth[entication]*|access[-_]token|secret[-_]token/i
-
     rich_uri          = URI(self)
     rich_uri.user     = nil
     rich_uri.password = nil
 
-    if(rich_uri.query)
-      params = Hash[URI.decode_www_form rich_uri.query]
-
-      query_params = ""
-
-      params.each do |key,value|
-        match = key.match(keywords)
-
-        if(match)
-          if(match[0] == "Api-Token" && value =~ /dt\w*/)
-            params[key] = value.gsub(/(dt\w*\.\w*)\.\w*/, '\1.REDACTED')
-          else
-            params[key] = "***"
-          end
-        end
-
-        query_params += key + "=" + params[key] + "&"
-      end
+    if rich_uri.query
+      params = (URI.decode_www_form rich_uri.query).to_h
+      query_params = handle_params(params)
       rich_uri.query = query_params.chop
     end
+
     rich_uri.to_s
   end
 end

--- a/lib/java_buildpack/util/sanitizer.rb
+++ b/lib/java_buildpack/util/sanitizer.rb
@@ -25,6 +25,7 @@ class String
     rich_uri          = URI(self)
     rich_uri.user     = nil
     rich_uri.password = nil
+    rich_uri.query = rich_uri.query&.gsub(/(Api-Token=dt\w*\.\w*)\.\w*/, '\1.REDACTED')
     rich_uri.to_s
   end
 

--- a/lib/java_buildpack/util/sanitizer.rb
+++ b/lib/java_buildpack/util/sanitizer.rb
@@ -36,17 +36,8 @@ class String
 
     query_params = ''
 
-    params.each do |key, value|
-      match = key.match(keywords)
-
-      if match
-        params[key] = if match[0] == 'Api-Token' && value =~ /dt\w*/
-                        value.gsub(/(dt\w*\.\w*)\.\w*/, '\1.REDACTED')
-                      else
-                        '***'
-                      end
-      end
-
+    params.each do |key, _|
+      params[key] = '***' if key.match(keywords)
       query_params += key + '=' + params[key] + '&'
     end
 

--- a/spec/java_buildpack/util/sanitize_spec.rb
+++ b/spec/java_buildpack/util/sanitize_spec.rb
@@ -23,7 +23,23 @@ describe 'sanitize_uri' do # rubocop:disable RSpec/DescribeClass
   include_context 'with application help'
 
   it 'sanitizes uri with credentials in' do
-    expect('https://myuser:mypass@myhost/path/to/file'.sanitize_uri).to eq('https://myhost/path/to/file')
+    expect('https://myuser:mypass@myhost/path/to/file'\
+           '?authentication=verysecret'\
+           '&cred=verysecret'\
+           '&password=verysecret'\
+           '&include=java'\
+           '&bitness=64'\
+           '&Api-Token=dt0c01.H67ALCXCXK7PWAAOQLENSRET.PRIVATEPART'\
+           '&secret-token=verysecret'\
+           '&token=123456789'.sanitize_uri).to eq('https://myhost/path/to/file'\
+                                                  '?authentication=***'\
+                                                  '&cred=***'\
+                                                  '&password=***'\
+                                                  '&include=java'\
+                                                  '&bitness=64'\
+                                                  '&Api-Token=dt0c01.H67ALCXCXK7PWAAOQLENSRET.REDACTED'\
+                                                  '&secret-token=***'\
+                                                  '&token=***')
   end
 
   it 'does not sanatize uri with no credentials in' do

--- a/spec/java_buildpack/util/sanitize_spec.rb
+++ b/spec/java_buildpack/util/sanitize_spec.rb
@@ -37,7 +37,7 @@ describe 'sanitize_uri' do # rubocop:disable RSpec/DescribeClass
                                                   '&password=***'\
                                                   '&include=java'\
                                                   '&bitness=64'\
-                                                  '&Api-Token=dt0c01.H67ALCXCXK7PWAAOQLENSRET.REDACTED'\
+                                                  '&Api-Token=***'\
                                                   '&secret-token=***'\
                                                   '&token=***')
   end


### PR DESCRIPTION
Masking the private part of the API Token

Fix for Issue [#967](https://github.com/cloudfoundry/java-buildpack/issues/967)