### PR TITLE
Re-enables auto-reconfig by default

### DIFF
--- a/config/spring_auto_reconfiguration.yml
+++ b/config/spring_auto_reconfiguration.yml
@@ -19,4 +19,4 @@
 ---
 version: 2.+
 repository_root: "{default.repository.root}/auto-reconfiguration"
-enabled: false
+enabled: true

--- a/lib/java_buildpack/framework/spring_auto_reconfiguration.rb
+++ b/lib/java_buildpack/framework/spring_auto_reconfiguration.rb
@@ -71,7 +71,7 @@ module JavaBuildpack
         @logger.warn do
           'ATTENTION: The Spring Cloud Connectors library is present in your application. This library ' \
             'has been in maintenance mode since July 2019 and will stop receiving all updates after ' \
-            'Dec 2022.'
+            'Aug 2023.'
         end
         @logger.warn do
           'Please migrate to java-cfenv immediately. See https://via.vmw.com/EiBW for migration instructions.' \
@@ -87,8 +87,8 @@ module JavaBuildpack
         @logger.warn do
           'If you are not using these libraries, set `JBP_CONFIG_SPRING_AUTO_RECONFIGURATION=\'{enabled: false}\'` ' \
             'to disable their installation and clear this warning message. The buildpack will switch its default ' \
-            'to disable by default after Aug 2022. Spring Auto Reconfiguration and its shaded Spring Cloud ' \
-            'Connectors will be removed from the buildpack after Dec 2022.'
+            'to disable by default after April 2023. Spring Auto Reconfiguration and its shaded Spring Cloud ' \
+            'Connectors will be removed from the buildpack after Aug 2023.'
         end
         @logger.warn do
           'If you are using these libraries, please migrate to java-cfenv immediately. ' \


### PR DESCRIPTION
This re-enables the Spring AutoReconfiguration framework by default, to give users more time to [migrate](https://docs.cloudfoundry.org/buildpacks/java/configuring-service-connections.html#migrating) to `java-cfenv`