### PR TITLE
Add connection string for Azure Application Insights Agent 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The buildpack supports extension through the use of Git repository forking. The 
 * Standard Frameworks
   * [AppDynamics Agent](docs/framework-app_dynamics_agent.md) ([Configuration](docs/framework-app_dynamics_agent.md#configuration))
   * [AspectJ Weaver Agent](docs/framework-aspectj_weaver_agent.md) ([Configuration](docs/framework-aspectj_weaver_agent.md#configuration))
+  * [Azure Application Insights Agent](docs/framework-azure_application_insights_agent.md) ([Configuration](docs/framework-azure_application_insights_agent.md#configuration))
   * [Checkmarx IAST Agent](docs/framework-checkmarx_iast_agent.md) ([Configuration](docs/framework-checkmarx_iast_agent.md#configuration))
   * [Client Certificate Mapper](docs/framework-client_certificate_mapper.md) ([Configuration](docs/framework-client_certificate_mapper.md#configuration))
   * [Container Customizer](docs/framework-container_customizer.md) ([Configuration](docs/framework-container_customizer.md#configuration))

--- a/docs/framework-azure_application_insights_agent.md
+++ b/docs/framework-azure_application_insights_agent.md
@@ -1,0 +1,33 @@
+# Azure Application Insights Agent Framework
+The Azure Application Insights Agent Framework causes an application to be automatically configured to work with a bound [Azure Application Insights Service][].  **Note:** This framework is disabled by default.
+
+<table>
+  <tr>
+    <td><strong>Detection Criterion</strong></td><td>Existence of a single bound Azure Application Insights service.
+      <ul>
+        <li>Existence of a Azure Application Insights service is defined as the <a href="http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES"><code>VCAP_SERVICES</code></a> payload containing a service who's name, label or tag has <code>azure-application-insights</code> as a substring with at least `connection_string` or `instrumentation_key` set as credentials.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td><strong>Tags</strong></td>
+    <td><tt>azure-application-insights=&lt;version&gt;</tt></td>
+  </tr>
+</table>
+Tags are printed to standard output by the buildpack detect script
+
+## User-Provided Service
+Users must provide their own Azure Application Insights service. A user-provided Azure Application Insights service must have a name or tag with `azure-application-insights` in it so that the Azure Application Insights Agent Framework Framework will automatically configure the application to work with the service.
+
+The credential payload of the service has to contain one of the following entries:
+
+| Name | Description
+| ---- | -----------
+| `connection_string` | With agent version 3.x the connection string is required. You can find your connection string in your Application Insights resource.
+| `instrumentation_key` | With agent version 2.x the instrumentation key is required. With version 3.x this configuration is deprecated an it is recommended to switch to a connection string. You can find your instrumentation key in your Application Insights resource.
+
+## Configuration
+For general information on configuring the buildpack, including how to specify configuration values through environment variables, refer to [Configuration and Extension][].
+
+[Configuration and Extension]: ../README.md#configuration-and-extension
+[Azure Application Insights Service]: https://learn.microsoft.com/en-us/azure/azure-monitor/app/java-in-process-agent

--- a/lib/java_buildpack/framework/azure_application_insights_agent.rb
+++ b/lib/java_buildpack/framework/azure_application_insights_agent.rb
@@ -33,7 +33,7 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::BaseComponent#release)
       def release
-        credentials = @application.services.find_service(FILTER, CONNECTION_STRING, INSTRUMENTATION_KEY)['credentials']
+        credentials = @application.services.find_service(FILTER, [CONNECTION_STRING, INSTRUMENTATION_KEY])['credentials']
 
         if credentials.key?(CONNECTION_STRING)
           @droplet.java_opts.add_system_property('applicationinsights.connection.string',
@@ -54,7 +54,7 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::VersionedDependencyComponent#supports?)
       def supports?
-        @application.services.one_service?(FILTER, CONNECTION_STRING, INSTRUMENTATION_KEY)
+        @application.services.one_service?(FILTER, [CONNECTION_STRING, INSTRUMENTATION_KEY])
       end
 
       FILTER = /azure-application-insights/.freeze

--- a/lib/java_buildpack/framework/azure_application_insights_agent.rb
+++ b/lib/java_buildpack/framework/azure_application_insights_agent.rb
@@ -42,6 +42,10 @@ module JavaBuildpack
         if credentials.key?(INSTRUMENTATION_KEY)
           @droplet.java_opts.add_system_property('APPLICATION_INSIGHTS_IKEY',
                                                  credentials[INSTRUMENTATION_KEY])
+          # add environment variable for compatibility with agent version 3.x
+          # this triggers a warning message to switch to connection string
+          @droplet.environment_variables.add_environment_variable('APPINSIGHTS_INSTRUMENTATIONKEY',
+                                                                  credentials[INSTRUMENTATION_KEY])
         end
         @droplet.java_opts.add_javaagent(@droplet.sandbox + jar_name)
       end

--- a/lib/java_buildpack/framework/azure_application_insights_agent.rb
+++ b/lib/java_buildpack/framework/azure_application_insights_agent.rb
@@ -33,25 +33,32 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::BaseComponent#release)
       def release
-        credentials = @application.services.find_service(FILTER, INSTRUMENTATION_KEY)['credentials']
+        credentials = @application.services.find_service(FILTER, CONNECTION_STRING, INSTRUMENTATION_KEY)['credentials']
 
-        @droplet
-          .java_opts.add_javaagent(@droplet.sandbox + jar_name)
-          .add_system_property('APPLICATION_INSIGHTS_IKEY', credentials[INSTRUMENTATION_KEY])
+        if credentials.key?(CONNECTION_STRING)
+          @droplet.java_opts.add_system_property('applicationinsights.connection.string',
+                                                 credentials[CONNECTION_STRING])
+        end
+        if credentials.key?(INSTRUMENTATION_KEY)
+          @droplet.java_opts.add_system_property('APPLICATION_INSIGHTS_IKEY',
+                                                 credentials[INSTRUMENTATION_KEY])
+        end
+        @droplet.java_opts.add_javaagent(@droplet.sandbox + jar_name)
       end
 
       protected
 
       # (see JavaBuildpack::Component::VersionedDependencyComponent#supports?)
       def supports?
-        @application.services.one_service? FILTER, INSTRUMENTATION_KEY
+        @application.services.one_service?(FILTER, CONNECTION_STRING, INSTRUMENTATION_KEY)
       end
 
       FILTER = /azure-application-insights/.freeze
 
+      CONNECTION_STRING = 'connection_string'
       INSTRUMENTATION_KEY = 'instrumentation_key'
 
-      private_constant :FILTER, :INSTRUMENTATION_KEY
+      private_constant :FILTER, :CONNECTION_STRING, :INSTRUMENTATION_KEY
 
     end
 

--- a/spec/java_buildpack/framework/azure_application_insights_agent_spec.rb
+++ b/spec/java_buildpack/framework/azure_application_insights_agent_spec.rb
@@ -33,7 +33,9 @@ describe JavaBuildpack::Framework::AzureApplicationInsightsAgent do
   context do
 
     before do
-      allow(services).to receive(:one_service?).with(/azure-application-insights/, 'instrumentation_key')
+      allow(services).to receive(:one_service?).with(/azure-application-insights/,
+                                                     'connection_string',
+                                                     'instrumentation_key')
                                                .and_return(true)
     end
 
@@ -59,12 +61,14 @@ describe JavaBuildpack::Framework::AzureApplicationInsightsAgent do
 
     it 'updates JAVA_OPTS' do
       allow(services).to receive(:find_service)
-        .and_return('credentials' => { 'instrumentation_key' => 'test-instrumentation-key' })
+        .and_return('credentials' => { 'connection_string' => 'test-connection-string',
+                                       'instrumentation_key' => 'test-instrumentation-key' })
 
       component.release
 
       expect(java_opts).to include('-javaagent:$PWD/.java-buildpack/azure_application_insights_agent/' \
                                    "azure_application_insights_agent-#{version}.jar")
+      expect(java_opts).to include('-Dapplicationinsights.connection.string=test-connection-string')
       expect(java_opts).to include('-DAPPLICATION_INSIGHTS_IKEY=test-instrumentation-key')
     end
 

--- a/spec/java_buildpack/framework/azure_application_insights_agent_spec.rb
+++ b/spec/java_buildpack/framework/azure_application_insights_agent_spec.rb
@@ -72,6 +72,15 @@ describe JavaBuildpack::Framework::AzureApplicationInsightsAgent do
       expect(java_opts).to include('-DAPPLICATION_INSIGHTS_IKEY=test-instrumentation-key')
     end
 
+    it 'updates environment variables' do
+      allow(services).to receive(:find_service)
+        .and_return('credentials' => { 'instrumentation_key' => 'test-instrumentation-key' })
+
+      component.release
+
+      expect(environment_variables).to include('APPINSIGHTS_INSTRUMENTATIONKEY=test-instrumentation-key')
+    end
+
   end
 
 end


### PR DESCRIPTION
Improvements to Azure Application Insights Agent to make version 3.x usable using a connection string (see also #980). Also added some initial documentation