### PR TITLE
Use default.repository.root for Sky Walking Framework

### DIFF
--- a/config/sky_walking_agent.yml
+++ b/config/sky_walking_agent.yml
@@ -16,5 +16,5 @@
 # Configuration for the Sky Walking framework.
 ---
 version: +
-repository_root: https://java-buildpack.cloudfoundry.org/sky-walking
+repository_root: "{default.repository.root}/sky-walking"
 default_application_name: $(jq -r -n "$VCAP_APPLICATION | .space_name + \":\" + .application_name | @sh")


### PR DESCRIPTION
Replace hard-coded https://java-buildpack.cloudfoundry.org/ with {default.repository.root} for Apache SkyWalking Framework