### PR TITLE
Fixed issue with offline packaging for cflinuxfs4/jammy

### DIFF
--- a/rakelib/package.rb
+++ b/rakelib/package.rb
@@ -73,7 +73,7 @@ module Package
 
   BUILDPACK_VERSION = JavaBuildpack::BuildpackVersion.new(false).freeze
 
-  PLATFORMS = %w[bionic].freeze
+  PLATFORMS = %w[bionic jammy].freeze
 
   STAGING_DIR = "#{BUILD_DIR}/staging".freeze
 


### PR DESCRIPTION
Fixes #986 by ensuring both sets of binaries are packaged for offline builds 