### PR TITLE
Add PLATFORMS var for offline bundling

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,17 @@ Caching https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.10/s
 Creating build/java-buildpack-offline-cfd6b17.zip
 ```
 
+Different platforms can be selected using the `PLATFORMS` arguments. Supported values of `PLATFORMS` are **bionic** for cflinuxfs3 and **jammy** for cflinuxfs4. The default value is **bionic**.
+
+```bash
+$ bundle exec rake clean package OFFLINE=true ADD_TO_CACHE=sap_machine_jre PLATFORMS=jammy,bionic
+...
+Caching https://java-buildpack.cloudfoundry.org/google-stackdriver-debugger/jammy/x86_64/index.yml
+Caching https://java-buildpack.cloudfoundry.org/google-stackdriver-debugger/bionic/x86_64/index.yml
+...
+Creating build/java-buildpack-offline-v*.**.zip
+```
+
 ### Package Versioning
 Keeping track of different versions of the buildpack can be difficult. To help with this, the rake `package` task puts a version discriminator in the name of the created package file. The default value for this discriminator is the current Git hash (e.g. `cfd6b17`). To change the version when creating a package, use the `VERSION=<VERSION>` argument:
 

--- a/rakelib/package.rb
+++ b/rakelib/package.rb
@@ -73,7 +73,14 @@ module Package
 
   BUILDPACK_VERSION = JavaBuildpack::BuildpackVersion.new(false).freeze
 
-  PLATFORMS = %w[bionic jammy].freeze
+  PLATFORMS = %w[]
+  platform_var = ENV.fetch('PLATFORMS', 'bionic')
+  if platform_var != 'bionic'
+    platform_var = platform_var.split(',')
+    (PLATFORMS << platform_var).flatten!.uniq!
+  else
+    PLATFORMS << platform_var
+  end
 
   STAGING_DIR = "#{BUILD_DIR}/staging".freeze
 


### PR DESCRIPTION
As discussed in https://github.com/cloudfoundry/java-buildpack/issues/986 there's a need to have PLATFORMS var to allow selecting between bionic and jammy for cflinuxfs3 and cflinuxfs4 stacks. 