### PR TITLE
Adds CI/Rubocop support for Ruby 3.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,3 +71,7 @@ Lint/RedundantCopDisableDirective:
   Enabled: false # disabled as this can be tough to manage across multiple ruby versions
 Style/RedundantFreeze:
   Enabled: false # enable when we only support ruby 3.0+
+Naming/BlockForwarding:
+  Enabled: false # enable when we only support Ruby 3.1+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: either

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -36,3 +36,6 @@ RUN eval "$(rbenv init -)" \
 
 RUN eval "$(rbenv init -)" \
  && rbenv install 3.0.4
+
+RUN eval "$(rbenv init -)" \
+ && rbenv install 3.1.3


### PR DESCRIPTION
I added a 3.1 version to the CI Dockerfile and updated the `.rubocop.yml` to mostly ignore the issue it found with the code. Both offenses were instances of new functionality in 3.1 which we shouldn't upgrade to in order to maintain backwards-compatible support.