### PR TITLE
Distinguish platforms in SapMachine repository root URL

### DIFF
--- a/config/sap_machine_jre.yml
+++ b/config/sap_machine_jre.yml
@@ -21,7 +21,7 @@ jre:
   version_lines:
     - 11.+
     - 17.+
-  repository_root: "https://sap.github.io/SapMachine/assets/cf/jre/linux/{architecture}"
+  repository_root: "https://sap.github.io/SapMachine/assets/cf/jre/{platform}/{architecture}"
 jvmkill_agent:
   version: 1.+
   repository_root: "{default.repository.root}/jvmkill/{platform}/{architecture}"


### PR DESCRIPTION
SapMachine has so only offered one URL for its versions, https://sap.github.io/SapMachine/assets/cf/jre/linux/x86_64/index.yml. We now also differentiate platform types, that is we have https://sap.github.io/SapMachine/assets/cf/jre/bionic/x86_64/index.yml and https://sap.github.io/SapMachine/assets/cf/jre/jammy/x86_64/index.yml from which the deployment should chose.