### PR TITLE
fix start command and options error

### DIFF
--- a/lib/java_buildpack/jre/zing_jre.rb
+++ b/lib/java_buildpack/jre/zing_jre.rb
@@ -26,7 +26,6 @@ module JavaBuildpack
     class ZingJRE < OpenJDKLike
       # (see JavaBuildpack::Component::ModularComponent#command)
       def command
-        ''
       end
 
       # (see JavaBuildpack::Component::ModularComponent#sub_components)
@@ -40,8 +39,8 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::BaseComponent#release)
       def release
+        @droplet.java_opts.add_preformatted_options '-XX:+ExitOnOutOfMemoryError'
         super
-        @droplet.add_preformatted_options '-XX:+ExitOnOutOfMemoryError'
       end
     end
   end


### PR DESCRIPTION
This fixes the generated start command for Zing JRE apps and the add_preformatted_options error mentioned here: https://github.com/cloudfoundry/java-buildpack/pull/1005