### PR TITLE
Update Ruby check for cflinuxfs4 stack

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -94,7 +94,7 @@ function main() {
   phase="$(basename "${0}")"
 
   if [[ "${CF_STACK:-}" == "cflinuxfs4" ]]; then
-    if [[ ! -e "${RUBY_DIR}" ]]; then
+    if ! which ruby > /dev/null; then
       mkdir -p "${RUBY_DIR}"
 
       util::install


### PR DESCRIPTION
Updates the check for when to install Ruby, the script now checks for an existing installed Ruby and proceeds if none is found.