### PR TITLE
Install bootstrapped Ruby into java-buildpack specific location

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -7,7 +7,7 @@ set -o pipefail
 BUILDPACK_DIR="$(cd "$(dirname "${0}")/.." && pwd)"
 readonly BUILDPACK_DIR
 
-RUBY_DIR="/tmp/ruby"
+RUBY_DIR="/tmp/java-buildpack/ruby"
 readonly RUBY_DIR
 
 function util::config::lookup() {


### PR DESCRIPTION
This Buildpack bootstraps Ruby into `/tmp/ruby`, and there are situations where multiple Buildpacks attempt to bootstrap Ruby into the same location.