### PR TITLE
Update Contrast Agent Version to 5.0

### DIFF
--- a/config/contrast_security_agent.yml
+++ b/config/contrast_security_agent.yml
@@ -15,5 +15,5 @@
 
 # Configuration for the ContrastSecurity framework
 ---
-version: 4.+
+version: 5.+
 repository_root: https://download.run.pivotal.io/contrast-security


### PR DESCRIPTION
Updates Contrast Java Agent to version 5.0.

Release notes can be found here: https://docs.contrastsecurity.com/en/java-agent-release-notes-and-archive.html#java-5-0-0

Recommendation is for all customers to update because there is Java 19 support as well as a myriad of bug fixes:

To name a few notable changes
> Language versions currently supported: Java 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
Kafka Support
Spring Boot 3 Support & Spring 6.
