### PR TITLE
Polishing for Azure App Insights testing & Rubocop

### DIFF
--- a/lib/java_buildpack/framework/azure_application_insights_agent.rb
+++ b/lib/java_buildpack/framework/azure_application_insights_agent.rb
@@ -33,7 +33,8 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::BaseComponent#release)
       def release
-        credentials = @application.services.find_service(FILTER, [CONNECTION_STRING, INSTRUMENTATION_KEY])['credentials']
+        credentials = @application.services.find_service(FILTER, [CONNECTION_STRING,
+                                                                  INSTRUMENTATION_KEY])['credentials']
 
         if credentials.key?(CONNECTION_STRING)
           @droplet.java_opts.add_system_property('applicationinsights.connection.string',

--- a/spec/java_buildpack/framework/azure_application_insights_agent_spec.rb
+++ b/spec/java_buildpack/framework/azure_application_insights_agent_spec.rb
@@ -34,8 +34,7 @@ describe JavaBuildpack::Framework::AzureApplicationInsightsAgent do
 
     before do
       allow(services).to receive(:one_service?).with(/azure-application-insights/,
-                                                     'connection_string',
-                                                     'instrumentation_key')
+                                                     %w[connection_string instrumentation_key])
                                                .and_return(true)
     end
 


### PR DESCRIPTION
Fixes unit test to support optional service credentials, and fixes Rubocop issue with long line