### PR TITLE
Install ruby when custom stacks are used

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -93,7 +93,7 @@ function main() {
   local phase
   phase="$(basename "${0}")"
 
-  if [[ "${CF_STACK:-}" == "cflinuxfs4" ]]; then
+  if [[ "${CF_STACK:-}" != "cflinuxfs3" ]]; then
     if ! which ruby > /dev/null; then
       mkdir -p "${RUBY_DIR}"
 

--- a/bin/run
+++ b/bin/run
@@ -93,15 +93,13 @@ function main() {
   local phase
   phase="$(basename "${0}")"
 
-  if [[ "${CF_STACK:-}" != "cflinuxfs3" ]]; then
-    if ! which ruby > /dev/null; then
-      mkdir -p "${RUBY_DIR}"
+  if ! which ruby > /dev/null; then
+    mkdir -p "${RUBY_DIR}"
 
-      util::install
-    fi
-
+    util::install
     util::environment::setup
   fi
+
 
   exec "${BUILDPACK_DIR}/bin/ruby-run" "${phase}" "${@-}"
 }


### PR DESCRIPTION
If a user specifies a custom stack -- for example, a Paketo stack based on Ubuntu Jammy -- this check will fail and ruby will not be installed, causing the app to fail to stage.

This change skips installing ruby _only_ when the specified stack is cflinuxfs3, which is known to include its own ruby.

I considered a few alternatives before landing on this one:
- Removing the check entirely. It would result in an unnecessary installation of ruby for cflinuxfs3, but I suspect it would work all the same.
- Checking for ruby using `which ruby`, as the code does in line 97. In this case, we may want to move the call to `util::environment::setup` into the `if` block:
  ```
  if ! which ruby > /dev/null; then
      mkdir -p "${RUBY_DIR}"

      util::install
      util::environment::setup
    fi
  ```

I'm open to these other solutions, but unsure of their repercussions. I went with the least drastic change.