### PR TITLE
Updates JProfiler to 13.x line

### DIFF
--- a/config/jprofiler_profiler.yml
+++ b/config/jprofiler_profiler.yml
@@ -15,7 +15,7 @@
 
 # JMX configuration
 ---
-version: 12.+
+version: 13.+
 repository_root: https://download.run.pivotal.io/jprofiler
 enabled: false
 nowait: true


### PR DESCRIPTION
JProfiler 12.x line is EOL, this sets the default version line to 13.x.

To continue to use 12.x, you can set `JBP_CONFIG_JPROFILER_PROFILER_VERSION` to `12.+`