### PR TITLE
Revert "Updates Stackdriver Debugger to 3.x line, before deprecation"

### DIFF
--- a/config/google_stackdriver_debugger.yml
+++ b/config/google_stackdriver_debugger.yml
@@ -15,7 +15,7 @@
 
 # Configuration for the Groovy container
 ---
-version: 3.+
+version: 2.+
 repository_root: "{default.repository.root}/google-stackdriver-debugger/{platform}/{architecture}"
 application_name: 
 application_version: 


### PR DESCRIPTION
Reverts cloudfoundry/java-buildpack#1021

This change pushes the buildpack over the size limit, and is only temporary since the Debugger agent will not be supported after Aug 23. We will keep the 2.x version and mark the Agent deprecated for removal in a coming release. 