### PR TITLE
Disables Google Stackdriver Debugger framework

### DIFF
--- a/config/components.yml
+++ b/config/components.yml
@@ -54,7 +54,7 @@ frameworks:
   - "JavaBuildpack::Framework::Debug"
   - "JavaBuildpack::Framework::DynatraceOneAgent"
   - "JavaBuildpack::Framework::ElasticApmAgent"
-  - "JavaBuildpack::Framework::GoogleStackdriverDebugger"
+#  - "JavaBuildpack::Framework::GoogleStackdriverDebugger"
   - "JavaBuildpack::Framework::GoogleStackdriverProfiler"
   - "JavaBuildpack::Framework::IntroscopeAgent"
   - "JavaBuildpack::Framework::JacocoAgent"

--- a/config/packaging.yml
+++ b/config/packaging.yml
@@ -67,10 +67,6 @@ elastic_apm_agent:
 geode_store:
   name: Geode Tomcat Session Store
 
-google_stackdriver_debugger:
-  name: Google Stackdriver Debugger
-  release_notes: '[Release Notes](https://cloud.google.com/debugger/docs/release-notes)'
-
 google_stackdriver_profiler:
   name: Google Stackdriver Profiler
   release_notes: '[Release Notes](https://cloud.google.com/profiler/docs/release-notes)'
@@ -92,18 +88,18 @@ jprofiler_profiler:
 
 jre:
   name: OpenJDK JRE 8
-  cve_notes: '[Risk Matrix](https://www.oracle.com/security-alerts/cpuapr2023.html#AppendixJAVA)'
-  release_notes: '[Release Notes](https://bell-sw.com/pages/liberica-release-notes-8u372/)'
+  cve_notes: '[Risk Matrix](https://www.oracle.com/security-alerts/cpujul2023.html#AppendixJAVA)'
+  release_notes: '[Release Notes](https://docs.bell-sw.com/liberica-jdk/8u382b6/general/release-notes/)'
 
 jre-11:
   name: OpenJDK JRE 11
-  cve_notes: '[Risk Matrix](https://www.oracle.com/security-alerts/cpuapr2023.html#AppendixJAVA)'
-  release_notes: '[Release Notes](https://bell-sw.com/pages/liberica-release-notes-11.0.19/)'
+  cve_notes: '[Risk Matrix](https://www.oracle.com/security-alerts/cpujul2023.html#AppendixJAVA)'
+  release_notes: '[Release Notes](https://docs.bell-sw.com/liberica-jdk/11.0.20b8/general/release-notes/)'
 
 jre-17:
   name: OpenJDK JRE 17
-  cve_notes: '[Risk Matrix](https://www.oracle.com/security-alerts/cpuapr2023.html#AppendixJAVA)'
-  release_notes: '[Release Notes](https://bell-sw.com/pages/liberica-release-notes-17.0.7/)'
+  cve_notes: '[Risk Matrix](https://www.oracle.com/security-alerts/cpujul2023.html#AppendixJAVA)'
+  release_notes: '[Release Notes](https://docs.bell-sw.com/liberica-jdk/17.0.8b7/general/release-notes/)'
 
 jrebel_agent:
   name: JRebel Agent
@@ -191,4 +187,4 @@ tomcat:
 
 your_kit_profiler:
   name: YourKit Profiler
-  release_notes: '[Release Notes](https://www.yourkit.com/download/yjp_2022_3_builds.jsp)'
+  release_notes: '[Release Notes](https://www.yourkit.com/download/yjp_2023_5_builds.jsp)'


### PR DESCRIPTION
As announced in the previous release, this disables the Google Stackdriver Debugger integration by default, since the Google service is offline and its OSS replacement is temporary and will no longer be supported after the end of Aug 23.

PR also contains updates to release note pages.