### PR TITLE
Update geode-store for compatibility with Gemfire 9.15.6

### DIFF
--- a/config/tomcat.yml
+++ b/config/tomcat.yml
@@ -42,5 +42,5 @@ redis_store:
 geode_store:
   # The version of Geode Store must be less than or equal to your Tanzu Gemfire for VMs version to ensure compatibility.
   # The Geode Store version is pinned to 1.12.4 to be compatible with the most commonly used versions of Tanzu Gemfire for VMs.
-  version: 1.13.7
+  version: 1.14.9
   repository_root: https://java-buildpack-tomcat-gemfire-store.s3-us-west-2.amazonaws.com


### PR DESCRIPTION
Updating geode store default value to 1.14.9 to be more compatible with GemFire 9.15.6.