### PR TITLE
Fix #1027: properly detect new mysql connector

### DIFF
--- a/docs/framework-maria_db_jdbc.md
+++ b/docs/framework-maria_db_jdbc.md
@@ -4,18 +4,18 @@ The MariaDB JDBC Framework causes a JDBC driver JAR to be automatically download
 <table>
   <tr>
     <td><strong>Detection Criterion</strong></td>
-    <td>Existence of a single bound MariaDB or MySQL service and no provided MariaDB or MySQL JDBC JAR.
+    <td>Existence of a single bound MariaDB or MySQL service and NO provided MariaDB or MySQL JDBC jar.
       <ul>
-        <li>Existence of a MariaDB service is defined as the <a href="http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES"><code>VCAP_SERVICES</code></a> payload containing a service who's name, label or tag has <code>mariadb</code> as a substring.</li>
-        <li>Existence of a MySQL service is defined as the <a href="http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES"><code>VCAP_SERVICES</code></a> payload containing a service who's name, label or tag has <code>mysql</code> as a substring.</li>
-        <li>Existence of a MariaDB JDBC JAR is defined as the application containing a JAR who's name matches <tt>mariadb-java-client*.jar</tt></li>
-        <li>Existence of a MySQL JDBC JAR is defined as the application containing a JAR who's name matches <tt>mysql-connector-java*.jar</tt></li>
+        <li>Existence of a MariaDB service is defined as the <a href="http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES"><code>VCAP_SERVICES</code></a> payload containing a service whose name, label or tag has <code>mariadb</code> as a substring.</li>
+        <li>Existence of a MySQL service is defined as the <a href="http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES"><code>VCAP_SERVICES</code></a> payload containing a service whose name, label or tag has <code>mysql</code> as a substring.</li>
+        <li>Existence of a MariaDB JDBC jar is defined as the application containing a JAR whose name matches <code>mariadb-java-client*.jar</code></li>
+        <li>Existence of a MySQL JDBC jar is defined as the application containing a JAR whose name matches <code>mysql-connector-j*.jar</code></li>
       </ul>
     </td>
   </tr>
   <tr>
     <td><strong>Tags</strong></td>
-    <td><tt>maria-db-jdbc=&lt;version&gt;</tt></td>
+    <td><code>maria-db-jdbc=&lt;version&gt;</code></td>
   </tr>
 </table>
 Tags are printed to standard output by the buildpack detect script

--- a/lib/java_buildpack/framework/maria_db_jdbc.rb
+++ b/lib/java_buildpack/framework/maria_db_jdbc.rb
@@ -46,7 +46,7 @@ module JavaBuildpack
       private
 
       def driver?
-        %w[mariadb-java-client*.jar mysql-connector-java*.jar].any? do |candidate|
+        %w[mariadb-java-client*.jar mysql-connector-j*.jar].any? do |candidate|
           (@application.root + '**' + candidate).glob.any?
         end
       end

--- a/spec/java_buildpack/framework/maria_db_jdbc_spec.rb
+++ b/spec/java_buildpack/framework/maria_db_jdbc_spec.rb
@@ -49,6 +49,12 @@ describe JavaBuildpack::Framework::MariaDbJDBC do
       expect(component.detect).to be_nil
     end
 
+    it 'does not detect if the application has a new style -j MySQL driver',
+       app_fixture: 'framework_mariadb_jdbc_with_new_mysql_driver' do
+
+      expect(component.detect).to be_nil
+    end
+
     it 'downloads the MariaDB driver when needed',
        cache_fixture: 'stub-mariadb-java-client.jar' do
 


### PR DESCRIPTION
* Mysql connector was renamed recently from mysql-connector-java to mysql-connector-j, and needs to be detected by the buildpack
* Rephrase documentation to make it more obvious that if a maria db client or mysql connector exist, the buildpack should not add its own mariadb connector