### PR TITLE
Improved geode_store validation regex to identify gemfire or geode jars

### DIFF
--- a/lib/java_buildpack/container/tomcat/tomcat_geode_store.rb
+++ b/lib/java_buildpack/container/tomcat/tomcat_geode_store.rb
@@ -137,7 +137,7 @@ module JavaBuildpack
       def detect_geode_tomcat_version
         geode_tomcat_version = nil
 
-        geode_modules_tomcat_pattern = /geode-modules-tomcat(?<version>[0-9]*).*.jar/.freeze
+        geode_modules_tomcat_pattern = /ge.*-modules-tomcat(?<version>[0-9]*).*.jar/.freeze
         Dir.foreach(@droplet.sandbox + 'lib') do |file|
           if geode_modules_tomcat_pattern.match(file)
             unless geode_tomcat_version.nil?


### PR DESCRIPTION
Following updates to the geode_store tar files, gemfire artifacts are used instead of geode artifacts. This can create an issue where building a custom buildpack fails due to an internal check that looks for the geode-modules jar. This PR updates the regex for this check to work for either geode or gemfire modules jars.