### PR TITLE
Update Contrast Agent to 6.0

### DIFF
--- a/config/contrast_security_agent.yml
+++ b/config/contrast_security_agent.yml
@@ -15,5 +15,5 @@
 
 # Configuration for the ContrastSecurity framework
 ---
-version: 5.+
+version: 6.+
 repository_root: https://download.run.pivotal.io/contrast-security


### PR DESCRIPTION
Updates Contrast Java Agent to version 6.0.

Release notes can be found here: https://docs.contrastsecurity.com/en/java-agent-release-notes-and-archive.html#java-6-0-0

Recommendation is for all customers to update because there is Java 21 LTS support as well as many bug fixes