### PR TITLE
Improvement to condition to trigger java-cfenv framework

### DIFF
--- a/docs/framework-java-cfenv.md
+++ b/docs/framework-java-cfenv.md
@@ -8,7 +8,7 @@ It also sets the 'cloud' profile for Spring Boot applications, as the Spring Aut
 <table>
   <tr>
     <td><strong>Detection Criterion</strong></td>
-    <td>Existence of a <tt>spring-boot-3*.jar</tt> file in the application directory or a `Spring-Boot-Version: 3.*` manifest entry</td>
+    <td>Existence of a `Spring-Boot-Version: 3.*` manifest entry</td>
     <td>No existing `java-cfenv` library found</td>
   </tr>
   <tr>

--- a/lib/java_buildpack/framework/java_cf_env.rb
+++ b/lib/java_buildpack/framework/java_cf_env.rb
@@ -53,8 +53,8 @@ module JavaBuildpack
       private
 
       def spring_boot_3?
-        @spring_boot_utils.is?(@application) && Gem::Version.new((@spring_boot_utils.version @application)).release >=
-          Gem::Version.new('3.0.0')
+        @spring_boot_utils.is?(@application) &&
+        Gem::Version.new((@spring_boot_utils.version_strict @application)).release >= Gem::Version.new('3.0.0')
       end
 
       def java_cfenv?

--- a/lib/java_buildpack/util/spring_boot_utils.rb
+++ b/lib/java_buildpack/util/spring_boot_utils.rb
@@ -87,6 +87,14 @@ module JavaBuildpack
           @jar_finder.version(application)
       end
 
+      # The version of Spring Boot used by the application - only considers the MANIFEST entry
+      #
+      # @param [Application] application the application to search
+      # @return [String] the version of Spring Boot used by the application
+      def version_strict(application)
+        JavaBuildpack::Util::JavaMainUtils.manifest(application)[SPRING_BOOT_VERSION]
+      end
+
       private
 
       SPRING_BOOT_LIB = 'Spring-Boot-Lib'

--- a/spec/fixtures/framework_java_not_spring_boot3/META-INF/MANIFEST.MF
+++ b/spec/fixtures/framework_java_not_spring_boot3/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Main-Class: org.springframework.boot.loader.JarLauncher
+

--- a/spec/java_buildpack/framework/java_cfenv_spec.rb
+++ b/spec/java_buildpack/framework/java_cfenv_spec.rb
@@ -39,6 +39,12 @@ describe JavaBuildpack::Framework::JavaCfEnv do
     expect(component.detect).to be_nil
   end
 
+  it 'does not detect with Spring Boot 3 named jar but not Spring Boot 3 Manifest',
+     app_fixture: 'framework_java_not_spring_boot3' do
+
+    expect(component.detect).to be_nil
+  end
+
   it 'does not detect with Spring Boot 3 & java-cfenv present',
      app_fixture: 'framework_java_cf_exists' do
 


### PR DESCRIPTION
This PR changes the condition that checks when to contribute the Java CFEnv framework for Boot 3 apps. Previously, the condition checks for Spring Boot 3 using either the Manifest entry `Spring-Boot-Version` or presence of `spring-boot-<version>.jar` files.

This change ensures only the presence of the Manifest entry with a version > 3 is used to determine whether the app is a Spring Boot 3 app.