### PR TITLE
harmonization of gorouter -> java app communication

### DIFF
--- a/resources/tomcat/conf/server.xml
+++ b/resources/tomcat/conf/server.xml
@@ -19,7 +19,7 @@
 <Server port='-1'>
 
     <Service name='Catalina'>
-        <Connector port='${http.port}' bindOnInit='false' connectionTimeout='20000'>
+        <Connector port='${http.port}' bindOnInit='false' connectionTimeout='20000' keepAliveTimeout='120000'>
             <UpgradeProtocol className='org.apache.coyote.http2.Http2Protocol' />
         </Connector>
 

--- a/spec/fixtures/container_tomcat_geode_store/.java-buildpack/tomcat/conf/server.xml
+++ b/spec/fixtures/container_tomcat_geode_store/.java-buildpack/tomcat/conf/server.xml
@@ -18,7 +18,7 @@
 <Server port='-1'>
 
     <Service name='Catalina'>
-        <Connector port='${http.port}' bindOnInit='false' connectionTimeout='20000'/>
+        <Connector port='${http.port}' bindOnInit='false' connectionTimeout='20000' keepAliveTimeout='120000'/>
 
         <Engine defaultHost='localhost' name='Catalina'>
             <Valve className='org.apache.catalina.valves.RemoteIpValve' protocolHeader='x-forwarded-proto'/>

--- a/spec/fixtures/container_tomcat_geode_store_server_after.xml
+++ b/spec/fixtures/container_tomcat_geode_store_server_after.xml
@@ -17,7 +17,7 @@
   -->
 <Server port='-1'>
     <Service name='Catalina'>
-        <Connector port='${http.port}' bindOnInit='false' connectionTimeout='20000'/>
+        <Connector port='${http.port}' bindOnInit='false' connectionTimeout='20000' keepAliveTimeout='120000'/>
         <Engine defaultHost='localhost' name='Catalina'>
             <Valve className='org.apache.catalina.valves.RemoteIpValve' protocolHeader='x-forwarded-proto'/>
             <Valve className='com.gopivotal.cloudfoundry.tomcat.logging.access.CloudFoundryAccessLoggingValve' pattern='[ACCESS] %{org.apache.catalina.AccessLog.RemoteAddr}r %l %t %D %F %B %S vcap_request_id:%{X-Vcap-Request-Id}i' enabled='${access.logging.enabled}'/>


### PR DESCRIPTION
fix for #881

it is a known issue that gorouter -> java applications do not work properly together, once keepalive is used: https://knowledge.broadcom.com/external/article/298104/intermittent-502-eof-gorouter-errors-for.html

The fix is described in the link, but not implemented so far for the java buildpack
