### PR TITLE
Update tomcat session store version to 2.0.3

### DIFF
--- a/config/tomcat.yml
+++ b/config/tomcat.yml
@@ -45,5 +45,5 @@ redis_store:
 geode_store:
   # The version of Geode Store must be less than or equal to your Tanzu Gemfire for VMs version to ensure compatibility.
   # The Geode Store version is pinned to 1.12.4 to be compatible with the most commonly used versions of Tanzu Gemfire for VMs.
-  version: 1.14.9
+  version: 2.0.3
   repository_root: https://java-buildpack-tomcat-gemfire-store.s3-us-west-2.amazonaws.com


### PR DESCRIPTION
Gemfire for TAS 1.14.9 is EOS now.
Updating the tomcat session store version to 2.0.3 . It will be the default session store version in TAS foundation going forward.