### PR TITLE
Add multi-tech support to Dynatrace OneAgent integration

### DIFF
--- a/docs/framework-dynatrace_one_agent.md
+++ b/docs/framework-dynatrace_one_agent.md
@@ -31,6 +31,7 @@ The credential payload of the service may contain the following entries:
 | `networkzone` | (Optional) Network zones are Dynatrace entities that represent your network structure. They help you to route the traffic efficiently, avoiding unnecessary traffic across data centers and network regions. Enter the network zone you wish to pass to the server during the OneAgent Download.
 | `skiperrors` | (Optional) The errors during agent download are skipped and the injection is disabled. Use this option at your own risk. Possible values are 'true' and 'false'. This option is disabled by default!
 | `enablefips`| (Optional) Enables the use of [FIPS 140 cryptographic algorithms](https://docs.dynatrace.com/docs/shortlink/oneagentctl#fips-140). Possible values are 'true' and 'false'. This option is disabled by default!
+| addtechnologies | (Optional)  Adds additional OneAgent code-modules via a comma-separated list. See [supported values](https://docs.dynatrace.com/docs/dynatrace-api/environment-api/deployment/oneagent/download-oneagent-version#parameters) in the "included" row|
 
 ## Configuration
 For general information on configuring the buildpack, including how to specify configuration values through environment variables, refer to [Configuration and Extension][].

--- a/lib/java_buildpack/component/base_component.rb
+++ b/lib/java_buildpack/component/base_component.rb
@@ -89,7 +89,6 @@ module JavaBuildpack
       # @return [Void]
       def download(version, uri, name = @component_name)
         download_start_time = Time.now
-        print "FIXMEDEBUG #{'----->'.red.bold} Downloading #{name.blue.bold} #{version.to_s.blue} from #{uri} "
         print "#{'----->'.red.bold} Downloading #{name.blue.bold} #{version.to_s.blue} from #{uri.sanitize_uri} "
 
         JavaBuildpack::Util::Cache::CacheFactory.create.get(uri) do |file, downloaded|

--- a/lib/java_buildpack/component/base_component.rb
+++ b/lib/java_buildpack/component/base_component.rb
@@ -89,6 +89,7 @@ module JavaBuildpack
       # @return [Void]
       def download(version, uri, name = @component_name)
         download_start_time = Time.now
+        print "FIXMEDEBUG #{'----->'.red.bold} Downloading #{name.blue.bold} #{version.to_s.blue} from #{uri} "
         print "#{'----->'.red.bold} Downloading #{name.blue.bold} #{version.to_s.blue} from #{uri.sanitize_uri} "
 
         JavaBuildpack::Util::Cache::CacheFactory.create.get(uri) do |file, downloaded|

--- a/lib/java_buildpack/framework/dynatrace_one_agent.rb
+++ b/lib/java_buildpack/framework/dynatrace_one_agent.rb
@@ -116,7 +116,7 @@ module JavaBuildpack
       SKIP_ERRORS = 'skiperrors'
 
       private_constant :ADDTECHNOLOGIES, :APIURL, :APITOKEN, :ENABLE_FIPS, :DT_APPLICATION_ID, :DT_CONNECTION_POINT,
-                       :DT_NETWORK_ZONE, :DT_LOGSTREAM, :DT_TENANT, :DT_TENANTTOKEN, :LD_PRELOAD, :ENVIRONMENTID, 
+                       :DT_NETWORK_ZONE, :DT_LOGSTREAM, :DT_TENANT, :DT_TENANTTOKEN, :LD_PRELOAD, :ENVIRONMENTID,
                        :FILTER, :NETWORKZONE, :SKIP_ERRORS
 
       def agent_download_url
@@ -137,8 +137,6 @@ module JavaBuildpack
           end
         end
         return code_modules
-      end
-
       end
 
       def agent_manifest

--- a/lib/java_buildpack/util/sanitizer.rb
+++ b/lib/java_buildpack/util/sanitizer.rb
@@ -36,11 +36,13 @@ class String
 
     query_params = ''
 
-    params.each do |key, _|
-      params[key] = '***' if key.match(keywords)
-      query_params += key + '=' + params[key] + '&'
+    params.split("&").each do |single_param|
+      k, v = single_param.split("=")
+      if k.match(keywords)
+        v = "***"
+      end
+      query_params += k + '=' +v + '&'
     end
-
     query_params
   end
 
@@ -53,8 +55,7 @@ class String
     rich_uri.password = nil
 
     if rich_uri.query
-      params = (URI.decode_www_form rich_uri.query).to_h
-      query_params = handle_params(params)
+      query_params = handle_params(rich_uri.query)
       rich_uri.query = query_params.chop
     end
 


### PR DESCRIPTION
This adds handling for a new, optional, property named `addtechnologies` a user can configure in a CF service which enables them to add additional OneAgent code-modules to a given java-buildpack deployment.
This is required in multi-buildpack and sidecar scenarious to also monitor other technologies besides java.

Also had to refactor the URL sanitization a bit, because it was eating up multiple `include` parameters which resulted in displaying a faulty log output.