### PR TITLE
Update link to SapMachine repository

### DIFF
--- a/config/sap_machine_jre.yml
+++ b/config/sap_machine_jre.yml
@@ -21,7 +21,7 @@ jre:
   version_lines:
     - 11.+
     - 17.+
-  repository_root: "https://sap.github.io/SapMachine/assets/cf/jre/{platform}/{architecture}"
+  repository_root: "https://sapmachine.io/assets/cf/jre/{platform}/{architecture}"
 jvmkill_agent:
   version: 1.+
   repository_root: "{default.repository.root}/jvmkill/{platform}/{architecture}"


### PR DESCRIPTION
We have moved our web presence to https://sapmachine.io/ so the link needs to be updated. The old URL will still be supported for a while, though.