### PR TITLE
Bump JProfiler to 15.x branch

### DIFF
--- a/config/jprofiler_profiler.yml
+++ b/config/jprofiler_profiler.yml
@@ -15,7 +15,7 @@
 
 # JMX configuration
 ---
-version: 13.+
+version: 15.+
 repository_root: https://download.run.pivotal.io/jprofiler
 enabled: false
 nowait: true


### PR DESCRIPTION
The current version 13.x contains outdated dependencies with critical security vulnerabilities.