### PR TITLE
Bump JProfiler version with regard to security vulnerabilities

### DIFF
--- a/config/jprofiler_profiler.yml
+++ b/config/jprofiler_profiler.yml
@@ -15,7 +15,7 @@
 
 # JMX configuration
 ---
-version: 13.+
+version: 15.+
 repository_root: https://download.run.pivotal.io/jprofiler
 enabled: false
 nowait: true


### PR DESCRIPTION
The current JProfiler version 13 is outdated and contains critical security vulnerabilities when subject of security scanning. Addressing this with this PR