### PR TITLE
added open jdk jre 25

### DIFF
--- a/config/open_jdk_jre.yml
+++ b/config/open_jdk_jre.yml
@@ -22,6 +22,7 @@ jre:
   - 11.+
   - 17.+
   - 21.+
+  - 25.+
   repository_root: "{default.repository.root}/openjdk/{platform}/{architecture}"
 jvmkill_agent:
   version: 1.+

--- a/config/packaging.yml
+++ b/config/packaging.yml
@@ -110,6 +110,11 @@ jre-21:
   cve_notes: '[Risk Matrix](https://www.oracle.com/security-alerts/cpuapr2025.html#AppendixJAVA)'
   release_notes: '[Release Notes](https://docs.bell-sw.com/liberica-jdk/21.0.7b9/general/release-notes/)'
 
+jre-25:
+  name: OpenJDK JRE 25
+  cve_notes: '[Risk Matrix](https://www.oracle.com/security-alerts/cpuapr2025.html#AppendixJAVA)'
+  release_notes: '[Release Notes](https://docs.bell-sw.com/liberica-jdk/25b37/general/release-notes/)'
+
 jrebel_agent:
   name: JRebel Agent
   release_notes: '[ChangeLog](https://www.jrebel.com/products/jrebel/changelog)'


### PR DESCRIPTION
Added a reference to Java JRE 25 (based on changes in Java 21 Support issue #1035).

Intended to solve #1121

However, creating a buildpack locally results in:

```
➜  java-buildpack git:(issue-1121-java-25-support) ✗ bundle exec rake clean package OFFLINE=true PINNED=true
Pinning groovy version to 2.5.23
Pinning spring_boot_cli version to 2.7.18
Pinning Tomcat tomcat-10 version to 10.1.46
Pinning Tomcat tomcat version to 9.0.109
Pinning lifecycle_support version to 3.4.0_RELEASE
Pinning logging_support version to 3.4.0_RELEASE
Pinning access_logging_support version to 3.4.0_RELEASE
Pinning redis_store version to 1.3.6_RELEASE
Pinning geode_store version to 1.14.9
Pinning JRE jre-11 version to 11.0.27_9
Pinning JRE jre-11 version to 11.0.27_9
Pinning JRE jre-17 version to 17.0.15_10
Pinning JRE jre-17 version to 17.0.15_10
Pinning JRE jre-21 version to 21.0.7_9
Pinning JRE jre-21 version to 21.0.7_9
Pinning JRE jre-25 version to
[VersionResolver]                WARN  Discarding illegal version : Invalid version '': missing component
[VersionResolver]                WARN  Discarding illegal version : Invalid version '': missing component
[VersionResolver]                WARN  Discarding illegal version : Invalid version '': missing component
[VersionResolver]                WARN  Discarding illegal version : Invalid version '': missing component
[VersionResolver]                WARN  Discarding illegal version : Invalid version '': missing component
rake aborted!
Unable to resolve version '25.+' for platform 'bionic'
```
Seems there is no Java 25 in https://download.run.pivotal.io/openjdk/jammy/x86_64/index.yml or https://download.run.pivotal.io/openjdk/bionic/x86_64/index.yml. 

Is there a dependency on the availability on java 25 packages in those locations?