### PR TITLE
Fix Ruby version compatibility by always using buildpack Ruby

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -93,13 +93,15 @@ function main() {
   local phase
   phase="$(basename "${0}")"
 
-  if ! which ruby > /dev/null; then
-    mkdir -p "${RUBY_DIR}"
+  # Always install and use buildpack Ruby to ensure consistent version
+  # regardless of system Ruby availability
+  mkdir -p "${RUBY_DIR}"
 
+  if [ ! -d "${RUBY_DIR}/bin" ]; then
     util::install
-    util::environment::setup
   fi
 
+  util::environment::setup
 
   exec "${BUILDPACK_DIR}/bin/ruby-run" "${phase}" "${@-}"
 }

--- a/config/ruby.yml
+++ b/config/ruby.yml
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 # Configuration for Ruby
+# Note: Ruby 3.2.8+ is required for Psych 5.0.1+ which supports YAML.load_file
+# with permitted_classes and aliases keyword arguments used throughout the buildpack
 ---
 version: 3.2.+
 repository_root: https://raw.githubusercontent.com/cloudfoundry/ruby-buildpack/master/java-index


### PR DESCRIPTION
## Summary
- Fixes staging failure "unknown keywords: :permitted_classes, :aliases" reported in #1128 after Ruby 3.4.7 migration (#1127)
- Ensures buildpack always uses its own Ruby 3.2.8 (with Psych 5.0.1+) instead of falling back to cflinuxfs4's older system Ruby

## Details
After merging PR #1127, users reported staging failures in Cloud Foundry with the error:
```
ERR unknown keywords: :permitted_classes, :aliases
ERR Failed to compile droplet: Failed to run finalize script: exit status 1
```

**Root Cause:** The buildpack's `bin/run` script checked if system Ruby exists before installing its own Ruby. When Cloud Foundry's cflinuxfs4 stack provided an older system Ruby (with Psych < 5.0), the buildpack used it instead of downloading Ruby 3.2.8. The older Psych version doesn't support the `permitted_classes:` and `aliases:` keyword arguments added in the migration.

**Fix:** Modified `bin/run` to always install and use the buildpack's own Ruby 3.2.8, removing the conditional check for system Ruby. This ensures consistent behavior across all environments.

## Changes
- **bin/run**: Always install buildpack Ruby instead of checking for system Ruby
- **config/ruby.yml**: Added documentation comment about Ruby 3.2.8+/Psych 5.0.1+ requirement