### PR TITLE
Update/add sapmachine versions

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -605,4 +605,4 @@ dependencies:
 # ========================================
 # NOTE: Checkmarx agent is downloaded via API using authentication from service binding
 # The framework will download directly from the Checkmarx API at runtime
-# No manifest entry needed - download is fully dynamic 
+# No manifest entry needed - download is fully dynamic


### PR DESCRIPTION
- Added SapMachine 25 to the go migrated community buildpack
- Added SapMachine 21 to the go migrated community buildpack
- Removed SapMachine 11 which is EOL since some time
- Make 21 the default version for SapMachine as 17 is EOL September this year