### PR TITLE
Increase default timeout for integration tests

### DIFF
--- a/src/integration/init_test.go
+++ b/src/integration/init_test.go
@@ -43,7 +43,7 @@ func TestIntegration(t *testing.T) {
 	var Expect = NewWithT(t).Expect
 
 	format.MaxLength = 0
-	SetDefaultEventuallyTimeout(20 * time.Second)
+	SetDefaultEventuallyTimeout(40 * time.Second)
 
 	root, err := filepath.Abs("./../../")
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Increase default timeout for the integration tests

The timeout was hit when running the integration tests on my local machine, resulting in: 

```
=== NAME  TestIntegration/integration/Frameworks/Spring_Configuration/with_Spring_Auto-reconfiguration/skips_Spring_Auto-reconfiguration_when_disabled
    frameworks_test.go:661:
        Timed out after 30.001s.
        The matcher passed to Eventually returned the following error:
            <*url.Error | 0x14000408d50>:
            Get "http://localhost:55016": dial tcp [::1]:55016: connect: connection refused
            {
                Op: "Get",
                URL: "http://localhost:55016",
                Err: <*net.OpError | 0x1400041c000>{
                    Op: "dial",
                    Net: "tcp",
                    Source: nil,
                    Addr: <*net.TCPAddr | 0x14000496600>{
                        IP: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
                        Port: 55016,
                        Zone: "",
                    },
                    Err: <*os.SyscallError | 0x1400037a860>{
                        Syscall: "connect",
                        Err: <syscall.Errno>0x3d,
                    },
                },
            }
    frameworks_test.go:30: ❌ FAILED TEST - App/Container: switchblade-wnqsh4sdr
    frameworks_test.go:31:    Platform: docker 
```

and in

```
=== NAME  TestIntegration/integration/Groovy/with_a_simple_Groovy_application/successfully_deploys_a_non-POGO_Groovy_script
    groovy_test.go:48:
        Timed out after 20.001s.
        The matcher passed to Eventually returned the following error:
            <*url.Error | 0x14000419830>:
            Get "http://localhost:55061": EOF
            {
                Op: "Get",
                URL: "http://localhost:55061",
                Err: <*errors.errorString | 0x103807950>{s: "EOF"},
            }
    groovy_test.go:30: ❌ FAILED TEST - App/Container: switchblade-qbfod4sdg
    groovy_test.go:31:    Platform: docker

```