### PR TITLE
Fix issues in open_telemetry_javaagent and splunk_java_agent frameworks

### DIFF
--- a/src/java/common/context.go
+++ b/src/java/common/context.go
@@ -152,9 +152,11 @@ func GetVCAPServices() (VCAPServices, error) {
 }
 
 // HasService checks if a service with the given label exists
+// Matching is case-insensitive to handle various service broker conventions
 func (v VCAPServices) HasService(label string) bool {
+	labelLower := strings.ToLower(label)
 	for key := range v {
-		if strings.ToLower(key) == label {
+		if strings.ToLower(key) == labelLower {
 			return true
 		}
 	}

--- a/src/java/common/context.go
+++ b/src/java/common/context.go
@@ -152,11 +152,9 @@ func GetVCAPServices() (VCAPServices, error) {
 }
 
 // HasService checks if a service with the given label exists
-// Matching is case-insensitive to handle various service broker conventions
 func (v VCAPServices) HasService(label string) bool {
-	labelLower := strings.ToLower(label)
 	for key := range v {
-		if strings.ToLower(key) == labelLower {
+		if strings.ToLower(key) == label {
 			return true
 		}
 	}

--- a/src/java/frameworks/elastic_apm_agent.go
+++ b/src/java/frameworks/elastic_apm_agent.go
@@ -144,11 +144,13 @@ func (e *ElasticApmAgentFramework) findElasticApmService() *VCAPService {
 		return nil
 	}
 
-	if vcapServices.HasService("elastic-apm") {
-		return vcapServices.GetService("elastic-apm")
+	service := vcapServices.GetService("elastic-apm")
+	if service != nil {
+		return service
 	}
-	if vcapServices.HasService("elastic") {
-		return vcapServices.GetService("elastic")
+	service = vcapServices.GetService("elastic")
+	if service != nil {
+		return service
 	}
 
 	for _, services := range vcapServices {

--- a/src/java/frameworks/open_telemetry_javaagent.go
+++ b/src/java/frameworks/open_telemetry_javaagent.go
@@ -111,8 +111,9 @@ func (o *OpenTelemetryJavaagentFramework) Finalize() error {
 		// Set otel.service.name to the application name if not specified in credentials
 		if _, hasServiceName := service.Credentials["otel.service.name"]; !hasServiceName {
 			// Use the build directory name as the application name
-			appName := filepath.Base(o.context.Stager.BuildDir())
-			javaOpts += fmt.Sprintf(" -Dotel.service.name=%s", appName)
+			if appName := GetApplicationName(false); appName != "" {
+				javaOpts += fmt.Sprintf(" -Dotel.service.name=%s", appName)
+			}
 		}
 	}
 

--- a/src/java/frameworks/open_telemetry_javaagent.go
+++ b/src/java/frameworks/open_telemetry_javaagent.go
@@ -85,11 +85,8 @@ func (o *OpenTelemetryJavaagentFramework) Finalize() error {
 	vcapServices, _ := GetVCAPServices()
 
 	// Try to find service by various patterns
-	var service *VCAPService
-	if vcapServices.HasService("otel-collector") {
-		service = vcapServices.GetService("otel-collector")
-	}
-	if service == nil && vcapServices.HasService("opentelemetry") {
+	service := vcapServices.GetService("otel-collector")
+	if service == nil {
 		service = vcapServices.GetService("opentelemetry")
 	}
 	if service == nil {

--- a/src/java/frameworks/open_telemetry_javaagent_test.go
+++ b/src/java/frameworks/open_telemetry_javaagent_test.go
@@ -2,23 +2,321 @@ package frameworks_test
 
 import (
 	"os"
+	"path/filepath"
 
+	"github.com/cloudfoundry/java-buildpack/src/java/common"
+	"github.com/cloudfoundry/java-buildpack/src/java/frameworks"
+	"github.com/cloudfoundry/libbuildpack"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("OpenTelemetryJavaagent", func() {
-	AfterEach(func() {
-		os.Unsetenv("OTEL_SERVICE_NAME")
-		os.Unsetenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+var _ = Describe("OpenTelemetryJavaagentFramework", func() {
+	var (
+		ctx       *common.Context
+		framework *frameworks.OpenTelemetryJavaagentFramework
+		tmpDir    string
+		depsDir   string
+	)
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "otel-javaagent-test-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		depsDir = filepath.Join(tmpDir, "deps")
+		err = os.MkdirAll(filepath.Join(depsDir, "0"), 0755)
+		Expect(err).NotTo(HaveOccurred())
+
+		logger := libbuildpack.NewLogger(os.Stdout)
+		manifest := &libbuildpack.Manifest{}
+		stager := libbuildpack.NewStager([]string{tmpDir, "", depsDir, "0"}, logger, manifest)
+
+		ctx = &common.Context{
+			Stager:   stager,
+			Manifest: manifest,
+			Log:      logger,
+		}
+
+		framework = frameworks.NewOpenTelemetryJavaagentFramework(ctx)
 	})
 
-	DescribeTable("configuration environment variables",
-		func(envVar, expectedValue string) {
-			os.Setenv(envVar, expectedValue)
-			Expect(os.Getenv(envVar)).To(Equal(expectedValue))
-		},
-		Entry("OTEL_SERVICE_NAME", "OTEL_SERVICE_NAME", "my-service"),
-		Entry("OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_ENDPOINT", "https://otel-collector.example.com"),
-	)
+	AfterEach(func() {
+		os.RemoveAll(tmpDir)
+		os.Unsetenv("VCAP_SERVICES")
+	})
+
+	Describe("Detect", func() {
+		Context("without any service binding", func() {
+			It("does not detect", func() {
+				name, err := framework.Detect()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(name).To(BeEmpty())
+			})
+		})
+
+		Context("with otel-collector service label", func() {
+			It("detects successfully", func() {
+				os.Setenv("VCAP_SERVICES", `{
+					"otel-collector": [{
+						"name": "my-otel",
+						"label": "otel-collector",
+						"tags": [],
+						"credentials": {"endpoint": "http://collector:4318"}
+					}]
+				}`)
+				name, err := framework.Detect()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(name).To(Equal("OpenTelemetry Javaagent"))
+			})
+		})
+
+		Context("with opentelemetry service label", func() {
+			It("detects successfully", func() {
+				os.Setenv("VCAP_SERVICES", `{
+					"opentelemetry": [{
+						"name": "my-otel",
+						"label": "opentelemetry",
+						"tags": [],
+						"credentials": {}
+					}]
+				}`)
+				name, err := framework.Detect()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(name).To(Equal("OpenTelemetry Javaagent"))
+			})
+		})
+
+		Context("with otel tag", func() {
+			It("detects via tag", func() {
+				os.Setenv("VCAP_SERVICES", `{
+					"user-provided": [{
+						"name": "my-collector",
+						"label": "user-provided",
+						"tags": ["otel"],
+						"credentials": {}
+					}]
+				}`)
+				name, err := framework.Detect()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(name).To(Equal("OpenTelemetry Javaagent"))
+			})
+		})
+
+		Context("with opentelemetry tag", func() {
+			It("detects via tag", func() {
+				os.Setenv("VCAP_SERVICES", `{
+					"user-provided": [{
+						"name": "my-collector",
+						"label": "user-provided",
+						"tags": ["opentelemetry"],
+						"credentials": {}
+					}]
+				}`)
+				name, err := framework.Detect()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(name).To(Equal("OpenTelemetry Javaagent"))
+			})
+		})
+
+		Context("with otel-collector tag", func() {
+			It("detects via tag", func() {
+				os.Setenv("VCAP_SERVICES", `{
+					"user-provided": [{
+						"name": "my-collector",
+						"label": "user-provided",
+						"tags": ["otel-collector"],
+						"credentials": {}
+					}]
+				}`)
+				name, err := framework.Detect()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(name).To(Equal("OpenTelemetry Javaagent"))
+			})
+		})
+
+		Context("with user-provided service matching otel-collector name pattern", func() {
+			It("detects via name pattern", func() {
+				os.Setenv("VCAP_SERVICES", `{
+					"user-provided": [{
+						"name": "my-otel-collector",
+						"label": "user-provided",
+						"tags": [],
+						"credentials": {}
+					}]
+				}`)
+				name, err := framework.Detect()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(name).To(Equal("OpenTelemetry Javaagent"))
+			})
+		})
+
+		Context("with user-provided service matching otel name pattern", func() {
+			It("detects via name pattern", func() {
+				os.Setenv("VCAP_SERVICES", `{
+					"user-provided": [{
+						"name": "my-otel-sidecar",
+						"label": "user-provided",
+						"tags": [],
+						"credentials": {}
+					}]
+				}`)
+				name, err := framework.Detect()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(name).To(Equal("OpenTelemetry Javaagent"))
+			})
+		})
+
+		Context("with unrelated service binding", func() {
+			It("does not detect", func() {
+				os.Setenv("VCAP_SERVICES", `{
+					"newrelic": [{
+						"name": "newrelic-service",
+						"label": "newrelic",
+						"tags": ["apm"],
+						"credentials": {"licenseKey": "key"}
+					}]
+				}`)
+				name, err := framework.Detect()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(name).To(BeEmpty())
+			})
+		})
+
+		Context("with invalid VCAP_SERVICES JSON", func() {
+			It("does not detect and does not error", func() {
+				os.Setenv("VCAP_SERVICES", `{invalid}`)
+				name, err := framework.Detect()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(name).To(BeEmpty())
+			})
+		})
+	})
+
+	Describe("Finalize", func() {
+		otelOptsFile := func() string {
+			return filepath.Join(depsDir, "0", "java_opts", "36_open_telemetry_javaagent.opts")
+		}
+
+		Context("with otel-collector service and otel.* credentials", func() {
+			It("writes javaagent and otel.* properties to opts file", func() {
+				os.Setenv("VCAP_SERVICES", `{
+					"otel-collector": [{
+						"name": "my-otel",
+						"label": "otel-collector",
+						"tags": [],
+						"credentials": {
+							"otel.exporter.otlp.endpoint": "http://collector:4318",
+							"otel.traces.sampler": "always_on"
+						}
+					}]
+				}`)
+
+				err := framework.Finalize()
+				Expect(err).NotTo(HaveOccurred())
+
+				data, err := os.ReadFile(otelOptsFile())
+				Expect(err).NotTo(HaveOccurred())
+				opts := string(data)
+
+				Expect(opts).To(ContainSubstring("-javaagent:$DEPS_DIR/0/open_telemetry_javaagent/opentelemetry-javaagent.jar"))
+				Expect(opts).To(ContainSubstring("-Dotel.exporter.otlp.endpoint=http://collector:4318"))
+				Expect(opts).To(ContainSubstring("-Dotel.traces.sampler=always_on"))
+			})
+		})
+
+		Context("with credentials that do not start with otel.", func() {
+			It("does not include non-otel credentials as JVM properties", func() {
+				os.Setenv("VCAP_SERVICES", `{
+					"otel-collector": [{
+						"name": "my-otel",
+						"label": "otel-collector",
+						"tags": [],
+						"credentials": {
+							"otel.exporter.otlp.endpoint": "http://collector:4318",
+							"username": "admin",
+							"password": "secret"
+						}
+					}]
+				}`)
+
+				err := framework.Finalize()
+				Expect(err).NotTo(HaveOccurred())
+
+				data, err := os.ReadFile(otelOptsFile())
+				Expect(err).NotTo(HaveOccurred())
+				opts := string(data)
+
+				Expect(opts).NotTo(ContainSubstring("-Dusername="))
+				Expect(opts).NotTo(ContainSubstring("-Dpassword="))
+				Expect(opts).To(ContainSubstring("-Dotel.exporter.otlp.endpoint=http://collector:4318"))
+			})
+		})
+
+		Context("without a service binding", func() {
+			It("writes only the javaagent flag", func() {
+				err := framework.Finalize()
+				Expect(err).NotTo(HaveOccurred())
+
+				data, err := os.ReadFile(otelOptsFile())
+				Expect(err).NotTo(HaveOccurred())
+				opts := string(data)
+
+				Expect(opts).To(ContainSubstring("-javaagent:$DEPS_DIR/0/open_telemetry_javaagent/opentelemetry-javaagent.jar"))
+				Expect(opts).NotTo(ContainSubstring("-Dotel."))
+			})
+		})
+
+		Context("with otel.service.name already set in credentials", func() {
+			It("does not add a second otel.service.name from the app name", func() {
+				os.Setenv("VCAP_SERVICES", `{
+					"otel-collector": [{
+						"name": "my-otel",
+						"label": "otel-collector",
+						"tags": [],
+						"credentials": {
+							"otel.service.name": "explicit-service-name"
+						}
+					}]
+				}`)
+
+				err := framework.Finalize()
+				Expect(err).NotTo(HaveOccurred())
+
+				data, err := os.ReadFile(otelOptsFile())
+				Expect(err).NotTo(HaveOccurred())
+				opts := string(data)
+
+				Expect(opts).To(ContainSubstring("-Dotel.service.name=explicit-service-name"))
+				// Only one occurrence of otel.service.name
+				Expect(countOccurrences(opts, "-Dotel.service.name=")).To(Equal(1))
+			})
+		})
+
+		Context("runtime jar path uses forward slashes", func() {
+			It("produces a forward-slash path suitable for the Linux container", func() {
+				err := framework.Finalize()
+				Expect(err).NotTo(HaveOccurred())
+
+				data, err := os.ReadFile(otelOptsFile())
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(string(data)).To(ContainSubstring("$DEPS_DIR/0/open_telemetry_javaagent/opentelemetry-javaagent.jar"))
+			})
+		})
+	})
 })
+
+// countOccurrences counts non-overlapping occurrences of substr in s.
+func countOccurrences(s, substr string) int {
+	count := 0
+	for i := 0; i <= len(s)-len(substr); {
+		if s[i:i+len(substr)] == substr {
+			count++
+			i += len(substr)
+		} else {
+			i++
+		}
+	}
+	return count
+}

--- a/src/java/frameworks/sealights_agent.go
+++ b/src/java/frameworks/sealights_agent.go
@@ -135,8 +135,8 @@ func (f *SealightsAgentFramework) Finalize() error {
 
 	// Find Sealights service
 	var service *VCAPService
-	if vcapServices.HasService("sealights") {
-		service = vcapServices.GetService("sealights")
+	if svc := vcapServices.GetService("sealights"); svc != nil {
+		service = svc
 	} else {
 		service = vcapServices.GetServiceByNamePattern("sealights")
 	}

--- a/src/java/frameworks/splunk_otel_java_agent.go
+++ b/src/java/frameworks/splunk_otel_java_agent.go
@@ -129,7 +129,7 @@ func (s *SplunkOtelJavaAgentFramework) Finalize() error {
 	opts = append(opts, fmt.Sprintf("-javaagent:%s", runtimeJarPath))
 
 	// Configure service name
-	if appName := s.getApplicationName(); appName != "" {
+	if appName := GetApplicationName(false); appName != "" {
 		opts = append(opts, fmt.Sprintf("-Dotel.service.name=%s", appName))
 	}
 
@@ -232,25 +232,6 @@ func (s *SplunkOtelJavaAgentFramework) getCredentials() SplunkCredentials {
 	}
 
 	return creds
-}
-
-// getApplicationName returns the application name
-func (s *SplunkOtelJavaAgentFramework) getApplicationName() string {
-	vcapApp := os.Getenv("VCAP_APPLICATION")
-	if vcapApp == "" {
-		return ""
-	}
-
-	var appData map[string]interface{}
-	if err := json.Unmarshal([]byte(vcapApp), &appData); err != nil {
-		return ""
-	}
-
-	if name, ok := appData["application_name"].(string); ok {
-		return name
-	}
-
-	return ""
 }
 
 func (s *SplunkOtelJavaAgentFramework) constructJarPath(agentDir string) error {

--- a/src/java/frameworks/splunk_otel_java_agent.go
+++ b/src/java/frameworks/splunk_otel_java_agent.go
@@ -62,9 +62,8 @@ func (s *SplunkOtelJavaAgentFramework) Detect() (string, error) {
 	if vcapServices.HasService("splunk") ||
 		vcapServices.HasService("splunk-otel") ||
 		vcapServices.HasTag("splunk") ||
-		vcapServices.HasTag("otel") ||
 		vcapServices.HasServiceByNamePattern("splunk") ||
-		vcapServices.HasServiceByNamePattern("otel") {
+		vcapServices.HasServiceByNamePattern("splunk-o11y") {
 		s.context.Log.Info("Splunk OTEL service detected!")
 		return "Splunk OTEL", nil
 	}
@@ -185,7 +184,7 @@ func (s *SplunkOtelJavaAgentFramework) getCredentials() SplunkCredentials {
 
 	// Find the first matching Splunk service, preferring explicit labels over name pattern matches
 	var service *common.VCAPService
-	for _, label := range []string{"splunk", "splunk-otel"} {
+	for _, label := range []string{"splunk", "splunk-otel", "splunk-o11y"} {
 		if vcapServices.HasService(label) {
 			service = vcapServices.GetService(label)
 			break
@@ -195,7 +194,10 @@ func (s *SplunkOtelJavaAgentFramework) getCredentials() SplunkCredentials {
 		service = vcapServices.GetServiceByNamePattern("splunk")
 	}
 	if service == nil {
-		service = vcapServices.GetServiceByNamePattern("otel")
+		service = vcapServices.GetServiceByNamePattern("splunk-otel")
+	}
+	if service == nil {
+		service = vcapServices.GetServiceByNamePattern("splunk-o11y")
 	}
 	if service == nil {
 		return creds

--- a/src/java/frameworks/splunk_otel_java_agent.go
+++ b/src/java/frameworks/splunk_otel_java_agent.go
@@ -16,7 +16,6 @@
 package frameworks
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/cloudfoundry/java-buildpack/src/java/common"
 	"os"
@@ -179,56 +178,52 @@ func (s *SplunkOtelJavaAgentFramework) getCredentials() SplunkCredentials {
 	}
 
 	// Check service binding
-	vcapServices := os.Getenv("VCAP_SERVICES")
-	if vcapServices == "" {
+	vcapServices, err := GetVCAPServices()
+	if err != nil {
 		return creds
 	}
 
-	var services map[string][]map[string]interface{}
-	if err := json.Unmarshal([]byte(vcapServices), &services); err != nil {
-		return creds
-	}
-
-	// Look for splunk service
-	serviceNames := []string{
-		"splunk",
-		"splunk-otel",
-		"user-provided",
-	}
-
-	for _, serviceName := range serviceNames {
-		if serviceList, ok := services[serviceName]; ok {
-			for _, service := range serviceList {
-				if credentials, ok := service["credentials"].(map[string]interface{}); ok {
-					// Get OTLP endpoint
-					if endpoint, ok := credentials["otlp_endpoint"].(string); ok {
-						creds.OTLPEndpoint = endpoint
-					} else if endpoint, ok := credentials["otlpEndpoint"].(string); ok {
-						creds.OTLPEndpoint = endpoint
-					} else if endpoint, ok := credentials["endpoint"].(string); ok {
-						creds.OTLPEndpoint = endpoint
-					}
-
-					// Get access token
-					if token, ok := credentials["access_token"].(string); ok {
-						creds.AccessToken = token
-					} else if token, ok := credentials["accessToken"].(string); ok {
-						creds.AccessToken = token
-					} else if token, ok := credentials["token"].(string); ok {
-						creds.AccessToken = token
-					}
-
-					// Get realm
-					if realm, ok := credentials["realm"].(string); ok {
-						creds.Realm = realm
-					}
-
-					if creds.OTLPEndpoint != "" {
-						return creds
-					}
-				}
-			}
+	// Find the first matching Splunk service, preferring explicit labels over name pattern matches
+	var service *common.VCAPService
+	for _, label := range []string{"splunk", "splunk-otel"} {
+		if vcapServices.HasService(label) {
+			service = vcapServices.GetService(label)
+			break
 		}
+	}
+	if service == nil {
+		service = vcapServices.GetServiceByNamePattern("splunk")
+	}
+	if service == nil {
+		service = vcapServices.GetServiceByNamePattern("otel")
+	}
+	if service == nil {
+		return creds
+	}
+
+	credentials := service.Credentials
+
+	// Get OTLP endpoint
+	if endpoint, ok := credentials["otlp_endpoint"].(string); ok {
+		creds.OTLPEndpoint = endpoint
+	} else if endpoint, ok := credentials["otlpEndpoint"].(string); ok {
+		creds.OTLPEndpoint = endpoint
+	} else if endpoint, ok := credentials["endpoint"].(string); ok {
+		creds.OTLPEndpoint = endpoint
+	}
+
+	// Get access token
+	if token, ok := credentials["access_token"].(string); ok {
+		creds.AccessToken = token
+	} else if token, ok := credentials["accessToken"].(string); ok {
+		creds.AccessToken = token
+	} else if token, ok := credentials["token"].(string); ok {
+		creds.AccessToken = token
+	}
+
+	// Get realm
+	if realm, ok := credentials["realm"].(string); ok {
+		creds.Realm = realm
 	}
 
 	return creds

--- a/src/java/frameworks/splunk_otel_java_agent.go
+++ b/src/java/frameworks/splunk_otel_java_agent.go
@@ -185,10 +185,8 @@ func (s *SplunkOtelJavaAgentFramework) getCredentials() SplunkCredentials {
 	// Find the first matching Splunk service, preferring explicit labels over name pattern matches
 	var service *common.VCAPService
 	for _, label := range []string{"splunk", "splunk-otel", "splunk-o11y"} {
-		if vcapServices.HasService(label) {
-			service = vcapServices.GetService(label)
-			break
-		}
+		service = vcapServices.GetService(label)
+		break
 	}
 	if service == nil {
 		service = vcapServices.GetServiceByNamePattern("splunk")

--- a/src/java/frameworks/splunk_otel_java_agent_test.go
+++ b/src/java/frameworks/splunk_otel_java_agent_test.go
@@ -2,23 +2,432 @@ package frameworks_test
 
 import (
 	"os"
+	"path/filepath"
 
+	"github.com/cloudfoundry/java-buildpack/src/java/common"
+	"github.com/cloudfoundry/java-buildpack/src/java/frameworks"
+	"github.com/cloudfoundry/libbuildpack"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("SplunkOtelJavaAgent", func() {
+	var (
+		ctx       *common.Context
+		framework *frameworks.SplunkOtelJavaAgentFramework
+		tmpDir    string
+		depsDir   string
+		agentDir  string
+	)
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "splunk-otel-test-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		depsDir = filepath.Join(tmpDir, "deps")
+		err = os.MkdirAll(filepath.Join(depsDir, "0"), 0755)
+		Expect(err).NotTo(HaveOccurred())
+
+		agentDir = filepath.Join(depsDir, "0", "splunk_otel_java_agent")
+
+		logger := libbuildpack.NewLogger(os.Stdout)
+		manifest := &libbuildpack.Manifest{}
+		stager := libbuildpack.NewStager([]string{tmpDir, "", depsDir, "0"}, logger, manifest)
+
+		ctx = &common.Context{
+			Stager:   stager,
+			Manifest: manifest,
+			Log:      logger,
+		}
+
+		framework = frameworks.NewSplunkOtelJavaAgentFramework(ctx)
+	})
+
 	AfterEach(func() {
+		os.RemoveAll(tmpDir)
+		os.Unsetenv("VCAP_SERVICES")
+		os.Unsetenv("SPLUNK_OTEL_AGENT")
+		os.Unsetenv("OTEL_EXPORTER_OTLP_ENDPOINT")
 		os.Unsetenv("SPLUNK_ACCESS_TOKEN")
 		os.Unsetenv("SPLUNK_REALM")
 	})
 
-	DescribeTable("configuration environment variables",
-		func(envVar, expectedValue string) {
-			os.Setenv(envVar, expectedValue)
-			Expect(os.Getenv(envVar)).To(Equal(expectedValue))
-		},
-		Entry("SPLUNK_ACCESS_TOKEN", "SPLUNK_ACCESS_TOKEN", "test-token-abc123"),
-		Entry("SPLUNK_REALM", "SPLUNK_REALM", "us0"),
-	)
+	Describe("Detect", func() {
+		Context("without any binding or environment variable", func() {
+			It("does not detect", func() {
+				name, err := framework.Detect()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(name).To(BeEmpty())
+			})
+		})
+
+		Context("with SPLUNK_OTEL_AGENT environment variable", func() {
+			It("detects successfully", func() {
+				os.Setenv("SPLUNK_OTEL_AGENT", "/path/to/agent.jar")
+				name, err := framework.Detect()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(name).To(Equal("Splunk OTEL"))
+			})
+		})
+
+		Context("with OTEL_EXPORTER_OTLP_ENDPOINT environment variable", func() {
+			It("detects successfully", func() {
+				os.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")
+				name, err := framework.Detect()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(name).To(Equal("Splunk OTEL"))
+			})
+		})
+
+		Context("with splunk service label", func() {
+			It("detects successfully", func() {
+				os.Setenv("VCAP_SERVICES", `{
+					"splunk": [{
+						"name": "my-splunk",
+						"label": "splunk",
+						"tags": [],
+						"credentials": {}
+					}]
+				}`)
+				name, err := framework.Detect()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(name).To(Equal("Splunk OTEL"))
+			})
+		})
+
+		Context("with splunk-otel service label", func() {
+			It("detects successfully", func() {
+				os.Setenv("VCAP_SERVICES", `{
+					"splunk-otel": [{
+						"name": "my-splunk-otel",
+						"label": "splunk-otel",
+						"tags": [],
+						"credentials": {}
+					}]
+				}`)
+				name, err := framework.Detect()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(name).To(Equal("Splunk OTEL"))
+			})
+		})
+
+		Context("with splunk tag", func() {
+			It("detects via tag", func() {
+				os.Setenv("VCAP_SERVICES", `{
+					"user-provided": [{
+						"name": "my-apm",
+						"label": "user-provided",
+						"tags": ["splunk"],
+						"credentials": {}
+					}]
+				}`)
+				name, err := framework.Detect()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(name).To(Equal("Splunk OTEL"))
+			})
+		})
+
+		Context("with user-provided service matching splunk name pattern", func() {
+			It("detects via name pattern", func() {
+				os.Setenv("VCAP_SERVICES", `{
+					"user-provided": [{
+						"name": "my-splunk-collector",
+						"label": "user-provided",
+						"tags": [],
+						"credentials": {}
+					}]
+				}`)
+				name, err := framework.Detect()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(name).To(Equal("Splunk OTEL"))
+			})
+		})
+
+		Context("with unrelated service binding", func() {
+			It("does not detect", func() {
+				os.Setenv("VCAP_SERVICES", `{
+					"newrelic": [{
+						"name": "newrelic-service",
+						"label": "newrelic",
+						"tags": ["apm"],
+						"credentials": {"licenseKey": "key"}
+					}]
+				}`)
+				name, err := framework.Detect()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(name).To(BeEmpty())
+			})
+		})
+
+		Context("with invalid VCAP_SERVICES JSON", func() {
+			It("does not detect and does not error", func() {
+				os.Setenv("VCAP_SERVICES", `{invalid}`)
+				name, err := framework.Detect()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(name).To(BeEmpty())
+			})
+		})
+	})
+
+	Describe("Finalize", func() {
+		splunkOptsFile := func() string {
+			return filepath.Join(depsDir, "0", "java_opts", "42_splunk_otel_java_agent.opts")
+		}
+
+		createJar := func(name string) {
+			err := os.MkdirAll(agentDir, 0755)
+			Expect(err).NotTo(HaveOccurred())
+			err = os.WriteFile(filepath.Join(agentDir, name), []byte("fake jar"), 0644)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		Context("with primary jar name", func() {
+			BeforeEach(func() { createJar("splunk-otel-javaagent.jar") })
+
+			It("writes javaagent flag to opts file", func() {
+				err := framework.Finalize()
+				Expect(err).NotTo(HaveOccurred())
+
+				data, err := os.ReadFile(splunkOptsFile())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(data)).To(ContainSubstring("-javaagent:$DEPS_DIR/0/splunk_otel_java_agent/splunk-otel-javaagent.jar"))
+			})
+
+			It("uses forward slashes in the runtime jar path", func() {
+				err := framework.Finalize()
+				Expect(err).NotTo(HaveOccurred())
+
+				data, err := os.ReadFile(splunkOptsFile())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(data)).NotTo(ContainSubstring(`\`))
+			})
+		})
+
+		Context("with alternative jar name (splunk-otel-javaagent-all.jar)", func() {
+			BeforeEach(func() { createJar("splunk-otel-javaagent-all.jar") })
+
+			It("falls back to the -all jar and writes javaagent flag", func() {
+				err := framework.Finalize()
+				Expect(err).NotTo(HaveOccurred())
+
+				data, err := os.ReadFile(splunkOptsFile())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(data)).To(ContainSubstring("-javaagent:$DEPS_DIR/0/splunk_otel_java_agent/splunk-otel-javaagent-all.jar"))
+			})
+		})
+
+		Context("when jar is missing", func() {
+			It("returns an error", func() {
+				err := framework.Finalize()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("splunk OTEL Java agent JAR path not found"))
+			})
+		})
+
+		Context("with credentials from environment variables", func() {
+			BeforeEach(func() { createJar("splunk-otel-javaagent.jar") })
+
+			It("writes OTLP endpoint from env", func() {
+				os.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")
+
+				err := framework.Finalize()
+				Expect(err).NotTo(HaveOccurred())
+
+				data, err := os.ReadFile(splunkOptsFile())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(data)).To(ContainSubstring("-Dotel.exporter.otlp.endpoint=http://collector:4318"))
+			})
+
+			It("writes access token from env", func() {
+				os.Setenv("SPLUNK_ACCESS_TOKEN", "my-token")
+
+				err := framework.Finalize()
+				Expect(err).NotTo(HaveOccurred())
+
+				data, err := os.ReadFile(splunkOptsFile())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(data)).To(ContainSubstring("-Dsplunk.access.token=my-token"))
+			})
+
+			It("writes realm from env", func() {
+				os.Setenv("SPLUNK_REALM", "us1")
+
+				err := framework.Finalize()
+				Expect(err).NotTo(HaveOccurred())
+
+				data, err := os.ReadFile(splunkOptsFile())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(data)).To(ContainSubstring("-Dsplunk.realm=us1"))
+			})
+
+			It("env OTLP endpoint takes precedence over service binding", func() {
+				os.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://env-collector:4318")
+				os.Setenv("VCAP_SERVICES", `{
+					"splunk": [{
+						"name": "my-splunk",
+						"label": "splunk",
+						"tags": [],
+						"credentials": {"otlp_endpoint": "http://binding-collector:4318"}
+					}]
+				}`)
+
+				err := framework.Finalize()
+				Expect(err).NotTo(HaveOccurred())
+
+				data, err := os.ReadFile(splunkOptsFile())
+				Expect(err).NotTo(HaveOccurred())
+				opts := string(data)
+				Expect(opts).To(ContainSubstring("http://env-collector:4318"))
+				Expect(opts).NotTo(ContainSubstring("http://binding-collector:4318"))
+			})
+		})
+
+		Context("with credentials from splunk service binding", func() {
+			BeforeEach(func() { createJar("splunk-otel-javaagent.jar") })
+
+			DescribeTable("credential key variants for OTLP endpoint",
+				func(credKey string) {
+					os.Setenv("VCAP_SERVICES", `{
+						"splunk": [{
+							"name": "my-splunk",
+							"label": "splunk",
+							"tags": [],
+							"credentials": {"`+credKey+`": "http://collector:4318"}
+						}]
+					}`)
+
+					err := framework.Finalize()
+					Expect(err).NotTo(HaveOccurred())
+
+					data, err := os.ReadFile(splunkOptsFile())
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(data)).To(ContainSubstring("-Dotel.exporter.otlp.endpoint=http://collector:4318"))
+				},
+				Entry("otlp_endpoint", "otlp_endpoint"),
+				Entry("otlpEndpoint", "otlpEndpoint"),
+				Entry("endpoint", "endpoint"),
+			)
+
+			DescribeTable("credential key variants for access token",
+				func(credKey string) {
+					os.Setenv("VCAP_SERVICES", `{
+						"splunk": [{
+							"name": "my-splunk",
+							"label": "splunk",
+							"tags": [],
+							"credentials": {"`+credKey+`": "tok-abc123"}
+						}]
+					}`)
+
+					err := framework.Finalize()
+					Expect(err).NotTo(HaveOccurred())
+
+					data, err := os.ReadFile(splunkOptsFile())
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(data)).To(ContainSubstring("-Dsplunk.access.token=tok-abc123"))
+				},
+				Entry("access_token", "access_token"),
+				Entry("accessToken", "accessToken"),
+				Entry("token", "token"),
+			)
+
+			It("reads realm from service binding", func() {
+				os.Setenv("VCAP_SERVICES", `{
+					"splunk": [{
+						"name": "my-splunk",
+						"label": "splunk",
+						"tags": [],
+						"credentials": {"realm": "eu0"}
+					}]
+				}`)
+
+				err := framework.Finalize()
+				Expect(err).NotTo(HaveOccurred())
+
+				data, err := os.ReadFile(splunkOptsFile())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(data)).To(ContainSubstring("-Dsplunk.realm=eu0"))
+			})
+
+			It("prefers splunk label over splunk-otel label", func() {
+				os.Setenv("VCAP_SERVICES", `{
+					"splunk": [{
+						"name": "explicit-splunk",
+						"label": "splunk",
+						"tags": [],
+						"credentials": {"otlp_endpoint": "http://splunk-endpoint:4318"}
+					}],
+					"splunk-otel": [{
+						"name": "splunk-otel-svc",
+						"label": "splunk-otel",
+						"tags": [],
+						"credentials": {"otlp_endpoint": "http://splunk-otel-endpoint:4318"}
+					}]
+				}`)
+
+				err := framework.Finalize()
+				Expect(err).NotTo(HaveOccurred())
+
+				data, err := os.ReadFile(splunkOptsFile())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(data)).To(ContainSubstring("http://splunk-endpoint:4318"))
+				Expect(string(data)).NotTo(ContainSubstring("http://splunk-otel-endpoint:4318"))
+			})
+
+			It("falls back to name pattern when no explicit label matches", func() {
+				os.Setenv("VCAP_SERVICES", `{
+					"user-provided": [{
+						"name": "my-splunk-collector",
+						"label": "user-provided",
+						"tags": [],
+						"credentials": {"otlp_endpoint": "http://pattern-endpoint:4318"}
+					}]
+				}`)
+
+				err := framework.Finalize()
+				Expect(err).NotTo(HaveOccurred())
+
+				data, err := os.ReadFile(splunkOptsFile())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(data)).To(ContainSubstring("http://pattern-endpoint:4318"))
+			})
+
+			It("does not pick up an unrelated user-provided service", func() {
+				os.Setenv("VCAP_SERVICES", `{
+					"user-provided": [{
+						"name": "my-database",
+						"label": "user-provided",
+						"tags": [],
+						"credentials": {"otlp_endpoint": "http://db-endpoint:4318"}
+					}]
+				}`)
+
+				err := framework.Finalize()
+				Expect(err).NotTo(HaveOccurred())
+
+				data, err := os.ReadFile(splunkOptsFile())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(data)).NotTo(ContainSubstring("http://db-endpoint:4318"))
+			})
+		})
+
+		Context("without any credentials", func() {
+			BeforeEach(func() { createJar("splunk-otel-javaagent.jar") })
+
+			It("writes only the javaagent flag", func() {
+				err := framework.Finalize()
+				Expect(err).NotTo(HaveOccurred())
+
+				data, err := os.ReadFile(splunkOptsFile())
+				Expect(err).NotTo(HaveOccurred())
+				opts := string(data)
+
+				Expect(opts).To(ContainSubstring("-javaagent:"))
+				Expect(opts).NotTo(ContainSubstring("-Dotel.exporter.otlp.endpoint="))
+				Expect(opts).NotTo(ContainSubstring("-Dsplunk.access.token="))
+				Expect(opts).NotTo(ContainSubstring("-Dsplunk.realm="))
+			})
+		})
+	})
 })


### PR DESCRIPTION
The PR addresses certain issues in the `open_telemetry_javaagent` and `splunk_java_agent` frameworks. It also introduces refactoring and additional unit tests.
- Fix the bug #1134 issue, where `-Dotel.service.name` is wrongly set. It is now obtained from VCAP_APPLICATION and adjusted properly.
- Fix splunk otel detect conditions, add `splunk-o11y` which was anticipated in the ruby based implementation. Don't contribute splunk otel agent if not expected by having only some sort of `otel` named service or tag. With regard to #1236 
- Introduce refactoring, duplicated code cleanup
- Introduce additional unit tests