### PR TITLE
Issue 1259 java opts breaks pre start script

### DIFF
--- a/src/java/frameworks/java_opts_writer.go
+++ b/src/java/frameworks/java_opts_writer.go
@@ -93,9 +93,10 @@ if [ -d "$DEPS_DIR/%s/java_opts" ]; then
             opts_content="${opts_content//\$HOME/$HOME}"
             opts_content="${opts_content//\$JAVA_OPTS/$USER_JAVA_OPTS}"
             
-            # Now expand all remaining environment variables using eval with proper escaping
-            # This mimics Ruby buildpack behavior where shell naturally expands variables
-            # Use eval in a subshell to safely expand variables without executing commands
+            # Expand any remaining environment variables in opts content via eval.
+            # Note: eval executes commands, but .opts files are written by the buildpack
+            # at staging time and run within the container context.
+            # This matches how the Ruby buildpack naturally expanded variables via shell.
             opts_content=$(eval "echo \"$opts_content\"")
             
             if [ -n "$opts_content" ]; then

--- a/src/java/frameworks/java_opts_writer.go
+++ b/src/java/frameworks/java_opts_writer.go
@@ -74,7 +74,8 @@ func CreateJavaOptsAssemblyScript(ctx *common.Context) error {
 
 # Save original JAVA_OPTS from environment (user-provided)
 # Normalize to single line: YAML block scalars (>) may introduce newlines
-USER_JAVA_OPTS=$(echo "$JAVA_OPTS" | tr '\n' ' ' | tr -s ' ')
+# xargs trims leading/trailing whitespace and collapses internal spaces
+USER_JAVA_OPTS=$(echo "$JAVA_OPTS" | tr '\n' ' ' | tr -s ' ' | xargs)
 
 # Start building new JAVA_OPTS
 JAVA_OPTS=""

--- a/src/java/frameworks/java_opts_writer.go
+++ b/src/java/frameworks/java_opts_writer.go
@@ -85,15 +85,12 @@ if [ -d "$DEPS_DIR/%s/java_opts" ]; then
             # Read content and expand runtime variables
             opts_content=$(cat "$opts_file")
             
-            # First, expand special variables that need specific handling
-            # Expand $DEPS_DIR variable
-            opts_content=$(echo "$opts_content" | sed "s|\$DEPS_DIR|$DEPS_DIR|g")
-            
-            # Expand $HOME variable (for app-provided JARs like AspectJ)
-            opts_content=$(echo "$opts_content" | sed "s|\$HOME|$HOME|g")
-            
-            # Expand $JAVA_OPTS to the saved USER_JAVA_OPTS value (not the loop's current JAVA_OPTS)
-            opts_content=$(echo "$opts_content" | sed "s|\$JAVA_OPTS|$USER_JAVA_OPTS|g")
+            # Expand $DEPS_DIR, $HOME, $JAVA_OPTS using bash parameter expansion.
+            # sed-based substitution breaks when these values contain the sed delimiter (|),
+            # backslashes, ampersands, or newlines — all valid in JAVA_OPTS and paths.
+            opts_content="${opts_content//\$DEPS_DIR/$DEPS_DIR}"
+            opts_content="${opts_content//\$HOME/$HOME}"
+            opts_content="${opts_content//\$JAVA_OPTS/$USER_JAVA_OPTS}"
             
             # Now expand all remaining environment variables using eval with proper escaping
             # This mimics Ruby buildpack behavior where shell naturally expands variables

--- a/src/java/frameworks/java_opts_writer.go
+++ b/src/java/frameworks/java_opts_writer.go
@@ -73,7 +73,8 @@ func CreateJavaOptsAssemblyScript(ctx *common.Context) error {
 # Expands runtime variables like $DEPS_DIR, $HOME, $JAVA_OPTS, and all other environment variables
 
 # Save original JAVA_OPTS from environment (user-provided)
-USER_JAVA_OPTS="$JAVA_OPTS"
+# Normalize to single line: YAML block scalars (>) may introduce newlines
+USER_JAVA_OPTS=$(echo "$JAVA_OPTS" | tr '\n' ' ' | tr -s ' ')
 
 # Start building new JAVA_OPTS
 JAVA_OPTS=""

--- a/src/java/frameworks/java_opts_writer_test.go
+++ b/src/java/frameworks/java_opts_writer_test.go
@@ -63,35 +63,47 @@ var _ = Describe("Java Opts Writer", func() {
 	})
 
 	Describe("CreateJavaOptsAssemblyScript", func() {
-		It("handles multiline JAVA_OPTS from YAML block scalar without sed error", func() {
-			// Reproduce the manifest pattern:
-			//   JAVA_OPTS: >
-			//     -javaagent:$HOME/BOOT-INF/classes/some-java-agent.jar
-			//     -Xms512m
-			//     -Xmx1024m
-			// YAML '>' folds newlines to spaces, but CF may deliver them as literal newlines
-			multilineJavaOpts := "-javaagent:$HOME/BOOT-INF/classes/some-java-agent.jar\n-Xms512m\n-Xmx1024m\n-XX:MaxDirectMemorySize=256m"
-
+		runScript := func(javaOpts string, optsFileContent string) (string, error) {
 			err := frameworks.CreateJavaOptsAssemblyScript(ctx)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Create an opts file that references $JAVA_OPTS (as frameworks do)
 			optsDir := filepath.Join(depsDir, "0", "java_opts")
 			Expect(os.MkdirAll(optsDir, 0755)).To(Succeed())
-			Expect(os.WriteFile(filepath.Join(optsDir, "42_agent.opts"), []byte("-javaagent:somepath.jar $JAVA_OPTS"), 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(optsDir, "42_agent.opts"), []byte(optsFileContent), 0644)).To(Succeed())
 
-			// Run the generated profile.d script with multiline JAVA_OPTS
 			scriptPath := filepath.Join(depsDir, "0", "profile.d", "00_java_opts.sh")
-			cmd := exec.Command("bash", "-c",
-				"source "+scriptPath+" && echo \"$JAVA_OPTS\"")
+			cmd := exec.Command("bash", "-c", "source "+scriptPath+" && echo \"$JAVA_OPTS\"")
 			cmd.Env = append(os.Environ(),
-				"JAVA_OPTS="+multilineJavaOpts,
+				"JAVA_OPTS="+javaOpts,
 				"DEPS_DIR="+depsDir,
 				"HOME=/home/vcap/app",
 			)
 			output, err := cmd.CombinedOutput()
-			Expect(err).NotTo(HaveOccurred(), "script failed with output: %s", string(output))
-			Expect(string(output)).To(ContainSubstring("-Xms512m"))
+			return string(output), err
+		}
+
+		It("handles multiline JAVA_OPTS from YAML block scalar without sed error", func() {
+			// Reproduce the manifest pattern:
+			//   JAVA_OPTS: >
+			//     -javaagent:$HOME/BOOT-INF/lib/agent.jar
+			//     -XX:+UseZGC
+			// YAML '>' folds newlines to spaces, but CF may deliver them as literal newlines
+			multilineJavaOpts := "-javaagent:$HOME/BOOT-INF/lib/agent.jar\n-XX:+UseZGC\n-XX:+AlwaysPreTouch"
+
+			output, err := runScript(multilineJavaOpts, "-javaagent:somepath.jar $JAVA_OPTS")
+			Expect(err).NotTo(HaveOccurred(), "script failed with output: %s", output)
+			Expect(output).To(ContainSubstring("-XX:+UseZGC"))
+		})
+
+		It("handles pipe character in JAVA_OPTS (e.g. javaagent options) without sed error", func() {
+			// Reproduce the manifest pattern:
+			//   JAVA_OPTS: >
+			//     -javaagent:$HOME/BOOT-INF/lib/jfr-exporter.jar=enableExecutorMBeans|disableMyFeature
+			pipeJavaOpts := "-javaagent:$HOME/BOOT-INF/lib/jfr-exporter.jar=enableExecutorMBeans|disableMyFeature"
+
+			output, err := runScript(pipeJavaOpts, "-javaagent:somepath.jar $JAVA_OPTS")
+			Expect(err).NotTo(HaveOccurred(), "script failed with output: %s", output)
+			Expect(output).To(ContainSubstring("enableExecutorMBeans|disableMyFeature"))
 		})
 	})
 })

--- a/src/java/frameworks/java_opts_writer_test.go
+++ b/src/java/frameworks/java_opts_writer_test.go
@@ -105,5 +105,17 @@ var _ = Describe("Java Opts Writer", func() {
 			Expect(err).NotTo(HaveOccurred(), "script failed with output: %s", output)
 			Expect(output).To(ContainSubstring("enableExecutorMBeans|disableMyFeature"))
 		})
+
+		It("expands $HOME in opts file content", func() {
+			output, err := runScript("", "-javaagent:$HOME/BOOT-INF/lib/agent.jar")
+			Expect(err).NotTo(HaveOccurred(), "script failed with output: %s", output)
+			Expect(output).To(ContainSubstring("-javaagent:/home/vcap/app/BOOT-INF/lib/agent.jar"))
+		})
+
+		It("expands $DEPS_DIR in opts file content", func() {
+			output, err := runScript("", "-Djava.security.properties=$DEPS_DIR/0/security.properties")
+			Expect(err).NotTo(HaveOccurred(), "script failed with output: %s", output)
+			Expect(output).To(ContainSubstring("-Djava.security.properties=" + depsDir + "/0/security.properties"))
+		})
 	})
 })

--- a/src/java/frameworks/java_opts_writer_test.go
+++ b/src/java/frameworks/java_opts_writer_test.go
@@ -2,14 +2,55 @@ package frameworks_test
 
 import (
 	"os"
+	"os/exec"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/cloudfoundry/java-buildpack/src/java/common"
+	"github.com/cloudfoundry/java-buildpack/src/java/frameworks"
+	"github.com/cloudfoundry/libbuildpack"
 )
 
+func newJavaOptsContext(buildDir, cacheDir, depsDir string) *common.Context {
+	logger := libbuildpack.NewLogger(GinkgoWriter)
+	manifest := &libbuildpack.Manifest{}
+	installer := &libbuildpack.Installer{}
+	stager := libbuildpack.NewStager([]string{buildDir, cacheDir, depsDir, "0"}, logger, manifest)
+	return &common.Context{
+		Stager:    stager,
+		Manifest:  manifest,
+		Installer: installer,
+		Log:       logger,
+		Command:   &libbuildpack.Command{},
+	}
+}
+
 var _ = Describe("Java Opts Writer", func() {
+	var (
+		buildDir string
+		cacheDir string
+		depsDir  string
+		ctx      *common.Context
+	)
+
+	BeforeEach(func() {
+		var err error
+		buildDir, err = os.MkdirTemp("", "build")
+		Expect(err).NotTo(HaveOccurred())
+		cacheDir, err = os.MkdirTemp("", "cache")
+		Expect(err).NotTo(HaveOccurred())
+		depsDir, err = os.MkdirTemp("", "deps")
+		Expect(err).NotTo(HaveOccurred())
+		ctx = newJavaOptsContext(buildDir, cacheDir, depsDir)
+	})
+
 	AfterEach(func() {
 		os.Unsetenv("JAVA_OPTS")
+		os.RemoveAll(buildDir)
+		os.RemoveAll(cacheDir)
+		os.RemoveAll(depsDir)
 	})
 
 	Describe("Basic options", func() {
@@ -18,6 +59,39 @@ var _ = Describe("Java Opts Writer", func() {
 			os.Setenv("JAVA_OPTS", javaOpts)
 
 			Expect(os.Getenv("JAVA_OPTS")).To(Equal(javaOpts))
+		})
+	})
+
+	Describe("CreateJavaOptsAssemblyScript", func() {
+		It("handles multiline JAVA_OPTS from YAML block scalar without sed error", func() {
+			// Reproduce the manifest pattern:
+			//   JAVA_OPTS: >
+			//     -javaagent:$HOME/BOOT-INF/classes/some-java-agent.jar
+			//     -Xms512m
+			//     -Xmx1024m
+			// YAML '>' folds newlines to spaces, but CF may deliver them as literal newlines
+			multilineJavaOpts := "-javaagent:$HOME/BOOT-INF/classes/some-java-agent.jar\n-Xms512m\n-Xmx1024m\n-XX:MaxDirectMemorySize=256m"
+
+			err := frameworks.CreateJavaOptsAssemblyScript(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create an opts file that references $JAVA_OPTS (as frameworks do)
+			optsDir := filepath.Join(depsDir, "0", "java_opts")
+			Expect(os.MkdirAll(optsDir, 0755)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(optsDir, "42_agent.opts"), []byte("-javaagent:somepath.jar $JAVA_OPTS"), 0644)).To(Succeed())
+
+			// Run the generated profile.d script with multiline JAVA_OPTS
+			scriptPath := filepath.Join(depsDir, "0", "profile.d", "00_java_opts.sh")
+			cmd := exec.Command("bash", "-c",
+				"source "+scriptPath+" && echo \"$JAVA_OPTS\"")
+			cmd.Env = append(os.Environ(),
+				"JAVA_OPTS="+multilineJavaOpts,
+				"DEPS_DIR="+depsDir,
+				"HOME=/home/vcap/app",
+			)
+			output, err := cmd.CombinedOutput()
+			Expect(err).NotTo(HaveOccurred(), "script failed with output: %s", string(output))
+			Expect(string(output)).To(ContainSubstring("-Xms512m"))
 		})
 	})
 })


### PR DESCRIPTION
Fixes #1259

The `profile.d/00_java_opts.sh` script used `sed` to substitute `$JAVA_OPTS`, `$HOME` and `$DEPS_DIR` into `.opts` file content. This breaks at runtime when `JAVA_OPTS` contains:
- **newlines** — from YAML block scalar (`>`) in CF manifest
- **pipe characters** (`|`) — e.g. javaagent options like `agent.jar=featureA|featureB`
- **`&` or `\`** — interpreted as sed replacement metacharacters, causing silent corruption

When `sed` fails, the script continues without `set -e`, silently dropping all opts file content. The JVM starts with an empty `JAVA_OPTS`: no memory limits, no agents.

## Changes

- **Normalize `JAVA_OPTS` to single line** at capture time (`tr` newlines to spaces) before any substitution
- **Replace `sed` with bash parameter expansion** (`${var//find/replace}`) for `$JAVA_OPTS`, `$HOME` and `$DEPS_DIR` substitutions — no special-character restrictions
- **Add regression tests** covering multiline `JAVA_OPTS`, pipe characters, and `$HOME`/`$DEPS_DIR` expansion

## Why `set -e` was not added

`profile.d` scripts are **sourced** by the CF launcher, not run in a subshell — `set -e` would leak to the parent shell. A `kill -TERM $$` guard was also considered, but after analysis it provides little value: with `sed` replaced by bash parameter expansion, there are **no remaining commands in the assembly loop that can fail** (the substitutions are pure bash builtins). A guard checking for empty `JAVA_OPTS` would also be imprecise, since the memory calculator appends to `JAVA_OPTS` via its own separate `java.sh` script *after* `00_java_opts.sh` runs.