### PR TITLE
Adjust default version for newrelic

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -124,7 +124,7 @@ default_versions:
 - name: luna-security-provider
   version: 7.x
 - name: newrelic
-  version: 8.x
+  version: 9.x
 - name: cf-metrics-exporter
   version: 0.7.x
 - name: metric-writer


### PR DESCRIPTION
With https://github.com/cloudfoundry/java-buildpack/commit/ba8c1d1d836bbbcc1a4b79013b18effc0694f833 `newrelic` version was bumped to latest 9.x. Should also adjust the default version otherwise the `package.sh` script will fail to build the java buildpack archive with:
```
error while creating zipfile: No matching default dependency `newrelic` for stack `cflinuxfs4`
```