### PR TITLE
Adjust framework functionalities for the new dependencies paths

### DIFF
--- a/src/java/frameworks/azure_application_insights_agent.go
+++ b/src/java/frameworks/azure_application_insights_agent.go
@@ -278,7 +278,7 @@ func (a *AzureApplicationInsightsAgentFramework) getApplicationName() string {
 
 func (a *AzureApplicationInsightsAgentFramework) constructJarPath(agentDir string) error {
 	// Find the installed JAR
-	jarPattern := filepath.Join(agentDir, "applicationinsights-agent-*.jar")
+	jarPattern := filepath.Join(agentDir, "azure-application-insights*.jar")
 	matches, err := filepath.Glob(jarPattern)
 	if err != nil {
 		return fmt.Errorf("failed to search for Azure Application Insights agent JAR: %w", err)

--- a/src/java/frameworks/azure_application_insights_agent_test.go
+++ b/src/java/frameworks/azure_application_insights_agent_test.go
@@ -63,7 +63,7 @@ func installAzureAgent(depsDir, version string) {
 	agentDir := filepath.Join(depsDir, "0", "azure_application_insights_agent")
 	Expect(os.MkdirAll(agentDir, 0755)).To(Succeed())
 	Expect(os.WriteFile(
-		filepath.Join(agentDir, "applicationinsights-agent-"+version+".jar"),
+		filepath.Join(agentDir, "azure-application-insights-"+version+".jar"),
 		[]byte("fake jar"), 0644,
 	)).To(Succeed())
 }
@@ -293,7 +293,7 @@ var _ = Describe("Azure Application Insights Agent", func() {
 				content, err := os.ReadFile(filepath.Join(depsDir, "0", "java_opts", "13_azure_application_insights_agent.opts"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(content)).To(ContainSubstring("-javaagent:"))
-				Expect(string(content)).To(ContainSubstring("$DEPS_DIR/0/azure_application_insights_agent/applicationinsights-agent-3.4.0.jar"))
+				Expect(string(content)).To(ContainSubstring("$DEPS_DIR/0/azure_application_insights_agent/azure-application-insights-3.4.0.jar"))
 			})
 
 			It("opts file does not embed the staging-time absolute path", func() {

--- a/src/java/frameworks/cf_metrics_exporter.go
+++ b/src/java/frameworks/cf_metrics_exporter.go
@@ -58,11 +58,6 @@ func (f *CfMetricsExporterFramework) Supply() error {
 
 	agentDir := filepath.Join(f.context.Stager.DepDir(), cfMetricsExporterDirName)
 
-	err = f.constructJarPath(agentDir)
-	if err != nil {
-		return fmt.Errorf("cf metrics exporter agent not found during supply: %w", err)
-	}
-
 	// Ensure agent directory exists
 	if err := os.MkdirAll(agentDir, 0755); err != nil {
 		return fmt.Errorf("failed to create agent dir: %w", err)
@@ -76,6 +71,11 @@ func (f *CfMetricsExporterFramework) Supply() error {
 		if _, err := os.Stat(f.jarPath); err != nil {
 			return fmt.Errorf("expected jar file not found after download: %w", err)
 		}
+	}
+
+	err = f.constructJarPath(agentDir)
+	if err != nil {
+		return fmt.Errorf("cf metrics exporter agent not found during supply: %w", err)
 	}
 
 	// Log activation, including properties if set
@@ -95,14 +95,20 @@ func (f *CfMetricsExporterFramework) Finalize() error {
 		return nil
 	}
 
-	dep, _, err := f.getManifestDependency()
+	agentDir := filepath.Join(f.context.Stager.DepDir(), cfMetricsExporterDirName)
+
+	err := f.constructJarPath(agentDir)
 	if err != nil {
-		return err
+		return fmt.Errorf("cf metrics exporter agent jar path not found during finalize: %w", err)
 	}
 
-	jarName := fmt.Sprintf("cf-metrics-exporter-%s.jar", dep.Version)
+	relPath, err := filepath.Rel(f.context.Stager.DepDir(), f.jarPath)
+	if err != nil {
+		return fmt.Errorf("failed to determine relative path for cf metrics exporter agent: %w", err)
+	}
+
 	depsIdx := f.context.Stager.DepsIdx()
-	agentPath := fmt.Sprintf("$DEPS_DIR/%s/cf_metrics_exporter/%s", depsIdx, jarName)
+	agentPath := filepath.Join(fmt.Sprintf("$DEPS_DIR/%s", depsIdx), relPath)
 
 	props := os.Getenv("CF_METRICS_EXPORTER_PROPS")
 	var javaOpt string

--- a/src/java/frameworks/cf_metrics_exporter.go
+++ b/src/java/frameworks/cf_metrics_exporter.go
@@ -68,14 +68,10 @@ func (f *CfMetricsExporterFramework) Supply() error {
 		if err := f.context.Installer.InstallDependency(dep, agentDir); err != nil {
 			return fmt.Errorf("failed to download cf-metrics-exporter: %w", err)
 		}
-		if _, err := os.Stat(f.jarPath); err != nil {
-			return fmt.Errorf("expected jar file not found after download: %w", err)
+		err := f.constructJarPath(agentDir)
+		if err != nil {
+			return fmt.Errorf("cf metrics exporter agent not found during supply: %w", err)
 		}
-	}
-
-	err = f.constructJarPath(agentDir)
-	if err != nil {
-		return fmt.Errorf("cf metrics exporter agent not found during supply: %w", err)
 	}
 
 	// Log activation, including properties if set

--- a/src/java/frameworks/cf_metrics_exporter.go
+++ b/src/java/frameworks/cf_metrics_exporter.go
@@ -14,6 +14,7 @@ const cfMetricsExporterDirName = "cf_metrics_exporter"
 
 type CfMetricsExporterFramework struct {
 	context *common.Context
+	jarPath string
 }
 
 func NewCfMetricsExporterFramework(ctx *common.Context) *CfMetricsExporterFramework {
@@ -56,8 +57,11 @@ func (f *CfMetricsExporterFramework) Supply() error {
 	}
 
 	agentDir := filepath.Join(f.context.Stager.DepDir(), cfMetricsExporterDirName)
-	jarName := fmt.Sprintf("cf-metrics-exporter-%s.jar", dep.Version)
-	jarPath := filepath.Join(agentDir, jarName)
+
+	err = f.constructJarPath(agentDir)
+	if err != nil {
+		return fmt.Errorf("cf metrics exporter agent not found during supply: %w", err)
+	}
 
 	// Ensure agent directory exists
 	if err := os.MkdirAll(agentDir, 0755); err != nil {
@@ -65,11 +69,11 @@ func (f *CfMetricsExporterFramework) Supply() error {
 	}
 
 	// Download the JAR if not present
-	if _, err := os.Stat(jarPath); os.IsNotExist(err) {
+	if _, err := os.Stat(f.jarPath); os.IsNotExist(err) {
 		if err := f.context.Installer.InstallDependency(dep, agentDir); err != nil {
 			return fmt.Errorf("failed to download cf-metrics-exporter: %w", err)
 		}
-		if _, err := os.Stat(jarPath); err != nil {
+		if _, err := os.Stat(f.jarPath); err != nil {
 			return fmt.Errorf("expected jar file not found after download: %w", err)
 		}
 	}
@@ -111,3 +115,18 @@ func (f *CfMetricsExporterFramework) Finalize() error {
 	// Priority 43: after SkyWalking (41), Splunk OTEL (42)
 	return writeJavaOptsFile(f.context, 43, cfMetricsExporterDirName, javaOpt)
 }
+
+func (f *CfMetricsExporterFramework) constructJarPath(agentDir string) error {
+	// Find the installed JAR
+	jarPattern := filepath.Join(agentDir, "cf-metrics-exporter-*.jar")
+	matches, err := filepath.Glob(jarPattern)
+	if err != nil {
+		return fmt.Errorf("failed to search for CF Metrics Exported jar: %w", err)
+	}
+	if len(matches) == 0 {
+		return fmt.Errorf("agent jar not found after installation in %s", agentDir)
+	}
+	f.jarPath = matches[0]
+	return nil
+}
+

--- a/src/java/frameworks/cf_metrics_exporter.go
+++ b/src/java/frameworks/cf_metrics_exporter.go
@@ -118,7 +118,7 @@ func (f *CfMetricsExporterFramework) Finalize() error {
 
 func (f *CfMetricsExporterFramework) constructJarPath(agentDir string) error {
 	// Find the installed JAR
-	jarPattern := filepath.Join(agentDir, "cf-metrics-exporter-*.jar")
+	jarPattern := filepath.Join(agentDir, "cf-metrics-exporter*.jar")
 	matches, err := filepath.Glob(jarPattern)
 	if err != nil {
 		return fmt.Errorf("failed to search for CF Metrics Exported jar: %w", err)
@@ -129,4 +129,3 @@ func (f *CfMetricsExporterFramework) constructJarPath(agentDir string) error {
 	f.jarPath = matches[0]
 	return nil
 }
-

--- a/src/java/frameworks/cf_metrics_exporter.go
+++ b/src/java/frameworks/cf_metrics_exporter.go
@@ -63,15 +63,12 @@ func (f *CfMetricsExporterFramework) Supply() error {
 		return fmt.Errorf("failed to create agent dir: %w", err)
 	}
 
-	// Download the JAR if not present
-	if _, err := os.Stat(f.jarPath); os.IsNotExist(err) {
-		if err := f.context.Installer.InstallDependency(dep, agentDir); err != nil {
-			return fmt.Errorf("failed to download cf-metrics-exporter: %w", err)
-		}
-		err := f.constructJarPath(agentDir)
-		if err != nil {
-			return fmt.Errorf("cf metrics exporter agent not found during supply: %w", err)
-		}
+	if err := f.context.Installer.InstallDependency(dep, agentDir); err != nil {
+		return fmt.Errorf("failed to download cf-metrics-exporter: %w", err)
+	}
+	err = f.constructJarPath(agentDir)
+	if err != nil {
+		return fmt.Errorf("cf metrics exporter agent not found during supply: %w", err)
 	}
 
 	// Log activation, including properties if set

--- a/src/java/frameworks/maria_db_jdbc.go
+++ b/src/java/frameworks/maria_db_jdbc.go
@@ -194,7 +194,7 @@ func (f *MariaDBJDBCFramework) hasExistingDriver() bool {
 }
 
 func (f *MariaDBJDBCFramework) constructJarPath(mariadbDir string) error {
-	jarPattern := filepath.Join(mariadbDir, "mariadb-jdbc-*.jar")
+	jarPattern := filepath.Join(mariadbDir, f.DependencyIdentifier()+"*.jar")
 	matches, err := filepath.Glob(jarPattern)
 	if err != nil {
 		return fmt.Errorf("failed to search for MariaDB JDBC JAR: %w", err)
@@ -206,6 +206,7 @@ func (f *MariaDBJDBCFramework) constructJarPath(mariadbDir string) error {
 	return nil
 }
 
-func (m *MariaDBJDBCFramework) DependencyIdentifier() string {
+func (f *MariaDBJDBCFramework) DependencyIdentifier() string {
 	return "mariadb-jdbc"
 }
+

--- a/src/java/frameworks/open_telemetry_javaagent.go
+++ b/src/java/frameworks/open_telemetry_javaagent.go
@@ -11,6 +11,7 @@ import (
 // OpenTelemetryJavaagentFramework implements OpenTelemetry instrumentation support
 type OpenTelemetryJavaagentFramework struct {
 	context *common.Context
+	jarPath string
 }
 
 // NewOpenTelemetryJavaagentFramework creates a new OpenTelemetry Javaagent framework instance
@@ -75,8 +76,20 @@ func (o *OpenTelemetryJavaagentFramework) Finalize() error {
 	// Get buildpack index for multi-buildpack support
 	depsIdx := o.context.Stager.DepsIdx()
 
+	agentDir := filepath.Join(o.context.Stager.DepDir(), "open_telemetry_javaagent")
+
+	err := o.constructJarPath(agentDir)
+	if err != nil {
+		return fmt.Errorf("OTEL Java agent JAR path not found during finalize: %w", err)
+	}
+
+	relPath, err := filepath.Rel(o.context.Stager.DepDir(), o.jarPath)
+	if err != nil {
+		return fmt.Errorf("failed to determine relative path for OTEL Java agent: %w", err)
+	}
+
 	// Build runtime agent path
-	agentJar := fmt.Sprintf("$DEPS_DIR/%s/open_telemetry_javaagent/opentelemetry-javaagent.jar", depsIdx)
+	agentJar := filepath.Join(fmt.Sprintf("$DEPS_DIR/%s", depsIdx), relPath)
 
 	// Add javaagent to JAVA_OPTS
 	javaOpts := fmt.Sprintf("-javaagent:%s", agentJar)
@@ -123,6 +136,20 @@ func (o *OpenTelemetryJavaagentFramework) Finalize() error {
 	return nil
 }
 
+func (o *OpenTelemetryJavaagentFramework) constructJarPath(agentDir string) error {
+	jarPattern := filepath.Join(agentDir, o.DependencyIdentifier()+"*.jar")
+	matches, err := filepath.Glob(jarPattern)
+	if err != nil {
+		return fmt.Errorf("failed to search for OTEL javaagent jar: %w", err)
+	}
+	if len(matches) == 0 {
+		return fmt.Errorf("otel agent jar not found after installation in %s", agentDir)
+	}
+	o.jarPath = matches[0]
+	return nil
+}
+
 func (o *OpenTelemetryJavaagentFramework) DependencyIdentifier() string {
 	return "open-telemetry-javaagent"
 }
+

--- a/src/java/frameworks/open_telemetry_javaagent_test.go
+++ b/src/java/frameworks/open_telemetry_javaagent_test.go
@@ -28,6 +28,13 @@ var _ = Describe("OpenTelemetryJavaagentFramework", func() {
 		err = os.MkdirAll(filepath.Join(depsDir, "0"), 0755)
 		Expect(err).NotTo(HaveOccurred())
 
+		agentDir := filepath.Join(depsDir, "0", "open_telemetry_javaagent")
+		Expect(os.MkdirAll(agentDir, 0755)).To(Succeed())
+		Expect(os.WriteFile(
+			filepath.Join(agentDir, "open-telemetry-javaagent_2.27.0_linux_noarch_any-stack_bd01fea1.jar"),
+			[]byte("fake jar"), 0644,
+		)).To(Succeed())
+
 		logger := libbuildpack.NewLogger(os.Stdout)
 		manifest := &libbuildpack.Manifest{}
 		stager := libbuildpack.NewStager([]string{tmpDir, "", depsDir, "0"}, logger, manifest)
@@ -219,7 +226,7 @@ var _ = Describe("OpenTelemetryJavaagentFramework", func() {
 				Expect(err).NotTo(HaveOccurred())
 				opts := string(data)
 
-				Expect(opts).To(ContainSubstring("-javaagent:$DEPS_DIR/0/open_telemetry_javaagent/opentelemetry-javaagent.jar"))
+				Expect(opts).To(ContainSubstring("-javaagent:$DEPS_DIR/0/open_telemetry_javaagent/open-telemetry-javaagent_2.27.0_linux_noarch_any-stack_bd01fea1.jar"))
 				Expect(opts).To(ContainSubstring("-Dotel.exporter.otlp.endpoint=http://collector:4318"))
 				Expect(opts).To(ContainSubstring("-Dotel.traces.sampler=always_on"))
 			})
@@ -262,7 +269,7 @@ var _ = Describe("OpenTelemetryJavaagentFramework", func() {
 				Expect(err).NotTo(HaveOccurred())
 				opts := string(data)
 
-				Expect(opts).To(ContainSubstring("-javaagent:$DEPS_DIR/0/open_telemetry_javaagent/opentelemetry-javaagent.jar"))
+				Expect(opts).To(ContainSubstring("-javaagent:$DEPS_DIR/0/open_telemetry_javaagent/open-telemetry-javaagent_2.27.0_linux_noarch_any-stack_bd01fea1.jar"))
 				Expect(opts).NotTo(ContainSubstring("-Dotel."))
 			})
 		})
@@ -301,7 +308,7 @@ var _ = Describe("OpenTelemetryJavaagentFramework", func() {
 				data, err := os.ReadFile(otelOptsFile())
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(string(data)).To(ContainSubstring("$DEPS_DIR/0/open_telemetry_javaagent/opentelemetry-javaagent.jar"))
+				Expect(string(data)).To(ContainSubstring("$DEPS_DIR/0/open_telemetry_javaagent/open-telemetry-javaagent_2.27.0_linux_noarch_any-stack_bd01fea1.jar"))
 			})
 		})
 	})

--- a/src/java/frameworks/splunk_otel_java_agent.go
+++ b/src/java/frameworks/splunk_otel_java_agent.go
@@ -230,18 +230,19 @@ func (s *SplunkOtelJavaAgentFramework) getCredentials() SplunkCredentials {
 }
 
 func (s *SplunkOtelJavaAgentFramework) constructJarPath(agentDir string) error {
-	jarPattern := filepath.Join(agentDir, "splunk-otel-javaagent.jar")
-	if _, err := os.Stat(jarPattern); err != nil {
-		// Try alternative name
-		jarPattern = filepath.Join(agentDir, "splunk-otel-javaagent-all.jar")
-		if _, err := os.Stat(jarPattern); err != nil {
-			return fmt.Errorf("javaagent jar not found after installation in %s (tried both splunk-otel-javaagent.jar and splunk-otel-javaagent-all.jar)", agentDir)
-		}
+	jarPattern := filepath.Join(agentDir, s.DependencyIdentifier()+"*.jar")
+	matches, err := filepath.Glob(jarPattern)
+	if err != nil {
+		return fmt.Errorf("failed to search for Splunk OTEL javaagent jar: %w", err)
 	}
-	s.jarPath = jarPattern
+	if len(matches) == 0 {
+		return fmt.Errorf("splunk otel agent jar not found after installation in %s", agentDir)
+	}
+	s.jarPath = matches[0]
 	return nil
 }
 
 func (s *SplunkOtelJavaAgentFramework) DependencyIdentifier() string {
 	return "splunk-otel-javaagent"
 }
+


### PR DESCRIPTION
After recent dependency updates with regard to automatic PR creation from the dependency pipeline and `cflinuxfs5` adjustments some of the jar dependencies paths and names were changed. Adapting the corresponding frameworks and tests with regard to these changes.
Linked to https://github.com/cloudfoundry/java-buildpack/pull/1281, https://github.com/cloudfoundry/java-buildpack/pull/1278, https://github.com/cloudfoundry/java-buildpack/pull/1273, https://github.com/cloudfoundry/java-buildpack/pull/1271, https://github.com/cloudfoundry/java-buildpack/pull/1272