### PR TITLE
Adjust cflinuxfs5 stack for some dependencies and correct docs

### DIFF
--- a/RUBY_VS_GO_BUILDPACK_COMPARISON.md
+++ b/RUBY_VS_GO_BUILDPACK_COMPARISON.md
@@ -551,9 +551,9 @@ cf set-env myapp JBP_CONFIG_TOMCAT '{tomcat: {version: 10.1.+}}'
 cf set-env myapp JBP_CONFIG_TOMCAT '{external_configuration_enabled: true, external_configuration: {version: "1.0.0"}}'
 ```
 
-#### External Configuration: Different Approaches
+#### External Configuration: 
 
-**Ruby Buildpack**: Runtime repository_root override ✅
+Both buildpacks support repository_root override ✅
 
 ```bash
 # ✅ Works: Specify custom repository at runtime
@@ -566,33 +566,6 @@ cf set-env myapp JBP_CONFIG_TOMCAT '{
 }'
 ```
 
-**Implementation**:
-```ruby
-# Ruby buildpack fetches index.yml from repository_root at staging time
-def compile
-  download(@version, @uri) { |file| expand file }  # Downloads from repository_root
-end
-```
-
-**Go Buildpack**: Manifest-only configuration ⚠️
-
-```bash
-# ❌ DOES NOT WORK: repository_root via environment variable not supported
-cf set-env myapp JBP_CONFIG_TOMCAT '{external_configuration_enabled: true, ...}'
-```
-
-**Required approach**:
-1. Fork buildpack
-2. Add external configuration to `manifest.yml`:
-   ```yaml
-   dependencies:
-     - name: tomcat-external-configuration
-       version: 1.0.0
-       uri: https://my-repo.example.com/tomcat-config-1.0.0.tar.gz
-       sha256: abc123...
-       cf_stacks:
-         - cflinuxfs4
-   ```
 3. Package and upload custom buildpack
 
 **Why the difference**: Go buildpack prioritizes security (mandatory SHA256 verification) and reproducibility (same manifest = same configs) over runtime flexibility.

--- a/RUBY_VS_GO_BUILDPACK_COMPARISON.md
+++ b/RUBY_VS_GO_BUILDPACK_COMPARISON.md
@@ -566,10 +566,6 @@ cf set-env myapp JBP_CONFIG_TOMCAT '{
 }'
 ```
 
-3. Package and upload custom buildpack
-
-**Why the difference**: Go buildpack prioritizes security (mandatory SHA256 verification) and reproducibility (same manifest = same configs) over runtime flexibility.
-
 ### 2A.5 Access Logging Configuration
 
 #### Default Behavior: Disabled (Parity)

--- a/RUBY_VS_GO_BUILDPACK_COMPARISON.md
+++ b/RUBY_VS_GO_BUILDPACK_COMPARISON.md
@@ -1214,13 +1214,13 @@ func (s *SpringBootCLIContainer) Detect() (string, error) {
 
 ### 3.1 Cloud Foundry API Versions
 
-| Aspect | Ruby (V2 API) | Go (V3 API) |
-|--------|---------------|-------------|
-| **Phases** | detect → compile → release | detect → supply → finalize |
-| **Multi-buildpack** | Not supported (needs workarounds) | Native support (multiple supply phases) |
+| Aspect | Ruby (V2 API) | Go (V3 API)                                |
+|--------|---------------|--------------------------------------------|
+| **Phases** | detect → compile → release | detect → supply → finalize -> release      |
+| **Multi-buildpack** | Not supported (needs workarounds) | Native support (multiple supply phases)    |
 | **Entrypoints** | `bin/detect`, `bin/compile`, `bin/release` | `bin/detect`, `bin/supply`, `bin/finalize` |
-| **State Management** | Droplet object (in-memory) | Files in `/deps/<idx>/` (persistent) |
-| **Caching** | `$CF_BUILDPACK_BUILDPACK_CACHE` | Same + `/deps/<idx>/` for dependencies |
+| **State Management** | Droplet object (in-memory) | Files in `/deps/<idx>/` (persistent)       |
+| **Caching** | `$CF_BUILDPACK_BUILDPACK_CACHE` | Same + `/deps/<idx>/` for dependencies     |
 
 ### 3.2 Phase Responsibilities
 
@@ -1696,8 +1696,6 @@ func (t *Tomcat) Supply() error {
 
 **Key difference**: The Go buildpack **initially forgot to use strip_components**, requiring helper functions like `findTomcatHome()`. The correct approach is to use `crush.Extract()` with `strip=1` parameter (similar to Ruby's `--strip 1`).
 
-See detailed analysis: `/ruby_vs_go_buildpack_comparison.md` (the OLD document focuses on this specific issue).
-
 ### 5.3 Caching Strategies
 
 | Aspect | Ruby Buildpack | Go Buildpack |
@@ -1714,13 +1712,13 @@ See detailed analysis: `/ruby_vs_go_buildpack_comparison.md` (the OLD document f
 
 ### 6.1 Test Framework Comparison
 
-| Aspect | Ruby Buildpack | Go Buildpack |
-|--------|---------------|--------------|
-| **Unit Test Framework** | RSpec | Go testing + Gomega assertions |
-| **Integration Tests** | Separate repo (java-buildpack-system-test) | In-tree (src/integration/) |
-| **Test Runner** | Rake tasks | Switchblade framework |
-| **Platforms** | Cloud Foundry only | CF + Docker (with GitHub token) |
-| **Total Tests** | ~300+ specs | ~100+ integration tests |
+| Aspect | Ruby Buildpack | Go Buildpack                          |
+|--------|---------------|---------------------------------------|
+| **Unit Test Framework** | RSpec | Go testing + Gomega assertions        |
+| **Integration Tests** | Separate repo (java-buildpack-system-test) | In-tree (src/integration/)            |
+| **Test Runner** | Rake tasks | Switchblade framework                 |
+| **Platforms** | Cloud Foundry only | CF + Docker (with GitHub token)       |
+| **Total Tests** | ~300+ specs | ~800+ integration tests               |
 | **Test Apps** | External repo (java-test-applications) | Embedded in src/integration/testdata/ |
 
 ### 6.2 Test Organization
@@ -2286,8 +2284,6 @@ The Go-based Java buildpack is a **production-ready, feature-complete** migratio
 ## Appendix B: Further Reading
 
 - **ARCHITECTURE.md** - Detailed Go buildpack architecture
-- **comparison.md** - Component-by-component feature parity analysis
-- **ruby_vs_go_buildpack_comparison.md** - OLD document (focused on dependency extraction only, outdated)
 - **docs/custom-jre-usage.md** - Guide for custom JRE repositories in Go buildpack
 - **docs/DEVELOPING.md** - Development workflow and testing
 - **docs/IMPLEMENTING_FRAMEWORKS.md** - Framework implementation guide
@@ -2296,5 +2292,5 @@ The Go-based Java buildpack is a **production-ready, feature-complete** migratio
 ---
 
 **Document Version**: 1.0  
-**Last Updated**: January 5, 2026  
+**Last Updated**: May 20, 2026  
 **Authors**: Cloud Foundry Java Buildpack Team

--- a/manifest.yml
+++ b/manifest.yml
@@ -399,6 +399,7 @@ dependencies:
   sha256: e024103719ffa99a011607942ecddfd91c5681113e6cea27f5514bc9fa172875
   cf_stacks:
   - cflinuxfs4
+  - cflinuxfs5
 - name: mariadb-jdbc
   version: 3.5.8
   uri: https://buildpacks.cloudfoundry.org/dependencies/mariadb-jdbc/mariadb-jdbc_3.5.8_linux_noarch_any-stack_6127dc78.jar
@@ -592,7 +593,7 @@ dependencies:
   sha256: b3452d5ffbf0652e0f44958a5cb306a961906280102e5fa1a15840d2ddb6bcc1
   cf_stacks:
   - cflinuxfs4
-  - cflinuxfs3
+  - cflinuxfs5
   source: https://repo1.maven.org/maven2/org/cloudfoundry/tomcat-access-logging-support/3.4.0.RELEASE/tomcat-access-logging-support-3.4.0.RELEASE.jar
   source_sha256: b3452d5ffbf0652e0f44958a5cb306a961906280102e5fa1a15840d2ddb6bcc1
 - name: tomcat-lifecycle-support
@@ -601,7 +602,7 @@ dependencies:
   sha256: 3861d32a91b58302fa936d6f84354e1874f71e59dd97b003efcc992a5a6f3c47
   cf_stacks:
   - cflinuxfs4
-  - cflinuxfs3
+  - cflinuxfs5
   source: https://repo1.maven.org/maven2/org/cloudfoundry/tomcat-lifecycle-support/3.4.0.RELEASE/tomcat-lifecycle-support-3.4.0.RELEASE.jar
   source_sha256: 3861d32a91b58302fa936d6f84354e1874f71e59dd97b003efcc992a5a6f3c47
 - name: tomcat-logging-support
@@ -610,7 +611,7 @@ dependencies:
   sha256: 07de9efe8dda4c67dec6183ec1d59953abf1372cd71fe276fc4598739bd70667
   cf_stacks:
   - cflinuxfs4
-  - cflinuxfs3
+  - cflinuxfs5
   source: https://repo1.maven.org/maven2/org/cloudfoundry/tomcat-logging-support/3.4.0.RELEASE/tomcat-logging-support-3.4.0.RELEASE.jar
   source_sha256: 07de9efe8dda4c67dec6183ec1d59953abf1372cd71fe276fc4598739bd70667
 - name: your-kit-profiler


### PR DESCRIPTION
- `tomcat-lifecycle-support`, `tomcat-logging-support` and `tomcat-access-logging-support` components will not be added to `dependency-builds` pipeline as no newer versions appear since years. They are compatible with all Tomcat versions and have no specifics with regard to `cflinuxfs4` and `cflinuxfs5` stack update. These components are in the CF domain, if anything provokes a new version release for them the community will be noted.
- `luna-security-provider` is also added to `cflinuxfs5`, not added to `dependency-builds` pipeline since newer versions are not produced.
- `RUBY_VS_GO_BUILDPACK_COMPARISON.md` is corrected, especially the `External Configuration` section which appears to be wrong as the same mechanism for overlaying tomcat configs is still supported in 5.x.