### PR TITLE
Adjust framework functionalities considering recent pipeline modifications

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -429,6 +429,7 @@ dependencies:
   sha256: 0f8b092a6c02035b29e9af6d0f025efe5f8ce95e0cc655b30e93d1c436d5d137
   cf_stacks:
   - cflinuxfs4
+  - cflinuxfs5
 - name: newrelic
   version: 9.2.0
   uri: https://buildpacks.cloudfoundry.org/dependencies/newrelic/newrelic_9.2.0_linux_noarch_any-stack_befb6434.zip

--- a/src/java/frameworks/client_certificate_mapper.go
+++ b/src/java/frameworks/client_certificate_mapper.go
@@ -61,7 +61,7 @@ func (c *ClientCertificateMapperFramework) Supply() error {
 func (c *ClientCertificateMapperFramework) Finalize() error {
 	// Find the installed JAR
 	mapperDir := filepath.Join(c.context.Stager.DepDir(), "client_certificate_mapper")
-	jarPattern := filepath.Join(mapperDir, "client-certificate-mapper-*.jar")
+	jarPattern := filepath.Join(mapperDir, "client-certificate-mapper*.jar")
 
 	matches, err := filepath.Glob(jarPattern)
 	if err != nil || len(matches) == 0 {

--- a/src/java/frameworks/contrast_security_agent.go
+++ b/src/java/frameworks/contrast_security_agent.go
@@ -48,7 +48,7 @@ func (c *ContrastSecurityAgentFramework) findContrastAgent(frameworkDir string) 
 	}
 
 	// Try specific pattern first, then fallback to generic
-	path, err := FindFileByPattern(frameworkDir, "contrast-security-*.jar", []string{""})
+	path, err := FindFileByPattern(frameworkDir, "contrast-security*.jar", []string{""})
 	if err == nil {
 		return path, nil
 	}

--- a/src/java/frameworks/datadog_javaagent.go
+++ b/src/java/frameworks/datadog_javaagent.go
@@ -305,7 +305,7 @@ func (d *DatadogJavaagentFramework) getApplicationVersion() string {
 
 func (d *DatadogJavaagentFramework) constructJarPathAndFixClassCount(datadogDir string) error {
 	// Find the installed JAR
-	jarPattern := filepath.Join(datadogDir, "dd-java-agent*.jar")
+	jarPattern := filepath.Join(datadogDir, d.DependencyIdentifier()+"*.jar")
 	matches, err := filepath.Glob(jarPattern)
 	if err != nil {
 		return fmt.Errorf("failed to search for Datadog agent JAR: %w", err)

--- a/src/java/frameworks/datadog_javaagent_test.go
+++ b/src/java/frameworks/datadog_javaagent_test.go
@@ -63,7 +63,7 @@ func installDatadogAgent(depsDir, version string, withClassdata bool) {
 	agentDir := filepath.Join(depsDir, "0", "datadog_javaagent")
 	Expect(os.MkdirAll(agentDir, 0755)).To(Succeed())
 
-	jarPath := filepath.Join(agentDir, "dd-java-agent-"+version+".jar")
+	jarPath := filepath.Join(agentDir, "datadog-javaagent_"+version+"_linux_noarch_any-stack_def0ebd6.jar")
 
 	f, err := os.Create(jarPath)
 	Expect(err).NotTo(HaveOccurred())
@@ -254,7 +254,7 @@ var _ = Describe("Datadog JavaAgent", func() {
 				content, err := os.ReadFile(filepath.Join(depsDir, "0", "java_opts", "19_datadog_javaagent.opts"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(content)).To(ContainSubstring("-javaagent:"))
-				Expect(string(content)).To(ContainSubstring("$DEPS_DIR/0/datadog_javaagent/dd-java-agent-1.28.0.jar"))
+				Expect(string(content)).To(ContainSubstring("$DEPS_DIR/0/datadog_javaagent/datadog-javaagent_1.28.0_linux_noarch_any-stack_def0ebd6.jar"))
 			})
 
 			It("opts file does not embed the staging-time absolute path", func() {


### PR DESCRIPTION
After recent dependency updates with regard to automatic PR creation from the dependency pipeline and `cflinuxfs5` adjustments some of the jar dependencies paths and names were changed. Adapting the corresponding frameworks and tests with regard to these changes.
Linked to https://github.com/cloudfoundry/java-buildpack/pull/1292, https://github.com/cloudfoundry/java-buildpack/pull/1296, https://github.com/cloudfoundry/java-buildpack/pull/1297

The PR also adjusts `cflinuxfs5` to the list of stacks for metrics-writer. The `metrics-writer` lacks new versions since years. No native binaries, no glibc dependency. Runs on any Java 8+ HotSpot JVM on cflinuxfs5. It's been added also to the dependency pipeline although seems no new versions will appear, although the [repo](https://github.com/cloudfoundry/java-buildpack-metric-writer) is not archived.

**Note** the PR should be merged along with the above mentioned PRs