### PR TITLE
Update go version and adjust script for cflinuxfs5

### DIFF
--- a/scripts/install_go.sh
+++ b/scripts/install_go.sh
@@ -5,24 +5,32 @@ set -u
 set -o pipefail
 
 function main() {
-  if [[ "${CF_STACK:-}" != "cflinuxfs3" && "${CF_STACK:-}" != "cflinuxfs4" ]]; then
+  if [[ "${CF_STACK:-}" != "cflinuxfs3" && "${CF_STACK:-}" != "cflinuxfs4" && "${CF_STACK:-}" != "cflinuxfs5" ]]; then
     echo "       **ERROR** Unsupported stack"
     echo "                 See https://docs.cloudfoundry.org/devguide/deploy-apps/stacks.html for more info"
     exit 1
   fi
 
   local version expected_sha dir
-  version="1.24.6"
-  expected_sha="f39b242d56a2a0d1e0ca5f6294e1811dc9653354603078b128b7f347a33bca2c"
+  version="1.24.13"
+  expected_sha_cflinuxfs4="7ed0876f713f6add32f07c1d82e7ea026b07995c084492c36e6fa27b37d58291"
+  expected_sha_cflinuxfs5="f8361b031b0940ade20ecd61c8e9876be6153f86fa675c4a5befaf5ce69e3ee5"
+  if [[ "${CF_STACK}" == "cflinuxfs4" ]]; then
+    expected_sha="${expected_sha_cflinuxfs4}"
+  elif [[ "${CF_STACK}" == "cflinuxfs5" ]]; then
+    expected_sha="${expected_sha_cflinuxfs5}"
+  else
+    echo "       **ERROR** No SHA defined for stack: ${CF_STACK}"
+    exit 1
+  fi
   dir="/tmp/go${version}"
 
   mkdir -p "${dir}"
 
   if [[ ! -f "${dir}/bin/go" ]]; then
     local url
-    # TODO: use exact stack based dep, after go buildpack has cflinuxfs4 support
-    #url="https://buildpacks.cloudfoundry.org/dependencies/go/go_${version}_linux_x64_${CF_STACK}_${expected_sha:0:8}.tgz"
-    url="https://buildpacks.cloudfoundry.org/dependencies/go/go_${version}_linux_x64_cflinuxfs3_${expected_sha:0:8}.tgz"
+    url="https://buildpacks.cloudfoundry.org/dependencies/go/go_${version}_linux_x64_${CF_STACK}_${expected_sha:0:8}.tgz"
+    # url="https://buildpacks.cloudfoundry.org/dependencies/go/go_${version}_linux_x64_cflinuxfs3_${expected_sha:0:8}.tgz"
 
     echo "-----> Download go ${version}"
     curl "${url}" \

--- a/scripts/install_go.sh
+++ b/scripts/install_go.sh
@@ -12,9 +12,9 @@ function main() {
   fi
 
   local version expected_sha dir
-  version="1.24.13"
-  expected_sha_cflinuxfs4="7ed0876f713f6add32f07c1d82e7ea026b07995c084492c36e6fa27b37d58291"
-  expected_sha_cflinuxfs5="f8361b031b0940ade20ecd61c8e9876be6153f86fa675c4a5befaf5ce69e3ee5"
+  version="1.25.10"
+  expected_sha_cflinuxfs4="a1d6fbc0293b4de0f122f55df4af8689b294ef7a9d749b9f24e761deef33464e"
+  expected_sha_cflinuxfs5="ae729ea414d69b4c3a4757f772d6b4f4c3a1a6213c1d0d7e3267139cef708327"
   if [[ "${CF_STACK}" == "cflinuxfs4" ]]; then
     expected_sha="${expected_sha_cflinuxfs4}"
   elif [[ "${CF_STACK}" == "cflinuxfs5" ]]; then

--- a/scripts/install_go.sh
+++ b/scripts/install_go.sh
@@ -5,7 +5,7 @@ set -u
 set -o pipefail
 
 function main() {
-  if [[ "${CF_STACK:-}" != "cflinuxfs3" && "${CF_STACK:-}" != "cflinuxfs4" && "${CF_STACK:-}" != "cflinuxfs5" ]]; then
+  if [[ "${CF_STACK:-}" != "cflinuxfs4" && "${CF_STACK:-}" != "cflinuxfs5" ]]; then
     echo "       **ERROR** Unsupported stack"
     echo "                 See https://docs.cloudfoundry.org/devguide/deploy-apps/stacks.html for more info"
     exit 1


### PR DESCRIPTION
- Added `cflinuxfs5` to the supported stacks for the java buildpack in the install_go script and removed `cflinuxfs3`
- Update the golang version to 1.25.10 and adjusted the corresponding locations for `cflinuxfs4` and `cflinuxfs5`