### PR TITLE
fix(tests): correct SapMachine and Tomcat version assertion strings

### DIFF
--- a/src/integration/java_main_test.go
+++ b/src/integration/java_main_test.go
@@ -126,7 +126,7 @@ func testJavaMain(platform switchblade.Platform, fixtures string) func(*testing.
 
 				// Verify SAPMachine JRE was installed from manifest
 				Expect(logs.String()).To(ContainSubstring("Java Buildpack"))
-				Expect(logs.String()).To(ContainSubstring("Installing SAP Machine"))
+				Expect(logs.String()).To(ContainSubstring("Installing SapMachine"))
 				Expect(logs.String()).To(ContainSubstring("17."))
 			})
 		})

--- a/src/integration/tomcat_test.go
+++ b/src/integration/tomcat_test.go
@@ -371,7 +371,7 @@ func testTomcat(platform switchblade.Platform, fixtures string) func(*testing.T,
 
 				Expect(err).NotTo(HaveOccurred(), logs.String)
 
-				Expect(logs.String()).To(ContainSubstring("Installing SAP Machine (17."))
+				Expect(logs.String()).To(ContainSubstring("Installing SapMachine (17."))
 				Eventually(deployment).Should(matchers.Serve(ContainSubstring("OK")))
 			})
 
@@ -384,7 +384,7 @@ func testTomcat(platform switchblade.Platform, fixtures string) func(*testing.T,
 
 				Expect(err).NotTo(HaveOccurred(), logs.String)
 
-				Expect(logs.String()).To(ContainSubstring("Installing SAP Machine (21."))
+				Expect(logs.String()).To(ContainSubstring("Installing SapMachine (21."))
 				Eventually(deployment).Should(matchers.Serve(ContainSubstring("OK")))
 			})
 
@@ -397,7 +397,7 @@ func testTomcat(platform switchblade.Platform, fixtures string) func(*testing.T,
 
 				Expect(err).NotTo(HaveOccurred(), logs.String)
 
-				Expect(logs.String()).To(ContainSubstring("Installing SAP Machine (25."))
+				Expect(logs.String()).To(ContainSubstring("Installing SapMachine (25."))
 				Eventually(deployment).Should(matchers.Serve(ContainSubstring("OK")))
 			})
 		})

--- a/src/integration/tomcat_test.go
+++ b/src/integration/tomcat_test.go
@@ -171,7 +171,7 @@ func testTomcat(platform switchblade.Platform, fixtures string) func(*testing.T,
 				Expect(err).NotTo(HaveOccurred(), logs.String)
 
 				Expect(logs.String()).To(ContainSubstring("Installing OpenJDK (8."))
-				Expect(logs.String()).To(ContainSubstring("Tomcat 9"))
+				Expect(logs.String()).To(ContainSubstring("Installed Tomcat (9."))
 				Eventually(deployment).Should(matchers.Serve(ContainSubstring("OK")))
 			})
 
@@ -185,7 +185,7 @@ func testTomcat(platform switchblade.Platform, fixtures string) func(*testing.T,
 				Expect(err).NotTo(HaveOccurred(), logs.String)
 
 				Expect(logs.String()).To(ContainSubstring("Installing OpenJDK (11."))
-				Expect(logs.String()).To(ContainSubstring("Tomcat 9"))
+				Expect(logs.String()).To(ContainSubstring("Installed Tomcat (9."))
 				Eventually(deployment).Should(matchers.Serve(ContainSubstring("OK")))
 			})
 
@@ -198,7 +198,7 @@ func testTomcat(platform switchblade.Platform, fixtures string) func(*testing.T,
 				Expect(err).NotTo(HaveOccurred(), logs.String)
 
 				Expect(logs.String()).To(ContainSubstring("Installing OpenJDK (17."))
-				Expect(logs.String()).To(ContainSubstring("Tomcat 9"))
+				Expect(logs.String()).To(ContainSubstring("Installed Tomcat (9."))
 				Eventually(deployment).Should(matchers.Serve(ContainSubstring("OK")))
 			})
 
@@ -224,7 +224,7 @@ func testTomcat(platform switchblade.Platform, fixtures string) func(*testing.T,
 				Expect(err).NotTo(HaveOccurred(), logs.String)
 
 				Expect(logs.String()).To(ContainSubstring("Installing OpenJDK (11."))
-				Expect(logs.String()).To(ContainSubstring("Tomcat 10"))
+				Expect(logs.String()).To(ContainSubstring("Installed Tomcat (10."))
 				Eventually(deployment).Should(matchers.Serve(ContainSubstring("OK")))
 			})
 
@@ -237,7 +237,7 @@ func testTomcat(platform switchblade.Platform, fixtures string) func(*testing.T,
 				Expect(err).NotTo(HaveOccurred(), logs.String)
 
 				Expect(logs.String()).To(ContainSubstring("Installing OpenJDK (17."))
-				Expect(logs.String()).To(ContainSubstring("Tomcat 10"))
+				Expect(logs.String()).To(ContainSubstring("Installed Tomcat (10."))
 				Eventually(deployment).Should(matchers.Serve(ContainSubstring("OK")))
 			})
 		})
@@ -258,7 +258,7 @@ func testTomcat(platform switchblade.Platform, fixtures string) func(*testing.T,
 				Expect(err).NotTo(HaveOccurred(), logs.String)
 
 				Expect(logs.String()).To(ContainSubstring("Installing OpenJDK (17."))
-				Expect(logs.String()).To(ContainSubstring("Tomcat 10.1."))
+				Expect(logs.String()).To(ContainSubstring("Installed Tomcat (10.1."))
 				Eventually(deployment).Should(matchers.Serve(ContainSubstring("OK")))
 			})
 		})


### PR DESCRIPTION
## Summary

- Fixes integration test assertions broken by PR #1288 (BaseJRE refactor) and prior logging cleanup (#1230)
- `Installing SAP Machine` → `Installing SapMachine` in `tomcat_test.go` and `java_main_test.go` (missed in #1288)
- `Tomcat 9` / `Tomcat 10` → `Installed Tomcat (9.` / `Installed Tomcat (10.` — log format changed in #1230 from `Installed Tomcat version %s` to `Installed Tomcat (%s)` but assertions were not updated

No functional code changes — test assertions only.