### PR TITLE
fix #1289: allowSchemeMismatch=true for tomcat server.xml

### DIFF
--- a/src/java/resources/files/tomcat/conf/server.xml
+++ b/src/java/resources/files/tomcat/conf/server.xml
@@ -20,7 +20,7 @@
 
     <Service name='Catalina'>
         <Connector port='${http.port}' bindOnInit='false' connectionTimeout='20000' keepAliveTimeout='120000'>
-            <UpgradeProtocol className='org.apache.coyote.http2.Http2Protocol' />
+            <UpgradeProtocol className='org.apache.coyote.http2.Http2Protocol' allowSchemeMismatch='true'/>
         </Connector>
 
         <Engine defaultHost='localhost' name='Catalina'>


### PR DESCRIPTION
Typically, tomcat runs behind a reverse proxy (gorouter) and TLS is terminated there. This leads to a scheme mismatch between the protocol reported in http headers and what tomcat actually sees. Due to  https://bz.apache.org/bugzilla/show_bug.cgi?id=70091 http2 routes don't work anymore with tomcat 10.1.55 and 11.0.22.

Fix is to configure allowSchemeMismatch='true' for UpgradeProtocol in server.xml. Requires tomcat >=10.1.56 or 11.0.23.