### PR TITLE
fix(java_opts): preserve backslashes in JAVA_OPTS on bash 4.x

### DIFF
--- a/scripts/unit.sh
+++ b/scripts/unit.sh
@@ -14,7 +14,7 @@ function main() {
   local src
   src="$(find "${ROOTDIR}/src" -mindepth 1 -maxdepth 1 -type d )"
 
-  echo "bash: $(bash --version | head -1)"
+  echo "bash: ${BASH_VERSION}"
 
   util::tools::ginkgo::install --directory "${ROOTDIR}/.bin"
   util::tools::buildpack-packager::install --directory "${ROOTDIR}/.bin"

--- a/scripts/unit.sh
+++ b/scripts/unit.sh
@@ -14,6 +14,8 @@ function main() {
   local src
   src="$(find "${ROOTDIR}/src" -mindepth 1 -maxdepth 1 -type d )"
 
+  echo "bash: $(bash --version | head -1)"
+
   util::tools::ginkgo::install --directory "${ROOTDIR}/.bin"
   util::tools::buildpack-packager::install --directory "${ROOTDIR}/.bin"
 

--- a/src/java/frameworks/java_opts_writer.go
+++ b/src/java/frameworks/java_opts_writer.go
@@ -196,14 +196,19 @@ if [ -d "$DEPS_DIR/%s/java_opts" ]; then
 
             # Restore USER_JAVA_OPTS via string-split, not ${//}: bash 4.x and 5.x
             # treat '\\' in replacement strings differently, corrupting backslashes.
-            # %% / # are pure string ops — no special-char interpretation, any bash.
-            # Guard required: without placeholder present, %% and # return the full
-            # string, so omitting the guard duplicates opts_content.
-            if [[ "$opts_content" == *"$_user_java_opts_placeholder"* ]]; then
-                _before="${opts_content%%"$_user_java_opts_placeholder"*}"
+            # %%%% / # are pure string ops — no special-char interpretation, any bash.
+            # Pre-count occurrences so the loop is bounded even if USER_JAVA_OPTS
+            # itself contained the placeholder string (infinite-loop defence).
+            # Counting uses empty replacement — no backslash in replacement, safe.
+            # Handles multiple occurrences (e.g. user config "$JAVA_OPTS -Xmx512m"
+            # with from_environment:true produces "$JAVA_OPTS -Xmx512m $JAVA_OPTS").
+            _stripped="${opts_content//"$_user_java_opts_placeholder"/}"
+            _placeholder_count=$(( (${#opts_content} - ${#_stripped}) / ${#_user_java_opts_placeholder} ))
+            for (( _i=0; _i<_placeholder_count; _i++ )); do
+                _before="${opts_content%%%%"$_user_java_opts_placeholder"*}"
                 _after="${opts_content#*"$_user_java_opts_placeholder"}"
                 opts_content="${_before}${USER_JAVA_OPTS}${_after}"
-            fi
+            done
             
             if [ -n "$opts_content" ]; then
                 JAVA_OPTS="$JAVA_OPTS $opts_content"

--- a/src/java/frameworks/java_opts_writer.go
+++ b/src/java/frameworks/java_opts_writer.go
@@ -141,13 +141,13 @@ case "$USER_JAVA_OPTS" in
 esac
 
 # Escape replacement-special chars once; these values are loop-invariant.
+# USER_JAVA_OPTS is injected via string-split below (not ${//}) — bash 4.x and 5.x
+# treat '\\' in replacement strings differently, corrupting backslashes.
 _escaped_deps_dir="${DEPS_DIR//\\/\\\\}"
 _escaped_deps_dir="${_escaped_deps_dir//&/\\&}"
 _escaped_home="${HOME//\\/\\\\}"
 _escaped_home="${_escaped_home//&/\\&}"
 _user_java_opts_placeholder='__JAVA_OPTS_BUILDPACK_PLACEHOLDER__'
-_escaped_user_java_opts="${USER_JAVA_OPTS//\\/\\\\}"
-_escaped_user_java_opts="${_escaped_user_java_opts//&/\\&}"
 
 if [ -d "$DEPS_DIR/%s/java_opts" ]; then
     for opts_file in "$DEPS_DIR/%s/java_opts"/*.opts; do
@@ -194,8 +194,16 @@ if [ -d "$DEPS_DIR/%s/java_opts" ]; then
                     ;;
             esac
 
-            # Now safely substitute JAVA_OPTS after expansion (preserves quotes, backslashes, and ampersands)
-            opts_content="${opts_content//$_user_java_opts_placeholder/$_escaped_user_java_opts}"
+            # Restore USER_JAVA_OPTS via string-split, not ${//}: bash 4.x and 5.x
+            # treat '\\' in replacement strings differently, corrupting backslashes.
+            # %% / # are pure string ops — no special-char interpretation, any bash.
+            # Guard required: without placeholder present, %% and # return the full
+            # string, so omitting the guard duplicates opts_content.
+            if [[ "$opts_content" == *"$_user_java_opts_placeholder"* ]]; then
+                _before="${opts_content%%"$_user_java_opts_placeholder"*}"
+                _after="${opts_content#*"$_user_java_opts_placeholder"}"
+                opts_content="${_before}${USER_JAVA_OPTS}${_after}"
+            fi
             
             if [ -n "$opts_content" ]; then
                 JAVA_OPTS="$JAVA_OPTS $opts_content"

--- a/src/java/frameworks/java_opts_writer_test.go
+++ b/src/java/frameworks/java_opts_writer_test.go
@@ -370,6 +370,15 @@ var _ = Describe("Java Opts Writer", func() {
 			Expect(output).To(ContainSubstring(`-Dpath=C:\\double`))
 		})
 
+		It("replaces all occurrences of $JAVA_OPTS when opts file contains it twice", func() {
+			// Scenario: JBP_CONFIG_JAVA_OPTS: '{java_opts: "$JAVA_OPTS -Xmx512m", from_environment: true}'
+			// produces opts file: "$JAVA_OPTS -Xmx512m $JAVA_OPTS" — two placeholders
+			output, err := runScript(`-Dfoo=bar`, "$JAVA_OPTS -Xmx512m $JAVA_OPTS")
+			Expect(err).NotTo(HaveOccurred(), "script failed with output: %s", output)
+			Expect(strings.Count(output, "-Dfoo=bar")).To(Equal(2))
+			Expect(output).NotTo(ContainSubstring("__JAVA_OPTS_BUILDPACK_PLACEHOLDER__"))
+		})
+
 		// Full invocation cycle tests for issue #1301:
 		// Verify that javaexec tokenizes $JAVA_OPTS without a shell, so glob chars,
 		// pipes, and shell metacharacters are never expanded or executed.


### PR DESCRIPTION
## Summary

- `bash` 4.x and 5.x treat `\\` in `${//}` replacement strings differently:
  bash 5.x collapses `\\` to `\`, bash 4.x leaves it as `\\`. A `JAVA_OPTS`
  value containing a backslash (e.g. `-Dpattern=foo\|bar`) was doubled on CI
  workers running bash 4.x, causing the unit test
  `preserves backslashes in JAVA_OPTS values` to fail remotely while passing
  locally on bash 5.x.
- Replace pre-escaped `${//}` substitution with string-split (`%%` / `#`) when
  restoring `USER_JAVA_OPTS` from its placeholder. Pure string operations — no
  special-character interpretation, identical across bash 3/4/5.
- Add `bash --version` to `scripts/unit.sh` to make bash version visible in CI logs.

## Test plan
- [ ] Existing unit test `preserves backslashes in JAVA_OPTS values` covers the regression
- [x] Verified fix on bash 4.4 via Docker (`ubuntu:18.04`) — old approach: FAIL, new: PASS
- [ ] All unit suites pass: `bash scripts/unit.sh`
- [ ] JVM_Configuration integration tests pass: `bash scripts/integration.sh --platform docker`