### PR TITLE
fix(java_opts): use string-split for $DEPS_DIR and $HOME to fix bash 5.1 regression

### DIFF
--- a/src/java/frameworks/java_opts_writer.go
+++ b/src/java/frameworks/java_opts_writer.go
@@ -140,13 +140,6 @@ case "$USER_JAVA_OPTS" in
         ;;
 esac
 
-# Escape replacement-special chars once; these values are loop-invariant.
-# USER_JAVA_OPTS is injected via string-split below (not ${//}) — bash 4.x and 5.x
-# treat '\\' in replacement strings differently, corrupting backslashes.
-_escaped_deps_dir="${DEPS_DIR//\\/\\\\}"
-_escaped_deps_dir="${_escaped_deps_dir//&/\\&}"
-_escaped_home="${HOME//\\/\\\\}"
-_escaped_home="${_escaped_home//&/\\&}"
 _user_java_opts_placeholder='__JAVA_OPTS_BUILDPACK_PLACEHOLDER__'
 
 if [ -d "$DEPS_DIR/%s/java_opts" ]; then
@@ -159,11 +152,22 @@ if [ -d "$DEPS_DIR/%s/java_opts" ]; then
             # a literal $VAR to the JVM (Ruby buildpack parity).
             opts_content="${opts_content//\\\$/$_escaped_dollar_placeholder}"
 
-            # Expand $DEPS_DIR and $HOME using bash parameter expansion.
-            # In ${var//pattern/repl}, '&' and '\' are special in replacement strings,
-            # so escape them first to preserve literal path contents.
-            opts_content="${opts_content//\$DEPS_DIR/$_escaped_deps_dir}"
-            opts_content="${opts_content//\$HOME/$_escaped_home}"
+            # Replace $DEPS_DIR and $HOME using string-split, not ${//}: bash 4.x, 5.1.x
+            # and 5.2.x differ in how '&' and '\' in replacement variables are handled,
+            # causing literal \& and \\ in output on bash 5.1 (cflinuxfs4).
+            _rest="$opts_content"; opts_content=""
+            while [[ "$_rest" == *'$DEPS_DIR'* ]]; do
+                opts_content+="${_rest%%%%'$DEPS_DIR'*}${DEPS_DIR}"
+                _rest="${_rest#*'$DEPS_DIR'}"
+            done
+            opts_content+="$_rest"
+
+            _rest="$opts_content"; opts_content=""
+            while [[ "$_rest" == *'$HOME'* ]]; do
+                opts_content+="${_rest%%%%'$HOME'*}${HOME}"
+                _rest="${_rest#*'$HOME'}"
+            done
+            opts_content+="$_rest"
 
             # Resolve the trusted $(nproc) token to the computed processor count.
             opts_content="${opts_content//\$\(nproc\)/$_nproc_count}"


### PR DESCRIPTION
## Summary

Follow-up to #1330. The `&` and `\` escaping applied to `$DEPS_DIR` and `$HOME` before `${//}` replacement behaves differently across bash minor versions:

- **bash 4.x**: `&` in replacement = matched text; `\&` = literal `&`; `\\` = literal `\` → escaping was correct
- **bash 5.1.x** (cflinuxfs4): `\&` and `\\` in replacement variable pass through literally → output contains `\&` and `\\` instead of `&` and `\`
- **bash 5.2.x** (cflinuxfs5): `\&` and `\\` in replacement variable are interpreted → escaping works again

cflinuxfs4 ships bash 5.1.16, so the escaped-variable approach introduced in #1330 broke `$DEPS_DIR` and `$HOME` substitution on the target stack.

Fix: apply the same string-split (`%%` / `#*`) approach used for `USER_JAVA_OPTS` to `$DEPS_DIR` and `$HOME`. No `&` or `\` in any replacement string — safe across all bash versions.

## Test plan

- `preserves ampersand and backslash in $HOME replacement` — covers this regression
- `expands $DEPS_DIR in opts file content` — covers DEPS_DIR substitution
- All unit suites pass: `bash scripts/unit.sh`
- Verified on bash 5.2.x locally (expected to be similar to cflinuxfs5); cflinuxfs4 (bash 5.1.16) was the broken environment this fix targets