### PR TITLE
Adjust default jprofiler version

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -117,7 +117,7 @@ default_versions:
 - name: your-kit-profiler
   version: 2025.x
 - name: jprofiler-profiler
-  version: 15.x
+  version: 16.x
 - name: sealights-agent
   version: 4.x
 - name: container-security-provider


### PR DESCRIPTION
After updating to the new jprofiler version with https://github.com/cloudfoundry/java-buildpack/pull/1319 the default should be adjusted properly to prevent for example:
```
error while creating zipfile: No matching default dependency `jprofiler-profiler` for stack `cflinuxfs4`
```
when packaging the buildpack
