### PR TITLE
fix(java-cfenv): add the mirrored java-cfenv-all jar to the classpath

### DIFF
--- a/src/java/frameworks/java_cf_env.go
+++ b/src/java/frameworks/java_cf_env.go
@@ -86,8 +86,9 @@ func (j *JavaCfEnvFramework) Supply() error {
 func (j *JavaCfEnvFramework) Finalize() error {
 	// Add the JAR to additional libraries (classpath)
 	javaCfEnvDir := filepath.Join(j.context.Stager.DepDir(), "java_cf_env")
-	// Match both the Maven name (java-cfenv-all-<ver>.jar) and the CF mirror name
-	// (java-cfenv_<ver>_<stack>_<sha>.jar, underscores) — a hyphen-only glob misses the latter.
+	// The CF mirror installs the jar as java-cfenv_<ver>_<stack>_<sha>.jar (underscores).
+	// Glob java-cfenv*.jar so this — and a hyphenated Maven name, if the uri is ever
+	// pointed directly at Maven Central — both match.
 	jarPattern := filepath.Join(javaCfEnvDir, "java-cfenv*.jar")
 
 	matches, err := filepath.Glob(jarPattern)

--- a/src/java/frameworks/java_cf_env.go
+++ b/src/java/frameworks/java_cf_env.go
@@ -86,7 +86,9 @@ func (j *JavaCfEnvFramework) Supply() error {
 func (j *JavaCfEnvFramework) Finalize() error {
 	// Add the JAR to additional libraries (classpath)
 	javaCfEnvDir := filepath.Join(j.context.Stager.DepDir(), "java_cf_env")
-	jarPattern := filepath.Join(javaCfEnvDir, "java-cfenv-*.jar")
+	// Match both the Maven name (java-cfenv-all-<ver>.jar) and the CF mirror name
+	// (java-cfenv_<ver>_<stack>_<sha>.jar, underscores) — a hyphen-only glob misses the latter.
+	jarPattern := filepath.Join(javaCfEnvDir, "java-cfenv*.jar")
 
 	matches, err := filepath.Glob(jarPattern)
 	if err != nil || len(matches) == 0 {

--- a/src/java/frameworks/java_cf_env_artifact_test.go
+++ b/src/java/frameworks/java_cf_env_artifact_test.go
@@ -50,6 +50,8 @@ var _ = Describe("Java CF Env artifact", func() {
 	var deps []manifestDependency
 
 	BeforeEach(func() {
+		deps = nil
+
 		manifestPath, err := filepath.Abs(filepath.Join("..", "..", "..", "manifest.yml"))
 		Expect(err).NotTo(HaveOccurred())
 

--- a/src/java/frameworks/java_cf_env_artifact_test.go
+++ b/src/java/frameworks/java_cf_env_artifact_test.go
@@ -1,0 +1,163 @@
+//go:build cfenv_artifact
+
+// This test verifies a *necessary condition* for the buildpack's automatic "cloud"
+// Spring profile behaviour: the java-cfenv artifact the manifest ships must register
+// io.pivotal.cfenv.profile.CloudProfileApplicationListener as a Spring ApplicationListener
+// (via META-INF/spring.factories). That listener lives only in the java-cfenv-all module;
+// the bare java-cfenv core module does not carry it, which silently drops the "cloud"
+// profile (see cloudfoundry/java-buildpack#1349).
+//
+// It downloads each shipped jar, verifies its SHA-256 against the manifest (which also
+// guards against duplicate/mismatched mirror entries), then inspects spring.factories.
+//
+// It is network-bound, so it is excluded from the default unit suite by the cfenv_artifact
+// build tag. Run explicitly:
+//
+//	go test -tags cfenv_artifact ./src/java/frameworks/
+package frameworks_test
+
+import (
+	"archive/zip"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"gopkg.in/yaml.v2"
+)
+
+const cloudProfileListener = "io.pivotal.cfenv.profile.CloudProfileApplicationListener"
+
+type manifestDependency struct {
+	Name    string `yaml:"name"`
+	Version string `yaml:"version"`
+	URI     string `yaml:"uri"`
+	SHA256  string `yaml:"sha256"`
+}
+
+type manifestFile struct {
+	Dependencies []manifestDependency `yaml:"dependencies"`
+}
+
+var _ = Describe("Java CF Env artifact", func() {
+	var deps []manifestDependency
+
+	BeforeEach(func() {
+		manifestPath, err := filepath.Abs(filepath.Join("..", "..", "..", "manifest.yml"))
+		Expect(err).NotTo(HaveOccurred())
+
+		raw, err := os.ReadFile(manifestPath)
+		Expect(err).NotTo(HaveOccurred())
+
+		var m manifestFile
+		Expect(yaml.Unmarshal(raw, &m)).To(Succeed())
+
+		for _, d := range m.Dependencies {
+			if d.Name == "java-cfenv" && d.URI != "" {
+				deps = append(deps, d)
+			}
+		}
+		Expect(deps).NotTo(BeEmpty(), "no java-cfenv dependency entries with a uri found in manifest.yml")
+	})
+
+	It("ships a jar that registers the cloud-profile ApplicationListener", func() {
+		for _, dep := range deps {
+			By("checking java-cfenv " + dep.Version)
+
+			jar := downloadToTemp(dep.URI)
+			defer os.Remove(jar)
+
+			Expect(fileSHA256(jar)).To(Equal(dep.SHA256),
+				"java-cfenv %s: downloaded bytes do not match manifest sha256 (%s)", dep.Version, dep.URI)
+
+			factories, ok := readZipEntry(jar, "META-INF/spring.factories")
+			Expect(ok).To(BeTrue(),
+				"java-cfenv %s: jar has no META-INF/spring.factories — this is the bare core module, "+
+					"which cannot auto-activate the 'cloud' profile; ship java-cfenv-all instead", dep.Version)
+
+			Expect(factories).To(ContainSubstring(cloudProfileListener),
+				"java-cfenv %s: spring.factories does not register %s — the 'cloud' profile will not be "+
+					"activated automatically; ship java-cfenv-all instead", dep.Version, cloudProfileListener)
+
+			Expect(registersAsApplicationListener(factories, cloudProfileListener)).To(BeTrue(),
+				"java-cfenv %s: %s is present but not registered under "+
+					"org.springframework.context.ApplicationListener", dep.Version, cloudProfileListener)
+		}
+	})
+})
+
+// registersAsApplicationListener reports whether class is listed under the
+// org.springframework.context.ApplicationListener key, accounting for backslash
+// line continuations used in spring.factories files.
+func registersAsApplicationListener(factories, class string) bool {
+	const key = "org.springframework.context.ApplicationListener"
+	joined := strings.ReplaceAll(factories, "\\\n", "")
+	for _, line := range strings.Split(joined, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, key+"=") {
+			return strings.Contains(line, class)
+		}
+	}
+	return false
+}
+
+func downloadToTemp(uri string) string {
+	GinkgoHelper()
+
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Get(uri)
+	Expect(err).NotTo(HaveOccurred(), "download %s", uri)
+	defer resp.Body.Close()
+	Expect(resp.StatusCode).To(Equal(http.StatusOK), "download %s returned %d", uri, resp.StatusCode)
+
+	f, err := os.CreateTemp("", "java-cfenv-*.jar")
+	Expect(err).NotTo(HaveOccurred())
+	defer f.Close()
+
+	_, err = io.Copy(f, resp.Body)
+	Expect(err).NotTo(HaveOccurred())
+
+	return f.Name()
+}
+
+func fileSHA256(path string) string {
+	GinkgoHelper()
+
+	f, err := os.Open(path)
+	Expect(err).NotTo(HaveOccurred())
+	defer f.Close()
+
+	h := sha256.New()
+	_, err = io.Copy(h, f)
+	Expect(err).NotTo(HaveOccurred())
+
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func readZipEntry(jarPath, entry string) (string, bool) {
+	GinkgoHelper()
+
+	r, err := zip.OpenReader(jarPath)
+	Expect(err).NotTo(HaveOccurred())
+	defer r.Close()
+
+	for _, f := range r.File {
+		if f.Name == entry {
+			rc, err := f.Open()
+			Expect(err).NotTo(HaveOccurred())
+			defer rc.Close()
+
+			data, err := io.ReadAll(rc)
+			Expect(err).NotTo(HaveOccurred())
+			return string(data), true
+		}
+	}
+	return "", false
+}

--- a/src/java/frameworks/java_cf_env_test.go
+++ b/src/java/frameworks/java_cf_env_test.go
@@ -272,5 +272,29 @@ var _ = Describe("Java CF Env", func() {
 				Expect(string(content)).To(ContainSubstring("java-cfenv-2.5.0.jar"))
 			})
 		})
+
+		Context("when the mirrored, underscore-named JAR is installed", func() {
+			// The CF dependency mirror names the artifact
+			// java-cfenv_<version>_<stack>_<sha>.jar (underscores), not the
+			// hyphenated Maven name. Finalize must still add it to the classpath.
+			BeforeEach(func() {
+				javaCfEnvDir := filepath.Join(depsDir, "0", "java_cf_env")
+				Expect(os.MkdirAll(javaCfEnvDir, 0755)).To(Succeed())
+				Expect(os.WriteFile(
+					filepath.Join(javaCfEnvDir, "java-cfenv_3.5.1_linux_noarch_any-stack_696225e3.jar"),
+					[]byte("fake jar"),
+					0644,
+				)).To(Succeed())
+			})
+
+			It("adds the mirrored JAR to the profile.d CLASSPATH", func() {
+				Expect(fw.Finalize()).To(Succeed())
+				scriptPath := filepath.Join(depsDir, "0", "profile.d", "java_cf_env.sh")
+				Expect(scriptPath).To(BeAnExistingFile())
+				content, err := os.ReadFile(scriptPath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(content)).To(ContainSubstring("java-cfenv_3.5.1_linux_noarch_any-stack_696225e3.jar"))
+			})
+		})
 	})
 })


### PR DESCRIPTION
## Summary

The `java-cfenv` framework ships the correct artifact again — main now mirrors **`java-cfenv-all`** (the aggregate module that carries `CloudProfileApplicationListener` and the property post-processors), via the buildpacks-ci pipeline change and the releng bot PRs #1355 / #1356.

But that alone does not activate the `cloud` profile: the mirror installs the jar as `java-cfenv_<version>_<stack>_<sha>.jar` (underscores), while `Finalize` globbed `java-cfenv-*.jar` (hyphen). The two do not match, so the jar landed in `deps/…/java_cf_env/` but was **never added to the profile.d `CLASSPATH`** — at runtime the `cloud` profile still would not activate. Existing Finalize tests passed only because they used hyphenated fixtures, not the real mirror name.

Completes the runtime half of #1349 (the manifest/artifact half is already on main).

## Changes

- `java_cf_env.go` — `Finalize` now globs `java-cfenv*.jar`, matching both the Maven name (`java-cfenv-all-<ver>.jar`) and the CF mirror name (`java-cfenv_<ver>_<stack>_<sha>.jar`). This mirrors the pattern `hasJavaCfEnv` already uses.
- `java_cf_env_test.go` — add a Finalize test using the real underscore mirror filename (fails before the fix).
- `java_cf_env_artifact_test.go` — network-gated test (`//go:build cfenv_artifact`) that downloads each shipped jar, verifies its `sha256`, and asserts `spring.factories` registers `io.pivotal.cfenv.profile.CloudProfileApplicationListener`. Guards against ever shipping the bare core module again.

No manifest change — that landed via #1355 / #1356.

## Verification

- `go test ./...` — green (the artifact test is tag-excluded / offline).
- `go test ./src/java/frameworks/` — the new Finalize test is RED before the glob fix, GREEN after.
- `go test -tags cfenv_artifact ./src/java/frameworks/` — GREEN against the current mirror `-all` jars (3.5.1, 4.0.0); would fail on the bare core module.
