### PR TITLE
Fix pointing exact version with BP_JAVA_VERSION

### DIFF
--- a/src/java/jres/jre.go
+++ b/src/java/jres/jre.go
@@ -311,11 +311,17 @@ func GetJREVersion(ctx *common.Context, jreName string) (libbuildpack.Dependency
 }
 
 func normalizeVersionPattern(version string) string {
-	if strings.Contains(version, "+") {
-		return strings.ReplaceAll(version, "+", "*")
-	}
 	if strings.Contains(version, "*") {
 		return version
+	}
+	// Exact version with build metadata (e.g. "17.0.19+11") — pass through as-is.
+	// Must be checked before the general "+" replacement below.
+	exactVersionWithBuildRegex := regexp.MustCompile(`^\d+\.\d+\.\d+\+\d+$`)
+	if exactVersionWithBuildRegex.MatchString(version) {
+		return version
+	}
+	if strings.Contains(version, "+") {
+		return strings.ReplaceAll(version, "+", "*")
 	}
 	// Exact patch version (e.g. "17.0.13") — already fully specified, don't append ".*"
 	// which would produce an unmatchable pattern like "17.0.13.*".

--- a/src/java/jres/jre.go
+++ b/src/java/jres/jre.go
@@ -310,14 +310,16 @@ func GetJREVersion(ctx *common.Context, jreName string) (libbuildpack.Dependency
 	return dep, nil
 }
 
+var exactVersionWithBuildRegex = regexp.MustCompile(`^\d+\.\d+\.\d+\+\d+$`)
+var exactVersionRegex = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+
 func normalizeVersionPattern(version string) string {
 	if strings.Contains(version, "*") {
 		return version
 	}
 	// Exact version with build metadata (e.g. "17.0.19+11") — pass through as-is.
 	// Must be checked before the general "+" replacement below.
-	exactVersionWithBuildRegex := regexp.MustCompile(`^\d+\.\d+\.\d+\+\d+$`)
-	if exactVersionWithBuildRegex.MatchString(version) {
+	if isValidVersionWithBuild(version) {
 		return version
 	}
 	if strings.Contains(version, "+") {
@@ -325,11 +327,18 @@ func normalizeVersionPattern(version string) string {
 	}
 	// Exact patch version (e.g. "17.0.13") — already fully specified, don't append ".*"
 	// which would produce an unmatchable pattern like "17.0.13.*".
-	exactVersionRegex := regexp.MustCompile(`^\d+\.\d+\.\d+$`)
-	if exactVersionRegex.MatchString(version) {
+	if isValidVersion(version) {
 		return version
 	}
 	return version + ".*"
+}
+
+func isValidVersion(version string) bool {
+	return exactVersionRegex.MatchString(version)
+}
+
+func isValidVersionWithBuild(version string) bool {
+	return exactVersionWithBuildRegex.MatchString(version)
 }
 
 func parseJBPConfigVersion(configValue string) string {

--- a/src/java/jres/jre.go
+++ b/src/java/jres/jre.go
@@ -317,6 +317,12 @@ func normalizeVersionPattern(version string) string {
 	if strings.Contains(version, "*") {
 		return version
 	}
+	// Exact patch version (e.g. "17.0.13") — already fully specified, don't append ".*"
+	// which would produce an unmatchable pattern like "17.0.13.*".
+	exactVersionRegex := regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+	if exactVersionRegex.MatchString(version) {
+		return version
+	}
 	return version + ".*"
 }
 

--- a/src/java/jres/jre_test.go
+++ b/src/java/jres/jre_test.go
@@ -183,6 +183,12 @@ dependencies:
   cf_stacks:
   - cflinuxfs4
 - name: openjdk
+  version: 17.0.19+11
+  uri: https://example.com/openjdk-17.0.19+11.tar.gz
+  sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  cf_stacks:
+  - cflinuxfs4  
+- name: openjdk
   version: 21.0.5
   uri: https://example.com/openjdk-21.tar.gz
   sha256: 3333333333333333333333333333333333333333333333333333333333333333
@@ -320,6 +326,14 @@ dependencies:
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dep.Name).To(Equal("openjdk"))
 				Expect(dep.Version).To(Equal("17.0.13"))
+			})
+
+			It("resolves exact version with build metadata (X.Y.Z+W format)", func() {
+				os.Setenv("BP_JAVA_VERSION", "17.0.19+11")
+				dep, err := jres.GetJREVersion(ctx, "openjdk")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dep.Name).To(Equal("openjdk"))
+				Expect(dep.Version).To(Equal("17.0.19+11"))
 			})
 		})
 

--- a/src/java/jres/jre_test.go
+++ b/src/java/jres/jre_test.go
@@ -397,6 +397,14 @@ dependencies:
 				Expect(dep.Version).To(Equal("17.0.19+11"))
 			})
 
+			It("resolves exact version 17.0.19+11 pattern", func() {
+				os.Setenv("JBP_CONFIG_OPEN_JDK_JRE", "{jre: {version: 17.0.19+11}}")
+				dep, err := jres.GetJREVersion(ctx, "openjdk")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dep.Name).To(Equal("openjdk"))
+				Expect(dep.Version).To(Equal("17.0.19+11"))
+			})
+
 			It("resolves version 11.+ pattern", func() {
 				os.Setenv("JBP_CONFIG_OPEN_JDK_JRE", "{jre: {version: 11.+}}")
 				dep, err := jres.GetJREVersion(ctx, "openjdk")

--- a/src/java/jres/jre_test.go
+++ b/src/java/jres/jre_test.go
@@ -177,12 +177,6 @@ dependencies:
   cf_stacks:
   - cflinuxfs4
 - name: openjdk
-  version: 17.0.13
-  uri: https://example.com/openjdk-17.tar.gz
-  sha256: 2222222222222222222222222222222222222222222222222222222222222222
-  cf_stacks:
-  - cflinuxfs4
-- name: openjdk
   version: 17.0.19+11
   uri: https://example.com/openjdk-17.0.19+11.tar.gz
   sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -301,7 +295,7 @@ dependencies:
 				dep, err := jres.GetJREVersion(ctx, "openjdk")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dep.Name).To(Equal("openjdk"))
-				Expect(dep.Version).To(Equal("17.0.13"))
+				Expect(dep.Version).To(Equal("17.0.19+11"))
 			})
 
 			It("resolves major version 21", func() {
@@ -317,15 +311,23 @@ dependencies:
 				dep, err := jres.GetJREVersion(ctx, "openjdk")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dep.Name).To(Equal("openjdk"))
-				Expect(dep.Version).To(Equal("17.0.13"))
+				Expect(dep.Version).To(Equal("17.0.19+11"))
 			})
 
-			It("resolves exact patch version", func() {
-				os.Setenv("BP_JAVA_VERSION", "17.0.13")
+			It("handles version patterns with wildcards", func() {
+				os.Setenv("BP_JAVA_VERSION", "17.+")
 				dep, err := jres.GetJREVersion(ctx, "openjdk")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dep.Name).To(Equal("openjdk"))
-				Expect(dep.Version).To(Equal("17.0.13"))
+				Expect(dep.Version).To(Equal("17.0.19+11"))
+			})
+
+			It("resolves exact patch version", func() {
+				os.Setenv("BP_JAVA_VERSION", "17.0.19")
+				dep, err := jres.GetJREVersion(ctx, "openjdk")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dep.Name).To(Equal("openjdk"))
+				Expect(dep.Version).To(Equal("17.0.19+11"))
 			})
 
 			It("resolves exact version with build metadata (X.Y.Z+W format)", func() {
@@ -392,7 +394,7 @@ dependencies:
 				dep, err := jres.GetJREVersion(ctx, "openjdk")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dep.Name).To(Equal("openjdk"))
-				Expect(dep.Version).To(Equal("17.0.13"))
+				Expect(dep.Version).To(Equal("17.0.19+11"))
 			})
 
 			It("resolves version 11.+ pattern", func() {

--- a/src/java/jres/jre_test.go
+++ b/src/java/jres/jre_test.go
@@ -313,6 +313,14 @@ dependencies:
 				Expect(dep.Name).To(Equal("openjdk"))
 				Expect(dep.Version).To(Equal("17.0.13"))
 			})
+
+			It("resolves exact patch version", func() {
+				os.Setenv("BP_JAVA_VERSION", "17.0.13")
+				dep, err := jres.GetJREVersion(ctx, "openjdk")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dep.Name).To(Equal("openjdk"))
+				Expect(dep.Version).To(Equal("17.0.13"))
+			})
 		})
 
 		Context("without BP_JAVA_VERSION", func() {


### PR DESCRIPTION
Fixes #1338 
When specifying an exact version for `BP_JAVA_VERSION`, staging fails:
```
2026-07-10T17:10:30.21+0300 [STG/0] OUT **WARNING** Could not find openjdk matching version 17.0.19.*: improper constraint: 17.0.19.*
2026-07-10T17:10:30.21+0300 [STG/0] OUT **ERROR** Failed to install JRE: failed to determine OpenJDK version from manifest: no version of openjdk matching 17.0.19.* found
```