### PR TITLE
Refactor supply and fix possible issues in frameworks

### DIFF
--- a/src/java/containers/groovy.go
+++ b/src/java/containers/groovy.go
@@ -47,10 +47,7 @@ func (g *GroovyContainer) Supply() error {
 	// Install Groovy runtime
 	dep, err := g.context.Manifest.DefaultVersion("groovy")
 	if err != nil {
-		g.context.Log.Warning("Unable to determine default Groovy version")
-		// Fallback version
-		dep.Name = "groovy"
-		dep.Version = "4.0.0"
+		return fmt.Errorf("unable to determine Groovy version: %w", err)
 	}
 
 	// Install Groovy with strip components to remove the top-level directory
@@ -163,3 +160,4 @@ func (g *GroovyContainer) buildClasspath() string {
 	// Adding also container security provider and the additional CLASSPATH env built when profile.d scripts are sourced
 	return "-cp " + strings.Join(jarPaths, ":") + "${CLASSPATH:+:$CLASSPATH}${CONTAINER_SECURITY_PROVIDER:+:$CONTAINER_SECURITY_PROVIDER}"
 }
+

--- a/src/java/containers/java_main.go
+++ b/src/java/containers/java_main.go
@@ -265,10 +265,8 @@ func (j *JavaMainContainer) buildClasspath() (string, error) {
 
 	// Add all JARs in the build directory
 	jarFiles, err := filepath.Glob(filepath.Join(buildDir, "*.jar"))
-	if err == nil {
-		for _, jar := range jarFiles {
-			classpathEntries = append(classpathEntries, "$HOME/"+filepath.Base(jar))
-		}
+	if err == nil && len(jarFiles) > 0 {
+		classpathEntries = append(classpathEntries, "$HOME/*.jar")
 	}
 
 	// Add lib directory if it exists

--- a/src/java/containers/java_main.go
+++ b/src/java/containers/java_main.go
@@ -264,10 +264,10 @@ func (j *JavaMainContainer) buildClasspath() (string, error) {
 	}
 
 	// Add all JARs in the build directory
-	jarFiles, err := filepath.Glob(filepath.Join(buildDir, "$HOME/*.jar"))
+	jarFiles, err := filepath.Glob(filepath.Join(buildDir, "*.jar"))
 	if err == nil {
 		for _, jar := range jarFiles {
-			classpathEntries = append(classpathEntries, filepath.Base(jar))
+			classpathEntries = append(classpathEntries, "$HOME/"+filepath.Base(jar))
 		}
 	}
 
@@ -314,3 +314,4 @@ func (j *JavaMainContainer) Release() (string, error) {
 
 	return JavaExecCommand(j.context.Stager.DepsIdx(), fmt.Sprintf("-cp ${CLASSPATH}${CONTAINER_SECURITY_PROVIDER:+:$CONTAINER_SECURITY_PROVIDER} %s%s", mainClass, args)), nil
 }
+

--- a/src/java/containers/java_main_test.go
+++ b/src/java/containers/java_main_test.go
@@ -369,6 +369,24 @@ var _ = Describe("Java Main Container", func() {
 	})
 
 	Describe("buildClasspath", func() {
+		Context("with JARs in root directory", func() {
+			BeforeEach(func() {
+				os.WriteFile(filepath.Join(buildDir, "app.jar"), []byte("fake"), 0644)
+				os.WriteFile(filepath.Join(buildDir, "Main.class"), []byte("fake"), 0644)
+			})
+
+			It("includes root JARs with $HOME wildcard in classpath", func() {
+				container.Detect()
+				err := container.Finalize()
+				Expect(err).NotTo(HaveOccurred())
+
+				profileScript := filepath.Join(depsDir, "0", "profile.d", "java_main.sh")
+				data, err := os.ReadFile(profileScript)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(data)).To(ContainSubstring("$HOME/*.jar"))
+			})
+		})
+
 		Context("with JARs in root and lib/", func() {
 			BeforeEach(func() {
 				os.WriteFile(filepath.Join(buildDir, "app.jar"), []byte("fake"), 0644)
@@ -507,3 +525,4 @@ var _ = Describe("Java Main Container", func() {
 
 	})
 })
+

--- a/src/java/containers/spring_boot_cli.go
+++ b/src/java/containers/spring_boot_cli.go
@@ -73,10 +73,7 @@ func (s *SpringBootCLIContainer) Supply() error {
 	// Install Spring Boot CLI runtime
 	dep, err := s.context.Manifest.DefaultVersion("spring-boot-cli")
 	if err != nil {
-		s.context.Log.Warning("Unable to determine default Spring Boot CLI version: %s", err.Error())
-		// Fallback version
-		dep.Name = "spring-boot-cli"
-		dep.Version = "2.7.0"
+		return fmt.Errorf("unable to determine Spring Boot CLI version: %w", err)
 	}
 
 	springBootCLIDir := filepath.Join(s.context.Stager.DepDir(), "spring-boot-cli")
@@ -210,3 +207,4 @@ func (s *SpringBootCLIContainer) noShebang(files []string) bool {
 	}
 	return true
 }
+

--- a/src/java/frameworks/app_dynamics.go
+++ b/src/java/frameworks/app_dynamics.go
@@ -6,8 +6,6 @@ import (
 	"github.com/cloudfoundry/java-buildpack/src/java/resources"
 	"os"
 	"path/filepath"
-
-	"github.com/cloudfoundry/libbuildpack"
 )
 
 // AppDynamicsFramework implements AppDynamics APM agent support
@@ -52,11 +50,7 @@ func (a *AppDynamicsFramework) Supply() error {
 	// Get AppDynamics agent dependency from manifest
 	dep, err := a.context.Manifest.DefaultVersion("appdynamics")
 	if err != nil {
-		a.context.Log.Warning("Unable to determine AppDynamics version, using default")
-		dep = libbuildpack.Dependency{
-			Name:    "appdynamics",
-			Version: "24.7.0", // Fallback version
-		}
+		return fmt.Errorf("unable to determine AppDynamics version: %w", err)
 	}
 
 	// Install AppDynamics agent
@@ -193,3 +187,4 @@ func (a *AppDynamicsFramework) Finalize() error {
 func (a *AppDynamicsFramework) DependencyIdentifier() string {
 	return "appdynamics"
 }
+

--- a/src/java/frameworks/jacoco_agent.go
+++ b/src/java/frameworks/jacoco_agent.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"github.com/cloudfoundry/java-buildpack/src/java/common"
 	"path/filepath"
-
-	"github.com/cloudfoundry/libbuildpack"
 )
 
 // JacocoAgentFramework implements JaCoCo code coverage agent support
@@ -58,11 +56,7 @@ func (j *JacocoAgentFramework) Supply() error {
 	// Get JaCoCo agent dependency from manifest
 	dep, err := j.context.Manifest.DefaultVersion("jacoco")
 	if err != nil {
-		j.context.Log.Warning("Unable to determine JaCoCo version, using default")
-		dep = libbuildpack.Dependency{
-			Name:    "jacoco",
-			Version: "0.8.12", // Fallback version
-		}
+		return fmt.Errorf("unable to determine JaCoCo version: %w", err)
 	}
 
 	// Install JaCoCo agent ZIP
@@ -176,3 +170,4 @@ func (j *JacocoAgentFramework) Finalize() error {
 func (j *JacocoAgentFramework) DependencyIdentifier() string {
 	return "jacoco"
 }
+

--- a/src/java/frameworks/new_relic.go
+++ b/src/java/frameworks/new_relic.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/cloudfoundry/libbuildpack"
 )
 
 // NewRelicFramework implements New Relic APM agent support
@@ -60,11 +58,7 @@ func (n *NewRelicFramework) Supply() error {
 	// Get New Relic agent dependency from manifest
 	dep, err := n.context.Manifest.DefaultVersion("newrelic")
 	if err != nil {
-		n.context.Log.Warning("Unable to determine New Relic version, using default")
-		dep = libbuildpack.Dependency{
-			Name:    "newrelic",
-			Version: "8.14.0", // Fallback version
-		}
+		return fmt.Errorf("unable to determine New Relic version: %w", err)
 	}
 
 	// Install New Relic agent JAR
@@ -175,3 +169,4 @@ func (n *NewRelicFramework) Finalize() error {
 func (n *NewRelicFramework) DependencyIdentifier() string {
 	return "newrelic"
 }
+

--- a/src/java/frameworks/open_telemetry_javaagent.go
+++ b/src/java/frameworks/open_telemetry_javaagent.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"github.com/cloudfoundry/java-buildpack/src/java/common"
 	"path/filepath"
-
-	"github.com/cloudfoundry/libbuildpack"
 )
 
 // OpenTelemetryJavaagentFramework implements OpenTelemetry instrumentation support
@@ -54,11 +52,7 @@ func (o *OpenTelemetryJavaagentFramework) Supply() error {
 	// Get OpenTelemetry agent dependency from manifest
 	dep, err := o.context.Manifest.DefaultVersion("open-telemetry-javaagent")
 	if err != nil {
-		o.context.Log.Warning("Unable to determine OpenTelemetry version, using default")
-		dep = libbuildpack.Dependency{
-			Name:    "open-telemetry-javaagent",
-			Version: "2.10.0", // Fallback version
-		}
+		return fmt.Errorf("unable to determine OpenTelemetry version: %w", err)
 	}
 
 	// Install OpenTelemetry agent JAR

--- a/src/java/frameworks/postgresql_jdbc.go
+++ b/src/java/frameworks/postgresql_jdbc.go
@@ -5,8 +5,6 @@ import (
 	"github.com/cloudfoundry/java-buildpack/src/java/common"
 	"path/filepath"
 	"strings"
-
-	"github.com/cloudfoundry/libbuildpack"
 )
 
 // PostgresqlJdbcFramework implements PostgreSQL JDBC driver support
@@ -43,11 +41,7 @@ func (p *PostgresqlJdbcFramework) Supply() error {
 	// Get PostgreSQL JDBC dependency from manifest
 	dep, err := p.context.Manifest.DefaultVersion("postgresql-jdbc")
 	if err != nil {
-		p.context.Log.Warning("Unable to determine PostgreSQL JDBC version, using default")
-		dep = libbuildpack.Dependency{
-			Name:    "postgresql-jdbc",
-			Version: "42.7.0", // Fallback version
-		}
+		return fmt.Errorf("unable to determine PostgreSQL JDBC version: %w", err)
 	}
 
 	// Install PostgreSQL JDBC JAR
@@ -150,3 +144,4 @@ func (p *PostgresqlJdbcFramework) hasPostgresDriver() bool {
 func (p *PostgresqlJdbcFramework) DependencyIdentifier() string {
 	return "postgresql-jdbc"
 }
+

--- a/src/java/frameworks/spring_auto_reconfiguration.go
+++ b/src/java/frameworks/spring_auto_reconfiguration.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/cloudfoundry/libbuildpack"
 )
 
 // SpringAutoReconfigurationFramework implements Spring Auto-reconfiguration support for Cloud Foundry
@@ -64,11 +62,7 @@ func (s *SpringAutoReconfigurationFramework) Supply() error {
 	// Get Spring Auto-reconfiguration dependency from manifest
 	dep, err := s.context.Manifest.DefaultVersion("auto-reconfiguration")
 	if err != nil {
-		s.context.Log.Warning("Unable to determine Spring Auto-reconfiguration version, using default")
-		dep = libbuildpack.Dependency{
-			Name:    "auto-reconfiguration",
-			Version: "2.13.0", // Fallback version
-		}
+		return fmt.Errorf("unable to determine Spring Auto-reconfiguration version: %w", err)
 	}
 
 	// Install Spring Auto-reconfiguration JAR
@@ -209,3 +203,4 @@ func (s *SpringAutoReconfigurationFramework) hasSpringCloudConnectors() bool {
 func (s *SpringAutoReconfigurationFramework) DependencyIdentifier() string {
 	return "auto-reconfiguration"
 }
+

--- a/src/java/supply/supply.go
+++ b/src/java/supply/supply.go
@@ -25,7 +25,6 @@ type Supplier struct {
 func Run(s *Supplier) error {
 	s.Log.BeginStep("Supplying Java")
 
-	// Create container context
 	ctx := &common.Context{
 		Stager:    s.Stager,
 		Manifest:  s.Manifest,
@@ -53,13 +52,13 @@ func Run(s *Supplier) error {
 	s.Container = container
 
 	// Install JRE - returns installed JRE for config persistence
-	jre, jreName, err := s.installJRE()
+	jre, jreName, err := s.installJRE(ctx)
 	if err != nil {
 		return err
 	}
 
 	// Install frameworks (APM agents, etc.)
-	if err := s.installFrameworks(); err != nil {
+	if err := s.installFrameworks(ctx); err != nil {
 		s.Log.Error("Failed to install frameworks: %s", err.Error())
 		return err
 	}
@@ -88,16 +87,7 @@ func Run(s *Supplier) error {
 
 // installJRE installs the Java Runtime Environment.
 // Returns the installed JRE instance and its name so the caller can persist them to config.yml.
-func (s *Supplier) installJRE() (jres.JRE, string, error) {
-	// Create JRE context
-	ctx := &common.Context{
-		Stager:    s.Stager,
-		Manifest:  s.Manifest,
-		Installer: s.Installer,
-		Log:       s.Log,
-		Command:   s.Command,
-	}
-
+func (s *Supplier) installJRE(ctx *common.Context) (jres.JRE, string, error) {
 	// Create and populate JRE registry
 	registry := jres.NewRegistry(ctx)
 	registry.RegisterStandardJREs()
@@ -124,16 +114,7 @@ func (s *Supplier) installJRE() (jres.JRE, string, error) {
 }
 
 // installFrameworks installs framework components (APM agents, etc.)
-func (s *Supplier) installFrameworks() error {
-	// Create framework context
-	ctx := &common.Context{
-		Stager:    s.Stager,
-		Manifest:  s.Manifest,
-		Installer: s.Installer,
-		Log:       s.Log,
-		Command:   s.Command,
-	}
-
+func (s *Supplier) installFrameworks(ctx *common.Context) error {
 	// Create and populate framework registry
 	registry := frameworks.NewRegistry(ctx)
 	registry.RegisterStandardFrameworks()
@@ -185,3 +166,4 @@ func (s *Supplier) frameworkVersionSuffix(framework frameworks.Framework) string
 	// gets installed (e.g. java-cfenv resolves to a Spring-Boot-major-specific version).
 	return fmt.Sprintf(" (manifest default: %s)", dependency.Version)
 }
+


### PR DESCRIPTION
- Refactor `supply.go` in order not to reuse already created context instead of creating new one excessively.
 - Remove hardcoded fallback versions across frameworks and containers. Eight components (`new_relic, open_telemetry_javaagent, postgresql_jdbc, app_dynamics, jacoco_agent, spring_auto_reconfiguration, groovy,
    spring_boot_cli`) silently fell back to a hardcoded version string when `DefaultVersion` failed a manifest lookup. This masked misconfigured or missing manifest entries, potentially installing a stale cached artifact or failing with a confusing downstream error. All eight now return a descriptive error immediately, consistent with the rest of the codebase.
  - Fix broken classpath glob in JavaMainContainer.buildClasspath() (java_main.go). The glob pattern filepath.Join(buildDir, "$HOME/*.jar") produced a literal path like /tmp/build/$HOME/*.jar which never matched anything, silently dropping all root-level JARs from the classpath. Fixed to filepath.Join(buildDir, "*.jar") with $HOME/ prepended to each match when constructing the runtime path, consistent with how other classpath entries are built.