### PR TITLE
test(integration): skip java-cfenv JDBC mapping assertions (#1406)

### DIFF
--- a/src/integration/spring_boot_test.go
+++ b/src/integration/spring_boot_test.go
@@ -386,6 +386,7 @@ func testSpringBoot(platform switchblade.Platform, fixtures string, sb3JarPath, 
 				// detects postgres:// URI scheme and maps to spring.datasource.url/username/password.
 				// This proves the full service connector pipeline is active, beyond
 				// Spring Boot's built-in vcap.services.* property flattening.
+				t.Skip("java-cfenv JDBC mapping broken on SB3+/SB4, see https://github.com/cloudfoundry/java-buildpack/issues/1406")
 				Eventually(springEnv("spring.datasource.url")).
 					Should(ContainSubstring("jdbc:postgresql://host:5432/dbname"))
 				Eventually(springEnv("spring.datasource.username")).


### PR DESCRIPTION
## Summary

- Skip `spring.datasource.url/username/password` assertions in SB4 
  java-cfenv test — java-cfenv-all fat jar JDBC mapping is broken on 
  SB3+/SB4
- Assertions left in code with `t.Skip` so they show as skipped in CI 
  and are easy to re-enable after upstream fix
- Cloud profile + loaded-jars assertions remain active

See #1406 for root cause analysis and fix plan.