### PR TITLE
Fix container detection test when there is real push in CF

### DIFF
--- a/src/integration/container_detection_test.go
+++ b/src/integration/container_detection_test.go
@@ -70,6 +70,9 @@ func testContainerDetectionErrors(platform switchblade.Platform, fixtures string
 				Expect(err).NotTo(HaveOccurred())
 				defer cleanup()
 
+				// CF CLI rejects a truly empty directory before staging; a placeholder lets the buildpack's detect run.
+				Expect(os.WriteFile(filepath.Join(appDir, ".keep"), []byte{}, 0644)).To(Succeed())
+
 				_, logs, err := platform.Deploy.Execute(name, appDir)
 				Expect(err).To(HaveOccurred())
 				Expect(logs.String()).To(ContainSubstring("detected a compatible application"))
@@ -165,3 +168,4 @@ func testContainerDetectionErrors(platform switchblade.Platform, fixtures string
 		})
 	}
 }
+


### PR DESCRIPTION
Currently the `create-cf-infrastructure-and-execute-integration-test-for-java` in concourse always fail with for example:
```
=== CONT  TestIntegration/integration/ContainerDetection/when_detect_itself_rejects_the_application/fails_for_empty_directory
    container_detection_test.go:75: 
        Expected
....
            Pushing app switchblade-8lsvihwvr to org switchblade-8lsvihwvr / space switchblade-8lsvihwvr as admin...
            No app files found in '/tmp/jbp-container-detection-4157856279'
            FAILED
            
        to contain substring
            <string>: detected a compatible application
    container_detection_test.go:59: FAILED TEST - App/Container: switchblade-8lsvihwvr
    container_detection_test.go:60:    Platform: cf
```

When cf push is given a truly empty directory, the CF CLI rejects it with `"No app files found"` before staging begins, so the buildpack's detect script never runs and the expected log message never appears. The fix writes a non-Java .keep placeholder into the temp dir so the CF CLI accepts the upload — the buildpack's detect script then runs, finds no Java indicators, exits 1, and CF emits "None of the buildpacks detected a compatible application" which satisfies `ContainSubstring("detected a compatible application")`