### PR TITLE
Fix failing test in CF

### DIFF
--- a/src/integration/spring_boot_test.go
+++ b/src/integration/spring_boot_test.go
@@ -32,7 +32,7 @@ func testSpringBoot(platform switchblade.Platform, fixtures string, sb3JarPath, 
 				t.Logf("❌ FAILED TEST - App/Container: %s", name)
 				t.Logf("   Platform: %s", settings.Platform)
 			}
-			if name != "" && (!settings.KeepFailedContainers || !t.Failed()) {
+			if name != "" && !t.Skipped() && (!settings.KeepFailedContainers || !t.Failed()) {
 				Expect(platform.Delete.Execute(name)).To(Succeed())
 			}
 		})


### PR DESCRIPTION
t.Skip("SB4 jar not available") is called inside a spec (it) function, but the it.After still runs after a skip — and it calls platform.Delete.Execute(name) which tries to run cf delete-org even though no org was ever created (because the test skipped before doing anything). This causes "failed to delete-org: No API endpoint set".
Linked to https://github.com/cloudfoundry/java-buildpack/pull/1407